### PR TITLE
feat: Use lib alias for safetynet

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-native-bootsplash": "3.2.3",
     "react-native-fs": "^2.18.0",
     "react-native-gesture-handler": "1.10.3",
-    "react-native-google-safetynet": "^1.0.0",
+    "react-native-google-safetynet": "npm:cozy-react-native-google-safetynet@^1.0.0",
     "react-native-inappbrowser-reborn": "^3.5.1",
     "react-native-ios11-devicecheck": "https://github.com/cozy/react-native-devicecheck#app-attest-v0.1",
     "react-native-paper": "4.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13976,10 +13976,10 @@ react-native-gesture-handler@1.10.3:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-google-safetynet@^1.0.0:
+"react-native-google-safetynet@npm:cozy-react-native-google-safetynet@^1.0.0":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-google-safetynet/-/react-native-google-safetynet-1.0.0.tgz#2e51e0f77a6df52fc6744ca5dc721c006fecb6e6"
-  integrity sha512-KVrRYXrz5IZQ7l00Ak40d0i3ywgKQtnhNEpYKWjNVZHEwdYYu92oGTcLbzrgboEFdgvU084TWI5QMlgQTPoEAQ==
+  resolved "https://registry.yarnpkg.com/cozy-react-native-google-safetynet/-/cozy-react-native-google-safetynet-1.0.0.tgz#f26cad00870a093e29def5c60659b575e89c94d5"
+  integrity sha512-KjTbi3iqtCGmZ1abdEm2vQblLXR0uupesQMWUawoHgJq7H8Up0UXLhgCtWXyJc2EWF/+/pS7nX+2NTwtqUpaNg==
   dependencies:
     base64-js "^1.3.0"
     jwt-decode "^2.2.0"


### PR DESCRIPTION
This modifies the compileSdkVersion from 27 to 28 to avoid a compile bug when looking for sdk28 components