### PR TITLE
fix: Update typo on BackHandler callback

### DIFF
--- a/src/components/webviews/CozyWebView.js
+++ b/src/components/webviews/CozyWebView.js
@@ -59,7 +59,7 @@ export const CozyWebView = ({
     BackHandler.addEventListener('hardwareBackPress', handleBackPress)
 
     return () =>
-      BackHandler.removeEventListener('hardwareBackpress', handleBackPress)
+      BackHandler.removeEventListener('hardwareBackPress', handleBackPress)
   }, [handleBackPress])
 
   useEffect(() => {


### PR DESCRIPTION
The casing is inconsistent between subscription and unsubscription