### PR TITLE
feat: show/hide InAppBrowser on cozy-intent call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## ✨ Features
 
+* show/hide InApp Browser on cozy-intent call
 
 ## 🐛 Bug Fixes
 

--- a/src/libs/intents/InAppBrowser.js
+++ b/src/libs/intents/InAppBrowser.js
@@ -1,0 +1,43 @@
+import { InAppBrowser } from 'react-native-inappbrowser-reborn'
+import { BrowserResult } from 'react-native-inappbrowser-reborn/types' // eslint-disable-line no-unused-vars
+
+const IAB_OPTIONS = {
+  // iOS Properties
+  readerMode: false,
+  animated: true,
+  modalPresentationStyle: 'fullScreen',
+  modalTransitionStyle: 'coverVertical',
+  modalEnabled: true,
+  enableBarCollapsing: false,
+  // Android Properties
+  showTitle: true,
+  toolbarColor: '#8e9094',
+  secondaryToolbarColor: 'black',
+  enableUrlBarHiding: true,
+  enableDefaultShare: true,
+  forceCloseOnRedirection: false,
+  showInRecents: true,
+  animations: {
+    startEnter: 'slide_in_right',
+    startExit: 'slide_out_left',
+    endEnter: 'slide_in_left',
+    endExit: 'slide_out_right'
+  }
+}
+
+/**
+ * Show InAppBrowser with the specified url
+ *
+ * @param {String} options.url - url to which open the InAppBrowser
+ * @returns {BrowserResult}
+ */
+export const showInAppBrowser = ({ url }) => {
+  return InAppBrowser.open(url, IAB_OPTIONS)
+}
+
+/**
+ * CLose current InAppBrowser
+ */
+export const closeInAppBrowser = () => {
+  return InAppBrowser.close()
+}

--- a/src/libs/intents/localMethods.js
+++ b/src/libs/intents/localMethods.js
@@ -6,6 +6,7 @@ import { openApp } from '../functions/openApp'
 import { resetSessionToken } from '../functions/session'
 import { setFlagshipUI } from './setFlagshipUI'
 import { isDevMode } from '../utils'
+import { showInAppBrowser, closeInAppBrowser } from './InAppBrowser'
 
 export const asyncLogout = async () => {
   await clearClient()
@@ -38,5 +39,7 @@ export const localMethods = {
   logout,
   openApp: (href, app, iconParams) =>
     openApp(RootNavigation, href, app, iconParams),
-  setFlagshipUI
+  setFlagshipUI,
+  showInAppBrowser,
+  closeInAppBrowser
 }


### PR DESCRIPTION
Now you can trigger the display of an InAppBrowser from a webview with cozy-intent :
- showInAppBrowser(url) : display InAppBrowser with the specified url
- closeInAppBrowser() : close current InAppBrowser

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [X] Updated README & CHANGELOG, if necessary

