### PR TITLE
fix: Improve padding on custom wrapper class

### DIFF
--- a/src/screens/login/components/assets/common/css/cssTheme.js
+++ b/src/screens/login/components/assets/common/css/cssTheme.js
@@ -1,2 +1,5 @@
 export const themeCss = `
+  .wrapper {
+    padding: 1rem calc(env(safe-area-inset-bottom) + 1rem) 1rem;
+  }
 `


### PR DESCRIPTION
This is mandatory for android devices with no navigation bar.
Also mandatory for iOS phone to make space for navbar.
