### PR TITLE
fix: Fetch and save refresh token

### DIFF
--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -15,14 +15,14 @@ export const clearClient = () => {
  *
  * @param {CozyClient} client : client instance
  */
-export const saveClient = (client) => {
-  const {uri, oauthOptions} = client.getStackClient()
-  const token = client.getStackClient().getAccessToken()
+export const saveClient = async (client) => {
+  const {uri, oauthOptions, token} = client.getStackClient()
   const state = JSON.stringify({
     oauthOptions,
     token,
     uri,
   })
+
   return AsyncStorage.setItem(OAUTH_STORAGE_KEY, state)
 }
 


### PR DESCRIPTION
Related to https://trello.com/c/f2Qc7GSo/76-%F0%9F%9A%80%E2%98%81%EF%B8%8F-e71-limitation-token-valable-seulement-quelques-jours-1j

Previously, the refresh token was never fetched and saved. This has been updated, the application now uses the refreshToken method and will save all necessary information related to tokens.