### PR TITLE
[WIP] feat: Upgrade React Native Webview

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -286,7 +286,7 @@ PODS:
     - RCTTypeSafety
     - React
     - ReactCommon/turbomodule/core
-  - react-native-webview (11.3.1):
+  - react-native-webview (11.18.2):
     - React-Core
   - React-perflogger (0.66.4)
   - React-RCTActionSheet (0.66.4):
@@ -630,7 +630,7 @@ SPEC CHECKSUMS:
   react-native-gzip: 5ffb84bf191c7cd135338eca748317bc466d41a1
   react-native-netinfo: 3671b091c4843fda5e153612866ef4024b8f5d62
   react-native-safe-area-context: f98b0b16d1546d208fc293b4661e3f81a895afd9
-  react-native-webview: 07fca3f4378bd6ea26254bf63119bfd70f4fabeb
+  react-native-webview: 8ec7ddf9eb4ddcd92b32cee7907efec19a9ec7cb
   React-perflogger: 93075d8931c32cd1fce8a98c15d2d5ccc4d891bd
   React-RCTActionSheet: 7d3041e6761b4f3044a37079ddcb156575fb6d89
   React-RCTAnimation: 743e88b55ac62511ae5c2e22803d4f503f2a3a13

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-native-svg": "12.3.0",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-web": "0.17.7",
-    "react-native-webview": "11.3.1",
+    "react-native-webview": "^11.18.2",
     "react-scripts": "4.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14619,10 +14619,10 @@ react-native-web@0.17.7:
     normalize-css-color "^1.0.2"
     prop-types "^15.6.0"
 
-react-native-webview@11.3.1:
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.3.1.tgz#acc87db56eca568fd561edecbd990e8252b882a5"
-  integrity sha512-qHvD2DVbUVSuRLU33RU4LbfISoJ3q5PWj4fuDcMgEYaEnlvOiOQqR/x5t9z4kdVZ83T+WG8ktp19F2uTCaOKRg==
+react-native-webview@^11.18.2:
+  version "11.18.2"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.18.2.tgz#3e2537f8aa21a6a207f801c3135ed1ae9c03ba9e"
+  integrity sha512-EB2BzFi+soOp6GmZQrw6kpeFfoKMxw1vzZg68gWsBllAXfTpfJuxr5zsRoZSNyRRpIoaJ+N+Ok2BVJJiyUYx+g==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
Some Client Side Konnectors (Clisk) are
receiving a blob url and then try to
download the file. The previous version
of RNW was crashing the app since the
blob url was sended to the downloadManager
and then the downloadManager will crash
because it doesn't handle this kind of url
(aka blob://https://...). It only handles
http(s):// url.

This is the needed fix:
https://github.com/react-native-webview/react-native-webview/pull/2328

I didn't try to run the app on iOS yet
with this upgrade. This is currently only
a branch for testing purpose.

_Please explain what this PR does here._

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

