### PR TITLE
fix: Only log setFlagshipUi for RN events

### DIFF
--- a/src/libs/intents/localMethods.js
+++ b/src/libs/intents/localMethods.js
@@ -5,6 +5,7 @@ import { hideSplashScreen } from '../services/SplashScreenService'
 import { openApp } from '../functions/openApp'
 import { resetSessionToken } from '../functions/session'
 import { setFlagshipUI } from './setFlagshipUI'
+import { isDevMode } from '../utils'
 
 export const asyncLogout = async () => {
   await clearClient()
@@ -21,6 +22,14 @@ const logout = () => {
 
 const backToHome = () => {
   RootNavigation.navigate('home')
+}
+
+export const internalMethods = {
+  setFlagshipUI: intent =>
+    setFlagshipUI(
+      intent,
+      isDevMode() && internalMethods.setFlagshipUI.caller.name
+    )
 }
 
 export const localMethods = {

--- a/src/libs/intents/setFlagshipUI.js
+++ b/src/libs/intents/setFlagshipUI.js
@@ -13,13 +13,12 @@ const handleSideEffects = ({ bottomTheme, ...parsedIntent }) => {
   flagshipUI.emit('change', parsedIntent)
 }
 
-const handleLogging = (fn, intent) =>
-  fn?.caller?.name && log.info(`by ${fn.caller.name}()`, intent)
+const handleLogging = (intent, name) => name && log.info(`by ${name}()`, intent)
 
 export const flagshipUI = new EventEmitter()
 
-export const setFlagshipUI = intent => {
-  handleLogging(setFlagshipUI, intent)
+export const setFlagshipUI = (intent, callerName) => {
+  callerName && handleLogging(intent, callerName)
 
   return handleSideEffects(
     Object.fromEntries(

--- a/src/screens/cozy-app/CozyAppScreen.js
+++ b/src/screens/cozy-app/CozyAppScreen.js
@@ -3,12 +3,13 @@ import { StatusBar, View } from 'react-native'
 
 import CozyWebView from '../../components/webviews/CozyWebView'
 import { Animation } from './CozyAppScreen.Animation'
-import { flagshipUI, setFlagshipUI } from '../../libs/intents/setFlagshipUI'
+import { flagshipUI } from '../../libs/intents/setFlagshipUI'
 import { navbarHeight, statusBarHeight } from '../../libs/dimensions'
 import { styles } from './CozyAppScreen.styles'
+import { internalMethods } from '../../libs/intents/localMethods'
 
 const firstHalfUI = () =>
-  setFlagshipUI({
+  internalMethods.setFlagshipUI({
     bottomBackground: 'white',
     bottomTheme: 'dark',
     bottomOverlay: 'transparent',

--- a/src/screens/home/HomeScreen.js
+++ b/src/screens/home/HomeScreen.js
@@ -1,16 +1,17 @@
 import React, { useEffect, useState } from 'react'
 import { Platform, StatusBar, StyleSheet, View } from 'react-native'
 
+import DebugView from '../connectors/DebugView'
 import HomeView from './components/HomeView'
 import LauncherView from '../connectors/LauncherView'
-import DebugView from '../connectors/DebugView'
-import { setFlagshipUI } from '../../libs/intents/setFlagshipUI'
+import { internalMethods } from '../../libs/intents/localMethods'
 
 const resetUIState = () => {
-  setFlagshipUI({
+  internalMethods.setFlagshipUI({
     topTheme: 'light',
     bottomTheme: 'light'
   })
+
   Platform.OS !== 'ios' && StatusBar?.setBackgroundColor('transparent')
 }
 


### PR DESCRIPTION
Logging setFlagshipUI with post-me objects can create security issues.
Just added a check so it will never happen.
No test added as it's pretty trivial and dev-related.
