### PR TITLE
fix: Clear keychain on login/onboarding before saving `loginData` on it

### DIFF
--- a/src/libs/functions/passwordHelpers.js
+++ b/src/libs/functions/passwordHelpers.js
@@ -1,7 +1,7 @@
 import Minilog from '@cozy/minilog'
 
 import {queryResultToCrypto} from '../../components/webviews/CryptoWebView/cryptoObservable/cryptoObservable'
-import {saveVaultInformation} from '../keychain'
+import {deleteKeychain, saveVaultInformation} from '../keychain'
 
 const log = Minilog('passwordHelpers')
 
@@ -63,7 +63,7 @@ export const doHashPassword = async (
  *
  * @param {LoginData} loginData - login data containing hashed password and encryption keys
  */
-export const saveLoginData = async ({
+export const resetKeychainAndSaveLoginData = async ({
   passwordHash,
   key,
   privateKey,
@@ -71,6 +71,7 @@ export const saveLoginData = async ({
   masterKey,
 }) => {
   // Those must be called sequentially. Otherwise the keychain would throw
+  await deleteKeychain()
   await saveVaultInformation('passwordHash', passwordHash)
   await saveVaultInformation('key', key)
   await saveVaultInformation('privateKey', privateKey)

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -21,7 +21,7 @@ import {
   STATE_INVALID_PASSWORD,
 } from '../../libs/client'
 import {navbarHeight, statusBarHeight} from '../../libs/dimensions'
-import {saveLoginData} from '../../libs/functions/passwordHelpers'
+import {resetKeychainAndSaveLoginData} from '../../libs/functions/passwordHelpers'
 import {useSplashScreen} from '../../hooks/useSplashScreen'
 
 import strings from '../../strings.json'
@@ -209,7 +209,7 @@ const LoginSteps = ({setClient}) => {
       })
 
       showSplashScreen()
-      await saveLoginData(loginData)
+      await resetKeychainAndSaveLoginData(loginData)
       setClient(result.client)
     } catch (error) {
       if (error === OAUTH_USER_CANCELED_ERROR) {

--- a/src/screens/login/OnboardingScreen.js
+++ b/src/screens/login/OnboardingScreen.js
@@ -11,7 +11,7 @@ import Minilog from '@cozy/minilog'
 
 import {callOnboardingInitClient} from '../../libs/client'
 import {navbarHeight, statusBarHeight} from '../../libs/dimensions'
-import {saveLoginData} from '../../libs/functions/passwordHelpers'
+import {resetKeychainAndSaveLoginData} from '../../libs/functions/passwordHelpers'
 import {consumeRouteParameter} from '../../libs/functions/routeHelpers'
 
 import {routes} from '../../constants/routes'
@@ -127,7 +127,7 @@ const OnboardingSteps = ({setClient, route, navigation}) => {
         registerToken,
       })
 
-      await saveLoginData(loginData)
+      await resetKeychainAndSaveLoginData(loginData)
       setClient(client)
     } catch (error) {
       setError(error.message, error)


### PR DESCRIPTION
On iOS the keychain is persisted by the OS even if the app is
uninstalled

This may produce a bug when user uninstall the app while being
connected to a cozy, then when reinstalling the app it would be
impossible to login again

This is because `keychain.js` protects the keychain from being
overwritten if it contains data

On login and onboarding, we know that the keychain should be empty and
filled from scratch. So we can safely empty it before saving new
`loginData` into it
