### PR TITLE
chore: Add dependabot config - run every Saturday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    commit-message:
+      # Prefix all commit messages with "fix"
+      prefix: "fix"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    labels:
+      - "dependencies"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 
 ## 🔧 Tech
 
+* Add dependabot configuration


### PR DESCRIPTION
This configuration of dependabot will make dependabot  trigger only on Saturday.

- changelog feature ✅ 
- pull request template ✅ 
- automerge will be tested now 👀 
- renovate started, we have to wait for Saturday


#### Checklist

Before merging this PR, the following things must have been done:

~~* [ ] Faithful integration of the mockups at all screen sizes~~
~~* [ ] Tested on iOS~~
~~* [ ] Tested on Android~~
~~* [ ] Localized in English and French~~
~~* [ ] All changes have test coverage~~
* [x] Updated README & CHANGELOG, if necessary

