### PR TITLE
feat: Add wildcard authorization

### DIFF
--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -64,22 +64,7 @@ export const callInitClient = async uri => {
   // Your IDE might tell you the following 'await' has no effect, this seems to be a mistake
   const client = await initClient(uri, {
     scope: [
-      'io.cozy.apps',
-      'io.cozy.settings',
-      'io.cozy.konnectors',
-      'io.cozy.jobs',
-      'io.cozy.contacts',
-      'io.cozy.triggers',
-      'io.cozy.permissions',
-      'io.cozy.apps.suggestions',
-      'com.bitwarden.organizations',
-      'com.bitwarden.ciphers',
-      'io.cozy.bank.accounts',
-      'io.cozy.timeseries.geojson',
-      'io.cozy.files.*',
-      'io.cozy.bills',
-      'io.cozy.accounts',
-      'io.cozy.identities',
+      '*',
     ],
     oauth: {
       redirectURI: strings.COZY_SCHEME,


### PR DESCRIPTION
In #56 we introduced flagship certification

Now that we can verify that the running app is a genuine flagship app
then we want to give this app maximal permissions

This will ensure future needs like installing connectors and/or apps