### PR TITLE
fix: Fix multiple binary installed on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
+            <category android:name="android.intent.category.DEFAULT" />
         </intent-filter>
         <intent-filter>
           <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
Since the use of the Splashscreen, we have two
"Launcher" intent resulting of having 2 binaries
installed on Android.

Let's keep the SplashScreen as the "Launcher"
and let's say that the MainActivity is the default.


@Ldoppea @acezard My Android VM doesn't start anymore. Can you guys check if this fix the issue please? 