### PR TITLE
feat: bump app version to 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,45 @@
-# 0.0.1
+# 0.0.8
 
 ## ✨ Features
 
 
 ## 🐛 Bug Fixes
 
-* Don't reset password on bad password
 
 ## 🔧 Tech
 
-* Clear automatically all mocks after each tests
+
+# 0.0.7
+
+## ✨ Features
+
+* Handle back navigation on CozyWebView ([PR #140](https://github.com/cozy/cozy-pass-mobile/pull/140))
+
+## 🐛 Bug Fixes
+
+* Don't reset password on bad password ([PR #157](https://github.com/cozy/cozy-pass-mobile/pull/157))
+
+## 🔧 Tech
+
+* Improve debug logs ([PR #150](https://github.com/cozy/cozy-react-native/pull/150) and [PR #154](https://github.com/cozy/cozy-react-native/pull/154) and [PR #161](https://github.com/cozy/cozy-react-native/pull/161))
+* Improve linting ([PR #151](https://github.com/cozy/cozy-react-native/pull/151))
+* Add Prettier config ([PR #153](https://github.com/cozy/cozy-react-native/pull/153))
+* Improve tests tooling ([PR #155](https://github.com/cozy/cozy-react-native/pull/155))
+* Improve tests coverage ([PR #156](https://github.com/cozy/cozy-react-native/pull/156))
+* Run Test coverage only on CI ([PR #159](https://github.com/cozy/cozy-react-native/pull/159))
+* Clear automatically all mocks after each tests ([PR #160](https://github.com/cozy/cozy-react-native/pull/160))
+* Add Sentry tracking ([PR #51](https://github.com/cozy/cozy-react-native/pull/51) and [PR #163](https://github.com/cozy/cozy-react-native/pull/163) and [PR #164](https://github.com/cozy/cozy-react-native/pull/164))
+
+# 0.0.1 to 0.0.6
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+
+## 🔧 Tech
+
 * Add dependabot configuration
 * Move android Main files inside correct path for react-native link usage
 * Remove unused library @react-native-community/masked-view
-* Run Test coverage only on CI

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 0000504
-        versionName "0.0.5"
+        versionCode 0000701
+        versionName "0.0.7"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.5</string>
+	<string>0.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0000504</string>
+	<string>0000701</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
This PR
- updates the App version to 0.0.7 (I forgot to commit previous updates)
- fixes the changelog to 0.0.7 and creates a new entry for next 0.0.8 release
- improves the changelog by adding missing entries from previous days and add link to related PRs

