### PR TITLE
fix(ios): set background color not available on ios

### DIFF
--- a/src/screens/home/HomeScreen.js
+++ b/src/screens/home/HomeScreen.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react'
-import {StatusBar, StyleSheet, View} from 'react-native'
+import {Platform, StatusBar, StyleSheet, View} from 'react-native'
 
 import HomeView from './components/HomeView'
 import LauncherView from '../connectors/LauncherView'
@@ -11,8 +11,7 @@ const resetUIState = () => {
     topTheme: 'light',
     bottomTheme: 'light',
   })
-
-  StatusBar?.setBackgroundColor('transparent')
+  Platform.OS !== 'ios' && StatusBar?.setBackgroundColor('transparent')
 }
 
 export const HomeScreen = ({route, navigation}) => {


### PR DESCRIPTION
#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [x] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

