### PR TITLE
fix: allow to run a connector multiple times

### DIFF
--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -59,6 +59,7 @@ class LauncherView extends Component {
       contentScript: this.connector.source,
     })
     await this.launcher.start()
+    this.props.setLauncherContext({state: 'default'})
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
The launcher view is know unloaded in the end of the connector
Run.