### PR TITLE
fix: Remove CozyClient injection

### DIFF
--- a/src/screens/connectors/HomeView.js
+++ b/src/screens/connectors/HomeView.js
@@ -47,22 +47,12 @@ const HomeView = ({route, navigation, setLauncherContext}) => {
     if (konnectorParam) {
       setUri(`${uri}#/connected/${konnectorParam}`)
     }
-    const token = client.getStackClient().getAccessToken()
-    const [scheme, cozyDomain] = uri.split('://')
-    const cozyToken = token
-    const cozyClientConf = {
-      scheme,
-      lang: 'fr',
-      cozyDomain,
-      cozyToken,
-    }
 
     setRun(`
       window.cozy = {
         ClientConnectorLauncher: 'react-native',
         isFlagshipApp: true
       };
-      window.cozyClientConf = ${JSON.stringify(cozyClientConf)}
       return true;
       `)
 


### PR DESCRIPTION
This injection was needed when we started to
dev this application in order to be able to
connect to the Home Application without the
need to write the password again.

We don't need it anymore since:
-1/ Home app doesn't handle this kind of
stuff anymore
-2/ Flagship app has now the right to create
session for a webapp.