### PR TITLE
feat: bump app version to 0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,33 @@
-# 0.0.10
+# 0.0.11
 
 ## ✨ Features
 
 
 ## 🐛 Bug Fixes
 
-* Intercept clicks on mailto:, tel:, maps:, geo:, sms: to prevent error  ([PR #180](https://github.com/cozy/cozy-pass-mobile/pull/180) and [PR #213](https://github.com/cozy/cozy-pass-mobile/pull/213))
-* Display splash screen during loading steps  ([PR #214](https://github.com/cozy/cozy-pass-mobile/pull/214))
-* Prevent GoBack after logout  ([PR #218](https://github.com/cozy/cozy-pass-mobile/pull/218))
 
 ## 🔧 Tech
 
+
+# 0.0.10
+
+## ✨ Features
+
+* Add a Welcome page ([PR #209](https://github.com/cozy/cozy-pass-mobile/pull/209) and [PR #217](https://github.com/cozy/cozy-pass-mobile/pull/217))
+
+## 🐛 Bug Fixes
+
+* Intercept clicks on mailto:, tel:, maps:, geo:, sms: to prevent error  ([PR #180](https://github.com/cozy/cozy-pass-mobile/pull/180) and [PR #213](https://github.com/cozy/cozy-pass-mobile/pull/213))
+* Improve Post-me stability when browsing between cozy-apps ([PR #212](https://github.com/cozy/cozy-pass-mobile/pull/212))
+* Display splash screen during loading steps  ([PR #214](https://github.com/cozy/cozy-pass-mobile/pull/214))
+* Fix Navbar height calculation ([PR #215](https://github.com/cozy/cozy-pass-mobile/pull/215))
+* Prevent GoBack after logout  ([PR #218](https://github.com/cozy/cozy-pass-mobile/pull/218))
+* Add a safe area on login, onboarding and error screens ([PR #223](https://github.com/cozy/cozy-pass-mobile/pull/223))
+* Redirect to the correct screen when the device retrieves Internet connection ([PR #224](https://github.com/cozy/cozy-pass-mobile/pull/224))
+
+## 🔧 Tech
+
+* Add JSX support in Jest configuration ([PR #210](https://github.com/cozy/cozy-pass-mobile/pull/210))
 
 # 0.0.9
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 901
-        versionName "0.0.9"
+        versionCode 1001
+        versionName "0.0.10"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.9</string>
+	<string>0.0.10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0000901</string>
+	<string>0001002</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.10
- creates a new entry for next 0.0.11 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs