### PR TITLE
feat: build an offline debug apk

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 # Download Dependencies
 $ yarn
 
-# Run native server 
+# Run native server
 $ yarn start # (must be started for the following commands)
 
-# Run on iOS Device 
+# Run on iOS Device
 $ cd ios && pod install # Only the first time
-$ yarn ios 
+$ yarn ios
 
 # Run on Android Device
 $ yarn android
 
-# Run in the browser 
+# Run in the browser
 $ yarn web
 ```
 
@@ -49,3 +49,8 @@ $ yarn test
 
 
 
+## Build an offline apk
+
+* First, you must have `yarn start` running in another terminal
+* Then run ./scripts/build-debug-offline-apk.sh
+* The output will give you the path to the apk

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "web": "webpack serve --open --config webpack.config.js --inline --hot --port=9999",
     "web:test": "react-app-rewired test --env=jsdom",
     "build": "react-app-rewired build",
+    "build:android:debug": "./scripts/build-debug-offline-apk.sh",
     "start": "react-native start",
     "test": "jest connectors/connectorLibs/* src/libs/*",
     "token": "node scripts/token.js",

--- a/scripts/build-debug-offline-apk.sh
+++ b/scripts/build-debug-offline-apk.sh
@@ -1,0 +1,20 @@
+set -x
+
+# source :
+# https://dev.to/shubhkirtisharma/building-serverless-or-debug-apk-for-react-native-apps-356m
+
+cd `git rev-parse --show-toplevel`
+
+mkdir -p android/app/src/main/assets
+
+react-native bundle --platform android --dev false --entry-file src/index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res
+
+curl "http://localhost:8081/index.bundle?platform=android" -o "android/app/src/main/assets/index.android.bundle"
+
+cd android && ./gradlew clean assembleDebug
+
+cd ..
+
+echo Done.
+echo Result : $PWD/android/app/build/outputs/apk/debug/app-debug.apk
+


### PR DESCRIPTION
./scripts/build-debug-offline-apk.sh to generate a debug apk which does not need a running server

source : https://dev.to/shubhkirtisharma/building-serverless-or-debug-apk-for-react-native-apps-356m