### PR TITLE
feat: Cozy Store integration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react'
-import {SafeAreaView, StyleSheet, View} from 'react-native'
+import {SafeAreaView, StyleSheet, View, Linking} from 'react-native'
 import {NavigationContainer} from '@react-navigation/native'
+import {createStackNavigator} from '@react-navigation/stack'
 import {Provider as PaperProvider, TextInput, Button} from 'react-native-paper'
 
 import {decode, encode} from 'base-64'
@@ -9,7 +10,10 @@ import {CozyProvider} from 'cozy-client'
 
 import {lightTheme} from './theme'
 import Connectors from './screens/connectors'
+import StoreView from './screens/store/StoreView'
 import {getClient, saveClient, initClient} from './libs/client'
+
+const Root = createStackNavigator()
 
 // Polyfill needed for cozy-client connection
 if (!global.btoa) {
@@ -21,17 +25,6 @@ if (!global.atob) {
 }
 
 const COZY_PREFIX = 'cozy://'
-
-const config = {
-  screens: {
-    connectors: 'connectors',
-  },
-}
-
-const linking = {
-  prefixes: [COZY_PREFIX],
-  config,
-}
 
 const App = () => {
   const [client, setClient] = useState(null)
@@ -49,8 +42,15 @@ const App = () => {
     <PaperProvider theme={lightTheme}>
       {client ? (
         <CozyProvider client={client}>
-          <NavigationContainer linking={linking}>
-            <Connectors />
+          <NavigationContainer>
+            <Root.Navigator initialRouteName="home">
+              <Root.Screen
+                name="home"
+                component={Connectors}
+                options={{headerShown: false}}
+              />
+              <Root.Screen name="store" component={StoreView} />
+            </Root.Navigator>
           </NavigationContainer>
         </CozyProvider>
       ) : (

--- a/src/screens/connectors/HomeView.js
+++ b/src/screens/connectors/HomeView.js
@@ -1,35 +1,53 @@
-import React from 'react'
+import React, {useMemo} from 'react'
 import {get} from 'lodash'
 import {WebView} from 'react-native-webview'
 import {useClient} from 'cozy-client'
+import {generateWebLink} from 'cozy-ui/transpiled/react/AppLinker'
 
-const HomeView = (props) => {
+const HOME_URL = 'file:///android_asset/home/index.html'
+
+const HomeView = ({route, navigation, setLauncherContext}) => {
+  let initUrl = HOME_URL
+  const slugParam = get(route, 'params.slug')
+  if (slugParam) {
+    initUrl += `#/connected/${slugParam}`
+  }
+
   const client = useClient()
   const {uri} = client.getStackClient()
   const token = client.getStackClient().getAccessToken()
   const [scheme, cozyDomain] = uri.split('://')
   const cozyToken = token
-  const {setLauncherContext} = props
   const cozyClientConf = {
     scheme,
     lang: 'fr',
     cozyDomain,
     cozyToken,
   }
+
   const run = `
     window.cozy = {
-      ClientConnectorLauncher: 'react-native',
-      clientSideSlugs: ['ameli', 'sncf', 'blablacar', 'template'],
+      ClientConnectorLauncher: 'react-native'
     };
     window.cozyClientConf = ${JSON.stringify(cozyClientConf)}
     return true;
     `
+
+  const storeAddUrl = useMemo(() => {
+    const {subdomain: subDomainType} = client.getInstanceOptions()
+    return generateWebLink({
+      cozyUrl: new URL(uri).origin,
+      slug: 'store',
+      subDomainType,
+    })
+  }, [uri])
+
   return (
     <WebView
       originWhitelist={['*']}
       useWebKit={true}
       javaScriptEnabled={true}
-      source={{uri: 'file:///android_asset/home/index.html'}}
+      source={{uri: initUrl}}
       injectedJavaScriptBeforeContentLoaded={run}
       onMessage={(m) => {
         const data = get(m, 'nativeEvent.data')
@@ -40,8 +58,19 @@ const HomeView = (props) => {
           }
         }
       }}
+      onShouldStartLoadWithRequest={(request) => {
+        if (isStoreUrl(request.url)) {
+          navigation.push('store', {url: request.url})
+          return false
+        }
+        return true
+      }}
     />
   )
+}
+
+function isStoreUrl({url, storeAddUrl}) {
+  return url.includes(storeAddUrl.split('#').shift())
 }
 
 export default HomeView

--- a/src/screens/connectors/index.js
+++ b/src/screens/connectors/index.js
@@ -4,15 +4,18 @@ import HomeView from './HomeView'
 import LauncherView from './LauncherView'
 import DebugView from './DebugView'
 
-const Konnectors = ({navigation}) => {
+const Konnectors = ({route, navigation}) => {
   const [debug, setDebug] = useState(false)
   const [launcherContext, setLauncherContext] = useState({state: 'default'})
   return (
     <View style={styles.container}>
       <SafeAreaView style={styles.safeAreaView}>
         <StatusBar barStyle="dark-content" />
-        <Button title="Debug" onPress={() => setDebug(!debug)} />
-        <HomeView setLauncherContext={setLauncherContext} />
+        <HomeView
+          setLauncherContext={setLauncherContext}
+          navigation={navigation}
+          route={route}
+        />
         {debug && <DebugView />}
         {launcherContext.state === 'launch' && (
           <LauncherView

--- a/src/screens/store/StoreView.js
+++ b/src/screens/store/StoreView.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import {WebView} from 'react-native-webview'
+
+const run = `
+  window.cozy = {
+    containerApp : 'amiral'
+  };
+  return true;
+  `
+
+const StoreView = ({route, navigation}) => {
+  return (
+    <WebView
+      originWhitelist={['*']}
+      useWebKit={true}
+      javaScriptEnabled={true}
+      injectedJavaScriptBeforeContentLoaded={run}
+      onShouldStartLoadWithRequest={(request) => {
+        const test = request.url.match(/cozy:\/\/\?action=(.*)&slug=(.*)/)
+        if (test) {
+          const [action, slug] = test.slice(1)
+          if (action === 'connectorInstalled') {
+            navigation.push('home', {slug})
+            return false
+          }
+        }
+        return true
+      }}
+      source={{uri: route.params.url}}
+    />
+  )
+}
+
+export default StoreView


### PR DESCRIPTION
Integrates the store by intercepting redirects to "store" url in the Home View.

When the store has installed the connector and wants to open the installed connector, the amiral application will come back and go the page corresponding to the slug of the connector (`#/connected/<slug>/new`).

![image](https://user-images.githubusercontent.com/228695/137889821-517321b5-1a9f-4b59-a3ea-aeaeebbfbba8.png)


To work as expected, the store needs to have https://github.com/cozy/cozy-store/pull/764 deployed