### PR TITLE
fix(mailto): intercept clicks on mailto: and tel: to prevent error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ## 🐛 Bug Fixes
 
-* display splash screen during loading steps  ([PR #214](https://github.com/cozy/cozy-pass-mobile/pull/214))
+* Intercept clicks on mailto:, tel:, maps:, geo:, sms: to prevent error  ([PR #180](https://github.com/cozy/cozy-pass-mobile/pull/180) and [PR #213](https://github.com/cozy/cozy-pass-mobile/pull/213))
+* Display splash screen during loading steps  ([PR #214](https://github.com/cozy/cozy-pass-mobile/pull/214))
 
 ## 🔧 Tech
 

--- a/src/components/webviews/CozyWebView.js
+++ b/src/components/webviews/CozyWebView.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useState, useEffect } from 'react'
-import { BackHandler } from 'react-native'
+import { BackHandler, Linking } from 'react-native'
 import { useIsFocused } from '@react-navigation/native'
 
 import Minilog from '@cozy/minilog'
@@ -108,13 +108,26 @@ export const CozyWebView = ({
         uri
       }}
       injectedJavaScriptBeforeContentLoaded={run}
-      originWhitelist={['*']}
+      originWhitelist={['http://*', 'https://*', 'intent://*']}
       useWebKit={true}
       javaScriptEnabled={true}
       ref={ref => setWebviewRef(ref)}
       TEST_ONLY_setRef={setWebviewRef}
       decelerationRate="normal" // https://github.com/react-native-webview/react-native-webview/issues/1070
       onShouldStartLoadWithRequest={initialRequest => {
+        if (
+          initialRequest.url.startsWith('tel:') ||
+          initialRequest.url.startsWith('mailto:') ||
+          initialRequest.url.startsWith('maps:') ||
+          initialRequest.url.startsWith('geo:') ||
+          initialRequest.url.startsWith('sms:')
+        ) {
+          Linking.openURL(initialRequest.url).catch(error => {
+            log.error('Failed to open Link: ' + error.message)
+          })
+          return false
+        }
+
         if (shouldInterceptAuth(initialRequest.url)) {
           const asyncRedirect = async () => {
             const authLink = await handleInterceptAuth(initialRequest.url)


### PR DESCRIPTION
mailto: and tel: links do not work in webview
That is why we intercept them and prevent loading those requests.
https://github.com/react-native-webview/react-native-webview/issues/1084#issuecomment-573434774

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [x] Tested on iOS
* [x] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [x] Updated README & CHANGELOG, if necessary

![Capture d’écran 2022-05-09 à 15 44 03](https://user-images.githubusercontent.com/8363334/167423421-ef1c6002-9b26-4cfa-9567-683e8ee8c24a.png)

