### PR TITLE
feat(CCC): Overload previous worker state

### DIFF
--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -84,7 +84,7 @@ class LauncherView extends Component {
     const initConnectorError = await this.initConnector()
 
     this.launcher.on('SET_WORKER_STATE', options => {
-      this.setState({ worker: options })
+      this.setState({ worker: { ...this.state.worker, options } })
     })
 
     this.launcher.on('SET_USER_AGENT', userAgent => {


### PR DESCRIPTION
Instead of crushing it with setWorkerState.

This will allow functions like ContentScript.goto to work without changing the visibility of the worker for example

See https://trello.com/c/vazlMvKA/20-pb-je-veux-pouvoir-rendre-visible-mon-worker-sans-changer-son-url

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

