### PR TITLE
build: Add root alias for src directories

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,25 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['optional-require'],
+  plugins: [
+    'optional-require',
+    [
+      'module-resolver',
+      {
+        root: ['./'],
+        alias: {
+          '^/(.+)': './src/\\1'
+        },
+        extensions: [
+          '.ios.js',
+          '.android.js',
+          '.js',
+          '.jsx',
+          '.json',
+          '.tsx',
+          '.ts',
+          '.native.js'
+        ]
+      }
+    ]
+  ]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "/*": ["src/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Also add it to jsconfig for Electron based IDE.
Can be used later for TSConfig if needed.

With this change, you can import a file like this: 
`import { routes } from '/constants/routes'`

I did not use the `@` sign, because it conflicts with various third-party libraries in the regex auto resolver.
Instead, I chose the forward slash, because it reminds us of a root path.

Every directory directly under `src/` will then be automatically available as `/foobar` for `src/foobar`