### PR TITLE
feat: Use translucent bars on app loading

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -7,6 +7,8 @@
 
     <style name="BootTheme" parent="AppTheme">
         <item name="android:background">@drawable/bootsplash</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Couldn't find a way to make them completely transparent on app start