### PR TITLE
fix: Force FQDN to be lowercase when set by the ClouderyView

### DIFF
--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -45,7 +45,8 @@ export const ClouderyView = ({setInstanceData}) => {
 
       const instance = getUriFromRequest(request)
       if (instance) {
-        const fqdn = new URL(instance).host
+        const normalizedInstance = instance.toLowerCase()
+        const fqdn = new URL(normalizedInstance).host
         setInstanceData({
           instance,
           fqdn,


### PR DESCRIPTION
FQDN is used as a salt in order to hash the user's password

This implies that FQDN is case sensitive because a different casing
would produce a different hash

The cloudery and the stack force the FQDN to be lowercase so we want to
replicate this behavior on the mobile app
