### PR TITLE
fix: Add openApp iconParams fallback

### DIFF
--- a/src/libs/functions/openApp.js
+++ b/src/libs/functions/openApp.js
@@ -1,4 +1,5 @@
 import {Alert, Linking, Platform} from 'react-native'
+import {screenHeight, screenWidth} from '../dimensions'
 
 /**
  * App's mobile information. Used to describe the app scheme and its store urls
@@ -129,7 +130,12 @@ export const openApp = (navigation, href, app, iconParams) => {
 
   return navigation.navigate('cozyapp', {
     href,
-    iconParams: iconParams && JSON.parse(iconParams),
+    iconParams: (iconParams && JSON.parse(iconParams)) || {
+      x: screenWidth * 0.5 - 32 * 0.5,
+      y: screenHeight * 0.5 - 32 * 0.5,
+      width: 32,
+      height: 32,
+    },
     slug: app?.slug,
   })
 }

--- a/src/libs/functions/openApp.spec.js
+++ b/src/libs/functions/openApp.spec.js
@@ -2,6 +2,11 @@ import RN from 'react-native'
 
 import {openApp} from './openApp'
 
+jest.mock('../dimensions', () => ({
+  screenHeight: 732,
+  screenWidth: 412,
+}))
+
 jest.mock('react-native', () => ({
   Alert: {
     alert: jest.fn(),
@@ -30,6 +35,12 @@ describe('openApp', () => {
 
       expect(navigation.navigate).toHaveBeenCalledWith('cozyapp', {
         href: 'https://appurl',
+        iconParams: {
+          height: 32,
+          width: 32,
+          x: 190,
+          y: 350,
+        },
       })
     })
   })
@@ -42,7 +53,12 @@ describe('openApp', () => {
 
       expect(navigation.navigate).toHaveBeenCalledWith('cozyapp', {
         href: 'https://appurl',
-        iconParams: undefined,
+        iconParams: {
+          height: 32,
+          width: 32,
+          x: 190,
+          y: 350,
+        },
         slug: 'some_app_with_no_native_equivalent',
       })
     })


### PR DESCRIPTION
When opening cozyapp from a non-installed connector,
Cozy-store is opened but we receive no coordinates from the home
Fastest fix right now is to add a fallback and open from center
