### PR TITLE
test: Run coverage only on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ jobs:
       script: yarn lint
     - name: Test
       stage: test
-      script: yarn test
+      script: yarn test --coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 * Add dependabot configuration
 * Move android Main files inside correct path for react-native link usage
 * Remove unused library @react-native-community/masked-view
+* Run Test coverage only on CI

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,6 @@ const config = {
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native(-.*)?|@react-native(-community)?)/)'
   ],
-  collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}']
 }
 


### PR DESCRIPTION
When running test in local, the coverage adds several second to each run.
In order to remove frustration, let's run coverage only on CI.


