### PR TITLE
refactor: Allow bigger webview console

### DIFF
--- a/src/components/webviews/jsInteractions/jsLogInterception.js
+++ b/src/components/webviews/jsInteractions/jsLogInterception.js
@@ -1,32 +1,48 @@
 import log from 'cozy-logger'
 
 export const jsLogInterception = `
-  const originalJsConsole = console;
+  const originalJsConsole = console
   const consoleLog = (type, log) => {
-    originalJsConsole[type](log);
-    window.ReactNativeWebView.postMessage(
-      JSON.stringify({'type': 'Console', 'data': {'type': type, 'log': log}})
-    );
-  };
+    originalJsConsole[type](...log)
+
+    try {
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({
+          type: 'Console',
+          data: {type, log},
+        }),
+      )
+    } catch {}
+  }
+
   console = {
-    log: (log) => consoleLog('log', log),
-    debug: (log) => consoleLog('debug', log),
-    info: (log) => consoleLog('info', log),
-    warn: (log) => consoleLog('warn', log),
-    error: (log) => consoleLog('error', log),
-  };
+    log: (...log) => consoleLog('log', log),
+    debug: (...log) => consoleLog('debug', log),
+    info: (...log) => consoleLog('info', log),
+    warn: (...log) => consoleLog('warn', log),
+    error: (...log) => consoleLog('error', log),
+  }
 `
 
 export const tryConsole = (payload, logger, logId) => {
   try {
     const dataPayload = JSON.parse(payload.nativeEvent.data)
 
-    if (dataPayload) {
-      if (dataPayload.type === 'Console') {
-        const {type, log: msg} = dataPayload.data
-        logger[type](`[Console ${logId}] ${msg}`)
-      }
+    if (
+      !(dataPayload === null || dataPayload === undefined
+        ? undefined
+        : dataPayload.data)
+    ) {
+      return
     }
+
+    const {type, log: msg} = dataPayload.data
+
+    if (msg[0] === 'webview-service') {
+      // eslint-disable-next-line no-console
+      return console.debug(...msg)
+    }
+    logger[type](`[Console ${logId}]`, ...msg.map(v => JSON.stringify(v)))
   } catch (e) {
     log('error', e)
   }


### PR DESCRIPTION
Previously, the webview console forwarded only the first argument.
It is useful to forward all arguments.
Also added a specific forwarding for cozy-intent logs.
In the future, it could be useful to have some kind of API to easily enable or disable logging on demand.