### PR TITLE
fix: Properly init CozyClient with saved token

### DIFF
--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -40,7 +40,7 @@ export const getClient = async () => {
   const {uri, oauthOptions, token} = state
   const client = new CozyClient({
     uri,
-    token,
+    oauth: {token},
     oauthOptions,
   })
   return client


### PR DESCRIPTION
The saved token (with refresh token)), needs to be put in CozyClient constructor `oauth` option. 

This way, [an instance of OAuthClient is constructed](https://github.com/cozy/cozy-client/blob/826f995c85378bdcd76f3a62428c1d9857f0136d/packages/cozy-client/src/CozyClient.js#L1516)

Then OAuthClient [can handle the token attribute with refresh token](https://github.com/cozy/cozy-client/blob/826f995c85378bdcd76f3a62428c1d9857f0136d/packages/cozy-stack-client/src/OAuthClient.js#L419)