### PR TITLE
fix: Force the instance to be lowercase after validating ClouderyView

### DIFF
--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -54,7 +54,7 @@ export const ClouderyView = ({ setInstanceData }) => {
         const normalizedInstance = instance.toLowerCase()
         const fqdn = new URL(normalizedInstance).host
         setInstanceData({
-          instance,
+          instance: normalizedInstance,
           fqdn
         })
         return false

--- a/src/screens/login/components/ClouderyView.spec.js
+++ b/src/screens/login/components/ClouderyView.spec.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Button as MockButton } from 'react-native'
+import { fireEvent, render } from '@testing-library/react-native'
+
+import { ClouderyView } from './ClouderyView'
+
+const mockGetNextUrl = jest.fn()
+
+jest.mock('react-native-webview', () => {
+  const React = require('react')
+  class WebView extends React.Component {
+    render() {
+      return (
+        <MockButton
+          testID="triggerStartLoadWithRequest"
+          onPress={() => {
+            const request = {
+              loading: true,
+              url: mockGetNextUrl()
+            }
+            this.props.onShouldStartLoadWithRequest(request)
+          }}
+          title="WebView Button"
+        />
+      )
+    }
+  }
+  return { WebView }
+})
+
+describe('ClouderyView', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('on handleNavigation', () => {
+    it('should convert instance and FQDN to lowercase', async () => {
+      // Given
+      const props = {
+        setInstanceData: jest.fn()
+      }
+
+      const { getByTestId } = await render(<ClouderyView {...props} />)
+
+      const button = getByTestId('triggerStartLoadWithRequest')
+
+      // When
+      mockGetNextUrl.mockReturnValueOnce(
+        'https://loginflagship?fqdn=SOMEINSTANCE.MYCOZY.CLOUD'
+      )
+      fireEvent.press(button)
+
+      // Then
+      expect(props.setInstanceData).toHaveBeenCalledTimes(1)
+      expect(props.setInstanceData).toHaveBeenCalledWith({
+        instance: 'https://someinstance.mycozy.cloud/',
+        fqdn: 'someinstance.mycozy.cloud'
+      })
+    })
+  })
+})


### PR DESCRIPTION
The `instance` string is used by `cozy-intent` to register the webview

The same string is passed in the webview URL but it seems like the cozy
app rendered by the webview receives the URL with a different casing
and the `cozy-intent` pairing with ReactNative cannot be done

By forcing the `instance` to be lowercase after validating ClouderyView
we ensure that the entire app uses the same casing

However a security fix may be needed in `cozy-intent` too to avoid
future bugs like this to happen

