### PR TITLE
fix: Handle offline Webview more efficiently

### DIFF
--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -39,6 +39,17 @@ const run = `
     })();
   `
 
+const handleError = async webviewErrorEvent => {
+  try {
+    const isOffline = await NetService.isOffline()
+    isOffline && NetService.handleOffline()
+  } catch (error) {
+    log.error(error)
+  } finally {
+    log.error(webviewErrorEvent)
+  }
+}
+
 /**
  * Displays the Cloudery web page where the user can specify their Cozy instance
  *
@@ -60,10 +71,6 @@ export const ClouderyView = ({ setInstanceData }) => {
 
   const handleNavigation = request => {
     const instance = getUriFromRequest(request)
-
-    NetService.isOffline()
-      .then(isOffline => isOffline && NetService.handleOffline())
-      .catch(error => log.error(error))
 
     if (request.loading) {
       if (isLoginPage(request.url) && request.url !== strings.loginUri) {
@@ -123,6 +130,7 @@ export const ClouderyView = ({ setInstanceData }) => {
         style={{
           backgroundColor: colors.primaryColor
         }}
+        onError={handleError}
       />
       {loading && (
         <View


### PR DESCRIPTION
Instead of waiting for a request, just catch all WebView errors,
check if we are offline when the error happened,
if yes, redirect to offline page.
This is much more solid.
I wonder if we should do the same for other views?
