### PR TITLE
fix: Post-me browsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cheerio": "^1.0.0-rc.9",
     "cozy-client": "^27.24.0",
     "cozy-client-js": "^0.20.0",
-    "cozy-intent": "1.16.1",
+    "cozy-intent": "^2.0.1",
     "cozy-logger": "^1.9.0",
     "cozy-ui": "52.0.1",
     "ky": "0.25.1",

--- a/src/libs/functions/getHostname.js
+++ b/src/libs/functions/getHostname.js
@@ -1,0 +1,7 @@
+export const getHostname = nativeEvent => {
+  try {
+    return new URL(nativeEvent.url).hostname
+  } catch {
+    return nativeEvent?.url
+  }
+}

--- a/src/libs/functions/getHostname.spec.js
+++ b/src/libs/functions/getHostname.spec.js
@@ -1,0 +1,17 @@
+import { getHostname } from '/libs/functions/getHostname'
+
+it('returns a hostname from a native event', () => {
+  expect(getHostname({ url: 'https://ho.me/foo/#/foobared' })).toBe('ho.me')
+})
+
+it('does not throw if no valid hostname, and return url key as is', () => {
+  expect(getHostname({ url: 'notvalid' })).toBe('notvalid')
+})
+
+it('does not throw if no url key', () => {
+  expect(getHostname({})).toBeUndefined()
+})
+
+it('does not throw if no event at all', () => {
+  expect(getHostname()).toBeUndefined()
+})

