### PR TITLE
feat: bump app version to 0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,29 @@
-# 0.0.9
+# 0.0.10
 
 ## ✨ Features
 
-* Intercept redirection/reloading and refresh only WebView ([PR #187](https://github.com/cozy/cozy-react-native/pull/187))
 
 ## 🐛 Bug Fixes
 
 
 ## 🔧 Tech
 
+
+# 0.0.9
+
+## ✨ Features
+
+* The app now displays an Offline screen when no connection is available ([PR #180](https://github.com/cozy/cozy-pass-mobile/pull/180) and [PR #189](https://github.com/cozy/cozy-pass-mobile/pull/189))
+* Intercept redirection/reloading and refresh only WebView ([PR #187](https://github.com/cozy/cozy-react-native/pull/187))
+* The app now displays a NotFound screen when the entered Cozy url is not valid ([PR #197](https://github.com/cozy/cozy-react-native/pull/197))
+
+## 🐛 Bug Fixes
+
+* Prevent crash during the animated transition after login ([PR #205](https://github.com/cozy/cozy-pass-mobile/pull/205))
+
+## 🔧 Tech
+
+* Fix Android's Back button listener that would produce a memory leak ([PR #196](https://github.com/cozy/cozy-pass-mobile/pull/196))
 
 # 0.0.8
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 801
-        versionName "0.0.8"
+        versionCode 901
+        versionName "0.0.9"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.8</string>
+	<string>0.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0000801</string>
+	<string>0000901</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.9
- creates a new entry for next 0.0.10 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs