### PR TITLE
fix: User Script should not return value

### DIFF
--- a/src/screens/connectors/HomeView.js
+++ b/src/screens/connectors/HomeView.js
@@ -31,7 +31,6 @@ const HomeView = ({route, navigation, setLauncherContext}) => {
       isWebview: true
     };
     window.cozyClientConf = ${JSON.stringify(cozyClientConf)}
-    return true;
     `
 
   return (


### PR DESCRIPTION
On iOS and Android, latest versions produce a blank
page since user script should not return value.

let's remove it

(it was part of the iOS's PR but let's merge it alone 👍 ) 