### PR TITLE
feat: Do not open native Banks app from homepage

### DIFF
--- a/src/libs/functions/openApp.js
+++ b/src/libs/functions/openApp.js
@@ -19,14 +19,14 @@ import {Alert, Linking, Platform} from 'react-native'
  * Apps mobile information that can be used as a fallback if the Cozy
  * still has an old version of the app which doesn't describe its mobile
  * info on the manifest.webapp
- * 
+ *
  * This object is used for retro-compatibility support and may be deleted
  * in the future
- * 
+ *
  * If a new schema is inserted into this array or if a new app describe its
  * schema in its manifest.webapp, then AndroidManifest.xml and Info.plist
  * should be updated with the scheme permission
- * 
+ *
  * @type {Array.<AppManifestMobileInfo>}
  */
 const slugFallbacks = {
@@ -34,11 +34,6 @@ const slugFallbacks = {
     schema: 'cozypass://',
     id_playstore: 'io.cozy.pass',
     id_appstore: 'cozy-pass/id1502262449',
-  },
-  banks: {
-    schema: 'cozybanks://',
-    id_playstore: 'io.cozy.banks.mobile',
-    id_appstore: 'cozy-banks/id1349814380',
   },
 }
 


### PR DESCRIPTION
cozy-drive is already handled by the home Applinker
Indeed, cozy-intent takes priority over universal link,
so cozy-home's AppLinker will try to open the web version
of cozy-drive as wanted in this feature

https://trello.com/c/Hf9AkxLh/282-ne-pas-ouvrir-les-versions-natives-de-banks-et-drive-depuis-laa