--- a/src/libs/functions/urlHasConnector.js
+++ b/src/libs/functions/urlHasConnector.js
@@ -1,0 +1,10 @@
+export const urlHasConnectorOpen = url => {
+  try {
+    return (
+      new URL(url.endsWith('/') ? url.slice(0, -1) : url).hash.split('/')
+        .length >= 3
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/libs/functions/urlHasConnector.spec.js
+++ b/src/libs/functions/urlHasConnector.spec.js
@@ -1,0 +1,23 @@
+import { urlHasConnectorOpen } from '/libs/functions/urlHasConnector'
+
+it('should not throw when not given an improper URL and return false', () => {
+  expect(urlHasConnectorOpen('foobared')).toBe(false)
+})
+
+it('should return false when URL does not contain a connector', () => {
+  expect(urlHasConnectorOpen('https://ho.me/#/connected')).toBe(false)
+})
+
+it('should return false when URL does not contain a connector with trailing slash', () => {
+  expect(urlHasConnectorOpen('https://ho.me/#/connected/')).toBe(false)
+})
+
+it('should return true when URL does contain an active connector with short hash', () => {
+  expect(urlHasConnectorOpen('https://ho.me/#/connected/connector/')).toBe(true)
+})
+
+it('should return true when URL does contain an active connector with long hash', () => {
+  expect(
+    urlHasConnectorOpen('https://ho.me/#/connected/connector/accounts/123')
+  ).toBe(true)
+})

--- a/src/libs/intents/localMethods.js
+++ b/src/libs/intents/localMethods.js
@@ -29,7 +29,7 @@ export const internalMethods = {
   setFlagshipUI: intent =>
     setFlagshipUI(
       intent,
-      isDevMode() && internalMethods.setFlagshipUI.caller.name
+      isDevMode() && internalMethods.setFlagshipUI.caller?.name
     )
 }
 

--- a/src/libs/intents/setFlagshipUI.js
+++ b/src/libs/intents/setFlagshipUI.js
@@ -1,7 +1,11 @@
-import { changeBarColors } from 'react-native-immersive-bars'
 import { EventEmitter } from 'events'
+import { Platform, StatusBar } from 'react-native'
+import { changeBarColors } from 'react-native-immersive-bars'
 
 import Minilog from '@cozy/minilog'
+
+import { internalMethods } from '/libs/intents/localMethods'
+import { urlHasConnectorOpen } from '/libs/functions/urlHasConnector'
 
 const log = Minilog('SET_FLAGSHIP_UI')
 
@@ -14,6 +18,18 @@ const handleSideEffects = ({ bottomTheme, ...parsedIntent }) => {
 }
 
 const handleLogging = (intent, name) => log.info(`by ${name}`, intent)
+
+export const resetUIState = uri => {
+  const bottomTheme = urlHasConnectorOpen(uri)
+    ? 'dark-content'
+    : 'light-content'
+
+  StatusBar.setBarStyle(bottomTheme)
+
+  internalMethods.setFlagshipUI({ bottomTheme })
+
+  Platform.OS !== 'ios' && StatusBar?.setBackgroundColor('transparent')
+}
 
 export const flagshipUI = new EventEmitter()
 

--- a/src/screens/home/HomeScreen.js
+++ b/src/screens/home/HomeScreen.js
@@ -1,30 +1,15 @@
-import React, { useEffect, useState } from 'react'
-import { Platform, StatusBar, StyleSheet, View } from 'react-native'
+import React, { useState } from 'react'
+import { StyleSheet, View } from 'react-native'
 
 import DebugView from '../connectors/DebugView'
 import HomeView from './components/HomeView'
 import LauncherView from '../connectors/LauncherView'
-import { internalMethods } from '../../libs/intents/localMethods'
-
-const resetUIState = () => {
-  internalMethods.setFlagshipUI({
-    topTheme: 'light',
-    bottomTheme: 'light'
-  })
-
-  Platform.OS !== 'ios' && StatusBar?.setBackgroundColor('transparent')
-}
 
 export const HomeScreen = ({ route, navigation }) => {
   const [debug] = useState(false)
   const [launcherContext, setLauncherContext] = useState({
     state: 'default'
   })
-
-  useEffect(() => {
-    const unsubscribe = navigation.addListener('focus', resetUIState)
-    return unsubscribe
-  }, [navigation])
 
   return (
     <View style={styles.container}>

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -4,10 +4,11 @@ import { get } from 'lodash'
 import { useClient, generateWebLink } from 'cozy-client'
 import { useNativeIntent } from 'cozy-intent'
 
-import { useSession } from '../../../hooks/useSession'
-import CozyWebView from '../../../components/webviews/CozyWebView'
-import { consumeRouteParameter } from '../../../libs/functions/routeHelpers'
-import { statusBarHeight, getNavbarHeight } from '../../../libs/dimensions'
+import CozyWebView from '/components/webviews/CozyWebView'
+import { consumeRouteParameter } from '/libs/functions/routeHelpers'
+import { resetUIState } from '/libs/intents/setFlagshipUI'
+import { statusBarHeight, getNavbarHeight } from '/libs/dimensions'
+import { useSession } from '/hooks/useSession'
 
 const injectedJavaScriptBeforeContentLoaded = () => `
   window.addEventListener('load', (event) => {
@@ -66,6 +67,7 @@ const HomeView = ({ route, navigation, setLauncherContext }) => {
     const getHomeUri = async () => {
       const webLink = generateWebLink({
         cozyUrl: client.getStackClient().uri,
+        hash: 'connected',
         pathname: '/',
         slug: 'home',
         subDomainType: session.subDomainType
@@ -91,6 +93,11 @@ const HomeView = ({ route, navigation, setLauncherContext }) => {
       setTrackedWebviewInnerUri(webviewInneruri)
     }
   }
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', () => resetUIState(uri))
+    return unsubscribe
+  }, [navigation, uri])
 
   return uri ? (
     <CozyWebView

--- a/yarn.lock
+++ b/yarn.lock
@@ -6511,10 +6511,10 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-intent@1.16.1:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-1.16.1.tgz#ec75d4eff6db966998b6881580319134c9aec7bd"
-  integrity sha512-5Gl9a+kYicX1xV4s0P3BdAOwfjgrRvTubRKvT2EVIT7rwK0puPwQDidLFf3bbPtdJAtwjdWh/OHEuQ0HqK1gTw==
+cozy-intent@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.0.1.tgz#6119ab5bd0d4bb1f74af9763ff3ae32fc975aa3c"
+  integrity sha512-gtpC2++M7W74aqYLFF3Sb1H1XXxZrgALOWMhPYfcqC3L4tTXUuxFbCk/LDC/E4+fmFyJ/FldikUsjandrGPXtg==
   dependencies:
     post-me "0.4.5"
 


### PR DESCRIPTION
**Problem**
post-me connections broke when switching from apps to apps because getting URLs from WebView is unstable. Refs are mutable objects with ever-changing values. Handshakes would fail.

**Solution**
Instead of registering/unregistering post-me messengers with the WebView object, we now use primitive string values for URL. It switches the workload to the native app in determining the source URL, but as the app is the one that knows about navigation, it's a lot safer.