### PR TITLE
fix: Correctly compute CSS font's url in login screens

### DIFF
--- a/src/screens/login/components/assets/common/css/cssFonts.js
+++ b/src/screens/login/components/assets/common/css/cssFonts.js
@@ -2,19 +2,29 @@
 /* This code should reflect cozy-stack/assets/fonts/fonts.css  */
 /***************************************************************/
 
-export const fontsCss = instance => `
+export const fontsCss = instance => {
+  const regularLatoUrl = new URL(instance)
+  regularLatoUrl.pathname = 'assets/fonts/Lato-Regular.immutable.woff2'
+  const regularLatoUrlString = regularLatoUrl.toString()
+
+  const boldLatoUrl = new URL(instance)
+  boldLatoUrl.pathname = 'assets/fonts/Lato-Bold.immutable.woff2'
+  const boldLatoUrlString = boldLatoUrl.toString()
+
+  return `
 @font-face {
   font-family: Lato;
   font-style: normal;
   font-weight: normal;
-  src: url("${instance}/assets/fonts/Lato-Regular.immutable.woff2") format("woff2");
+  src: url("${regularLatoUrlString}") format("woff2");
   font-display: fallback;
 }
 @font-face {
   font-family: Lato;
   font-style: normal;
   font-weight: bold;
-  src: url("${instance}/assets/fonts/Lato-Bold.immutable.woff2") format("woff2");
+  src: url("${boldLatoUrlString}") format("woff2");
   font-display: fallback;
 }
 `
+}


### PR DESCRIPTION
When computing CSS font injection, fonts' urls are computed using
`instance` parameter

Sometimes the `instance` url has a trailing `/`. In this case previous
implementation would introduce a duplicated `/` in the url which would
result to a 404 error

New implementation uses javascript's `URL` class to construct the
fonts' urls and fix that behavior