### PR TITLE
build: Allow `jsx` extensions in Metro

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,18 +1,18 @@
-const {getDefaultConfig} = require('metro-config')
+const { getDefaultConfig } = require('metro-config')
 
 module.exports = (async () => {
   const {
-    resolver: {sourceExts, assetExts},
+    resolver: { sourceExts, assetExts }
   } = await getDefaultConfig()
   return {
     transformer: {
       experimentalImportSupport: false,
       inlineRequires: true,
-      babelTransformerPath: require.resolve('react-native-svg-transformer'),
+      babelTransformerPath: require.resolve('react-native-svg-transformer')
     },
     resolver: {
       assetExts: assetExts.filter(ext => ext !== 'svg'),
-      sourceExts: [...sourceExts, 'svg'],
-    },
+      sourceExts: [...sourceExts, 'jsx', 'svg']
+    }
   }
 })()


### PR DESCRIPTION
For some reason, it is not in Metro's default config
Also prettified the config file