### PR TITLE
fix(splashscreen): display splashscreen after login

### DIFF
--- a/src/hooks/useSplashScreen.js
+++ b/src/hooks/useSplashScreen.js
@@ -3,4 +3,5 @@ import {SplashScreenContext} from '../libs/contexts/SplashScreenContext'
 
 export const useSplashScreen = () => ({
   hideSplashScreen: useContext(SplashScreenContext).hide,
+  showSplashScreen: useContext(SplashScreenContext).show,
 })

--- a/src/libs/services/SplashScreenService.js
+++ b/src/libs/services/SplashScreenService.js
@@ -1,7 +1,9 @@
 import RNBootSplash from 'react-native-bootsplash'
 
 export class SplashScreenService {
+  show = showSplashScreen
   hide = hideSplashScreen
 }
 
+export const showSplashScreen = () => RNBootSplash.show({fade: true})
 export const hideSplashScreen = () => RNBootSplash.hide({fade: true})

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -22,6 +22,7 @@ import {
 } from '../../libs/client'
 import {navbarHeight, statusBarHeight} from '../../libs/dimensions'
 import {saveLoginData} from '../../libs/functions/passwordHelpers'
+import {useSplashScreen} from '../../hooks/useSplashScreen'
 
 import strings from '../../strings.json'
 
@@ -37,6 +38,7 @@ const ERROR_STEP = 'ERROR_STEP'
 const OAUTH_USER_CANCELED_ERROR = 'USER_CANCELED'
 
 const LoginSteps = ({setClient}) => {
+  const {showSplashScreen} = useSplashScreen()
   const [state, setState] = useState({
     step: CLOUDERY_STEP,
   })
@@ -206,6 +208,7 @@ const LoginSteps = ({setClient}) => {
         client,
       })
 
+      showSplashScreen()
       await saveLoginData(loginData)
       setClient(result.client)
     } catch (error) {


### PR DESCRIPTION
Add the splashscreen correctly on ios and android, after login success

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [x] Tested on iOS
* [x] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [x] Updated README & CHANGELOG, if necessary

