### PR TITLE
feat: Allow on demand Sentry logging

### DIFF
--- a/src/Sentry.js
+++ b/src/Sentry.js
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/react-native'
 import { CaptureConsole } from '@sentry/integrations'
 
+import { EnvService } from '/libs/services/EnvService'
 import { version } from '../package.json'
-import { isBuildMode } from './libs/utils'
 
 // Sentry Data Source Name
 // A DSN tells a Sentry SDK where to send events so the events are associated with the correct project.
@@ -19,12 +19,9 @@ export const SentryTags = {
 // Runtime initialisation.
 Sentry.init({
   dsn: SentryDsn,
-  enabled: isBuildMode(),
-  integrations: [
-    new CaptureConsole({
-      levels: ['error', 'warn']
-    })
-  ]
+  enabled: EnvService.hasSentryEnabled,
+  environment: EnvService.name,
+  integrations: [new CaptureConsole({ levels: ['error', 'warn'] })]
 })
 
 // Runtime default configuration.

--- a/src/config/local.js
+++ b/src/config/local.js
@@ -1,0 +1,4 @@
+export const localConfig = {
+  ignoreLogBox: true,
+  sentry: false
+}

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -1,5 +1,5 @@
 import Minilog from '@cozy/minilog'
-import { Linking } from 'react-native'
+import { Linking, LogBox } from 'react-native'
 import { useEffect, useState } from 'react'
 
 import strings from '../strings.json'
@@ -9,6 +9,9 @@ import { manageIconCache } from '../libs/functions/iconTable'
 import { navigate } from '../libs/RootNavigation'
 import { routes } from '../constants/routes'
 import { useSplashScreen } from './useSplashScreen'
+import { localConfig } from '/config/local'
+
+if (localConfig.ignoreLogBox) LogBox.ignoreAllLogs()
 
 const log = Minilog('useAppBootstrap')
 

--- a/src/hooks/useAppBootstrap.spec.js
+++ b/src/hooks/useAppBootstrap.spec.js
@@ -34,6 +34,9 @@ jest.mock('react-native', () => {
   const listeners = []
 
   return {
+    LogBox: {
+      ignoreAllLogs: jest.fn()
+    },
     Linking: {
       addEventListener: jest.fn((event, handler) => {
         listeners.push({ event, handler })

--- a/src/libs/intents/localMethods.js
+++ b/src/libs/intents/localMethods.js
@@ -5,8 +5,9 @@ import { hideSplashScreen } from '../services/SplashScreenService'
 import { openApp } from '../functions/openApp'
 import { resetSessionToken } from '../functions/session'
 import { setFlagshipUI } from './setFlagshipUI'
-import { isDevMode } from '../utils'
+import { EnvService } from '/libs/services/EnvService'
 import { showInAppBrowser, closeInAppBrowser } from './InAppBrowser'
+import strings from '/strings'
 
 export const asyncLogout = async () => {
   await clearClient()
@@ -56,7 +57,8 @@ export const internalMethods = {
   setFlagshipUI: intent =>
     setFlagshipUI(
       intent,
-      isDevMode() && internalMethods.setFlagshipUI.caller?.name
+      EnvService.nameIs(strings.environments.test) &&
+        internalMethods.setFlagshipUI.caller?.name
     )
 }
 

--- a/src/libs/services/EnvService.js
+++ b/src/libs/services/EnvService.js
@@ -1,0 +1,37 @@
+import strings from '/strings.json'
+import { localConfig } from '/config/local'
+
+let enableSentryOn = [strings.environments.production]
+
+const envNames = {
+  isTest: strings.environments.test,
+  isProduction: strings.environments.production
+}
+
+const envStatus = {
+  isTest: __DEV__,
+  isProduction: !__DEV__
+}
+
+const toggleLocalSentry = (shouldLog = false) =>
+  shouldLog
+    ? (enableSentryOn = [...enableSentryOn, strings.environments.test])
+    : (enableSentryOn = enableSentryOn.filter(
+        environment => environment !== strings.environments.test
+      ))
+
+const name = envNames[Object.entries(envStatus).find(value => value[1])[0]]
+
+const nameIs = envName => envName === name
+
+if (localConfig.sentry) toggleLocalSentry(true)
+
+const hasSentryEnabled = enableSentryOn.some(
+  environment => environment === name
+)
+
+export const EnvService = {
+  name,
+  nameIs,
+  hasSentryEnabled
+}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -22,13 +22,3 @@ export const dataURItoArrayBuffer = dataURI => {
   }
   return { contentType, arrayBuffer }
 }
-
-export const isDevMode = () => {
-  try {
-    return !!__DEV__
-  } catch {
-    return false
-  }
-}
-
-export const isBuildMode = () => !isDevMode()

--- a/src/strings.json
+++ b/src/strings.json
@@ -9,6 +9,10 @@
   "authLogin": "/auth/login?redirect=",
   "defaultHttpScheme": "https://",
   "emptyString": "",
+  "environments": {
+    "production": "production",
+    "test": "test"
+  },
   "errorAppendParamsFail": "Could not handle url, it is neither a valid URL string nor a string",
   "errorScreens": {
     "cozyNotFound": "cozyNotFound",


### PR DESCRIPTION
# Description

This pull request will allow a manual toggle to send Logs to Sentry even in local env.
It is disabled by default and can be activated by modifying the `sentry` value in `local.js` config file.

Also, LogBox was disabled by default and can be activated in the same file.

Addresses no ticket.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

This has been tested in local environment, sending tickets to Sentry in `test` tag (maybe the name could be better, it's a bit confusing between test/local/dev): https://errors.cozycloud.cc/organizations/cozycloud/issues/?environment=test&project=17

- [x] Sends logs in local mode when activated
- [x] Does not send logs in local mode when not activated

**Test Configuration**:
* PC OS: WIN10/WSL(Ubuntu 20)
* Web Browser: Edge
* Phone OS: Android 8
* Phone Browser: Samsung

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have improved existing tests to take into account my feature
- [ ] I have added tests that prove my fix is effective or that my feature works