### PR TITLE
fix: Use correct route when offline redirect

### DIFF
--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -22,7 +22,7 @@ export const useSession = () => {
       .then(isConnected => {
         if (isConnected) return
 
-        NetService.toggleNetWatcher({ callbackRoute: routes.home })
+        NetService.toggleNetWatcher({ callbackRoute: routes.stack })
         NetService.handleOffline()
         return hideSplashScreen()
       })


### PR DESCRIPTION
When offline and logged, it should redirect to stack and not home route.
Stack will display home by default on a client app.
