### PR TITLE
feat: bump app version to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,30 @@
+# 0.0.9
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+
+## 🔧 Tech
+
+
 # 0.0.8
 
 ## ✨ Features
 
-* show/hide InApp Browser on cozy-intent call
+* show/hide InApp Browser on cozy-intent call ([PR #179](https://github.com/cozy/cozy-pass-mobile/pull/179))
 
 ## 🐛 Bug Fixes
 
-* Prevent crash during the animated transition after login
+* Force the instance to be lowercase after validating ClouderyView ([PR #169](https://github.com/cozy/cozy-pass-mobile/pull/169))
+* Prevent crash during the animated transition after login ([PR #178](https://github.com/cozy/cozy-pass-mobile/pull/178))
+* Disable zoom on weviews ([PR #176](https://github.com/cozy/cozy-pass-mobile/pull/176))
+* Set a background color to ClouderyWebview ([PR #176](https://github.com/cozy/cozy-pass-mobile/pull/176))
+* Fix possible cases of failed handshake preventing webview apps to communicate with the native code ([PR #168](https://github.com/cozy/cozy-pass-mobile/pull/168))
 
 ## 🔧 Tech
+* Improve webview env injection ([PR #167](https://github.com/cozy/cozy-pass-mobile/pull/167))
 
 
 # 0.0.7

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 0000701
-        versionName "0.0.7"
+        versionCode 801
+        versionName "0.0.8"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.7</string>
+	<string>0.0.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0000701</string>
+	<string>0000801</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.8
- creates a new entry for next 0.0.9 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs


⚠️ I changed the Android's bundleVersion notation as previous made the build crash when passing from `0000701` to `0000801`. Leading 0s were not interpreted correctly by the build toolchain.

Also this fixes the build number displayed by the Google Console. In the following capture we expected to see "Codes de versions" to `601`, `701`, `801`, but we got `385`, `449`, `801` because bundleVersion was not interpreted correctly

![image](https://user-images.githubusercontent.com/1884255/166249236-2c5a553e-9d87-49f9-a802-f78d6feea40d.png)
