### PR TITLE
chore(travis): Running pod install in the pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,31 @@ cache:
     - node_modules
 
 stages:
- - lint
  - test
 
 jobs:
   include:
     - name: Lint
-      stage: lint
+      stage: test
       script: yarn lint
     - name: Test
       stage: test
       script: yarn test --coverage
+    - name: "Pod install check"
+      stage: test
+      os: osx
+      language: objective-c
+      osx_image: xcode13.3
+      env:
+        - JOB_NAME=IOS
+      before_install:
+        - npm install -g yarn
+        - yarn --frozen-lockfile
+      script:
+        - cd ios && pod install --deployment
+      cache:
+        cocoapods: true
+        yarn: true
+        directories:
+          - node_modules
+      podfile: ios/Podfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## 🔧 Tech
 
+* Run iOS installation on CI
 
 # 0.0.7
 

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -24,7 +24,7 @@ Before creating the release bundle, always do the following:
     - `npx react-native run-android --variant=release`
 - The generated AAB (Android App Bundle) is in `android/app/build/outputs/bundle/release/app-release.aab`
 
-# Release on Apple AppStore (iOS)
+# Release on App Store (iOS)
 
 - Execute `cd ios && pod install`
 - Open `ios/CozyReactNative.xcworkspace` in XCode


### PR DESCRIPTION
This PR introduces:
- OSX job - validated podfile and install for iOS

[OSX job lasted 4min](https://app.travis-ci.com/github/cozy/cozy-react-native/jobs/568974567) splitted into:
- 95-80 seconds to load cached node_modules of cozy-react-native
- 29-28 seconds to load cached cocoapods in cozy-react-native/ios
- 33-35 seconds to run pod install --deployment (blocking PR that didn't update lockfile)
- 59-47 seconds updating caches (ios+node_modules) (nothing has changed during in this job)

it's less than without cache (11min) but it's still a lot

