### PR TITLE
⚠️ WIP: chore(script): ensure installation run on each platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.7
+
+## 🔧 Tech
+
+* Ensure installation run on each platform
+
 # 0.0.1
 
 ## ✨ Features

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ios": "react-native run-ios",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
     "pre-commit": "yarn lint",
+    "prepare": "cd ios && pod install",
     "start": "react-native start",
     "test": "jest connectors/**/* src/**/*",
     "token": "node scripts/token.js",


### PR DESCRIPTION
Why:
In order to prevent forgetting to run pod install

Technically: 
`pod install` will be run after install, as yarn prepare is run after install.


#### Checklist

* [x] Updated README & CHANGELOG, if necessary

