### PR TITLE
fix: Improve Dimensions API for iOS

### DIFF
--- a/src/libs/dimensions.js
+++ b/src/libs/dimensions.js
@@ -1,25 +1,30 @@
-import { Dimensions } from 'react-native'
+import { Dimensions, Platform } from 'react-native'
 import { getStatusBarHeight } from 'react-native-status-bar-height'
 import { getNavigationBarHeight } from 'react-native-android-navbar-height'
 import Minilog from '@cozy/minilog'
 
-const getNavbarHeight = () => navbarHeight
 let navbarHeight = 0
 
-try {
-  ;(async () => {
-    navbarHeight =
-      (await getNavigationBarHeight()) / Dimensions.get('screen').scale
-  })()
-} catch (error) {
-  Minilog('dimensions.js').error(
-    'Failed to compute NavbarHeight, defaulting to 0',
-    error
-  )
+const getNavbarHeight = () => navbarHeight
+const statusBarHeight = getStatusBarHeight()
+const {
+  scale,
+  height: screenHeight,
+  width: screenWidth
+} = Dimensions.get('screen')
+
+const init = async () => {
+  try {
+    if (Platform.OS !== 'android') return
+    navbarHeight = (await getNavigationBarHeight()) / scale
+  } catch (error) {
+    Minilog('libs/dimensions').warn(
+      `Failed to compute NavbarHeight, keeping default value: ${navbarHeight}. Please refer to the error below.\n`,
+      error
+    )
+  }
 }
 
-const screenHeight = Dimensions.get('screen').height
-const screenWidth = Dimensions.get('screen').width
-const statusBarHeight = getStatusBarHeight()
+init()
 
 export { getNavbarHeight, screenHeight, screenWidth, statusBarHeight }


### PR DESCRIPTION
# Description

Previously, iOS users were triggering a caught exception every time they used the app because a non-available API was used.

Addresses this [Sentry ticket](https://errors.cozycloud.cc/organizations/cozycloud/issues/6917/)

## Type of change

The fix was to limit the use of this API only on Android systems, that way Sentry is not spammed with noise.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

This was not tested on iOS because I do not have one. But all was working well in the local environment. 

- [ ] Using the application on iOS should not trigger the `getNavigationBarHeight is not a function` error
- [x] No regression seen on Android

**Test Configuration**:
* PC OS: WIN10/WSL(Ubuntu 20)
* Web Browser: Edge
* Phone OS: Android 8
* Phone Browser: Samsung

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
