### PR TITLE
fix: Do not default subdomain type

### DIFF
--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -4,7 +4,7 @@ import {useEffect, useMemo, useState} from 'react'
 import {makeSessionAPI} from '../libs/functions/session'
 
 export const useSession = () => {
-  const [subdomainType, setSubdomainType] = useState('flat')
+  const [subdomainType, setSubdomainType] = useState()
   const client = useClient()
   const {data, ...query} = useQuery(
     Q('io.cozy.settings').getById('capabilities'),

--- a/src/libs/functions/session.js
+++ b/src/libs/functions/session.js
@@ -114,6 +114,7 @@ const makeSessionAPI = (client, subDomainType) => ({
   resetSessionToken,
   shouldCreateSession,
   shouldInterceptAuth: shouldInterceptAuth(client),
+  subDomainType,
 })
 
 // Exposed API

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -26,7 +26,7 @@ const HomeView = ({route, navigation, setLauncherContext}) => {
         cozyUrl: client.getStackClient().uri,
         pathname: '/',
         slug: 'home',
-        subDomainType: await getSubDomainType(),
+        subDomainType: session.subDomainType,
       })
 
       if (await shouldCreateSession(webLink)) {
@@ -39,27 +39,12 @@ const HomeView = ({route, navigation, setLauncherContext}) => {
       }
     }
 
-    const getSubDomainType = async () => {
-      try {
-        const {
-          data: {
-            attributes: {flat_subdomains},
-          },
-        } = await client.query(Q('io.cozy.settings').getById('capabilities'))
-
-        return flat_subdomains ? 'flat' : 'nested'
-      } catch (error) {
-        // Defaulting to flat if for whatever reason the subDomainType could not be fetched
-        return 'flat'
-      }
-    }
-
     const konnectorParam = get(route, 'params.konnector')
     if (konnectorParam) {
       setUri(`${uri}#/connected/${konnectorParam}`)
     }
 
-    if (!uri) {
+    if (!uri && session.subDomainType) {
       getHomeUri()
     }
   }, [uri, client, route, nativeIntent, ref, navigation, session])


### PR DESCRIPTION
Defaulting to 'flat' created bugs for 'nested' url when the few first render loops were fast