### PR TITLE
feat: runInWorkerUntilTrue : ensure bridge is ready before running the method one more time

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -84,7 +84,7 @@ class ReactNativeLauncher extends Launcher {
   }
 
   /**
-   * Run the specified method in the worker and make it fail with WORKER_RELOAD message
+   * Run the specified method in the worker and make it fail with WORKER_WILL_RELOAD message
    * if the worker page is reloaded
    *
    * @param {String} method
@@ -94,7 +94,7 @@ class ReactNativeLauncher extends Launcher {
     log.debug('runInworker called')
     try {
       return await new Promise((resolve, reject) => {
-        this.once('WORKER_RELOAD', () => {
+        this.once('WORKER_WILL_RELOAD', () => {
           // we need to reject once the worker is back and ready.
           // This way, the pilot can call the worker one more time
           // and be sure it is ready
@@ -217,7 +217,7 @@ class ReactNativeLauncher extends Launcher {
    * Actions to do before the worker reloads : restart the connection
    */
   onWorkerWillReload(event) {
-    this.emit('WORKER_RELOAD')
+    this.emit('WORKER_WILL_RELOAD')
     this.restartWorkerConnection(event)
     return true // allows the webview to load the new page
   }

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -100,9 +100,9 @@ describe('ReactNativeLauncher', () => {
       expect(launcher.worker.call).toHaveBeenCalledTimes(1)
       expect(result).toEqual('worker result')
     })
-    it('should return false WORKER_RELOAD event is emitted', async () => {
+    it('should return false WORKER_WILL_RELOAD event is emitted', async () => {
       launcher.worker.call.mockImplementation(async () => {
-        launcher.emit('WORKER_RELOAD')
+        launcher.emit('WORKER_WILL_RELOAD')
         launcher.emit('WORKER_RELOADED')
         await new Promise((resolve) => setTimeout(resolve, 100))
       })


### PR DESCRIPTION
Sometimes, when the connection is slow or the website is slow,
runInWorkerUntilTrue would retry running the function before the bridge
is ready. This caused error like '*** method is not implemented'.

Now, an event is emitted when the bridge is ready, and the launcher can
listen to it to know it can run the method once again and be sure the
bridge is ready.
