### PR TITLE
fix: Handle CozyUrl when it contains whitespaces

### DIFF
--- a/src/libs/functions/compose.js
+++ b/src/libs/functions/compose.js
@@ -1,0 +1,4 @@
+export const compose =
+  (...fns) =>
+  x =>
+    fns.reduce((acc, fn) => fn(acc), x)

--- a/src/libs/functions/compose.spec.js
+++ b/src/libs/functions/compose.spec.js
@@ -1,0 +1,9 @@
+import { compose } from './compose'
+
+it('composes functions', () => {
+  const funcA = arg => arg + arg
+  const funcB = arg => arg * arg
+  const funcC = arg => arg ** arg
+
+  expect(compose(funcA, funcB, funcC)(1)).toBe(256)
+})

--- a/src/libs/functions/getUriFromRequest.js
+++ b/src/libs/functions/getUriFromRequest.js
@@ -1,10 +1,13 @@
 import strings from '../../strings.json'
+import { compose } from './compose'
 
 const abort = 'https://urlwithnofqdn'
 
 // We don't want to throw so if there is no request with url provided, we just pass an invalid url
 export const validateRequest = request =>
   !request ? abort : !request.url ? abort : request.url
+
+const trimWhitespaces = string => string?.replace(/\s/g, '')
 
 const validateFqdn = fqdn => fqdn || null
 
@@ -23,5 +26,11 @@ const handleProtocol = url => {
   }
 }
 
-export const getUriFromRequest = request =>
-  handleProtocol(validateFqdn(getFqdn(validateRequest(request))))
+export const getUriFromRequest = req =>
+  compose(
+    validateRequest,
+    getFqdn,
+    validateFqdn,
+    trimWhitespaces,
+    handleProtocol
+  )(req)

--- a/src/libs/functions/getUriFromRequest.spec.js
+++ b/src/libs/functions/getUriFromRequest.spec.js
@@ -10,6 +10,12 @@ test('it returns an url with the correct scheme if none provided', () => {
   )
 })
 
+test('it returns a trimmed url if a whitespace url is provided', () => {
+  expect(
+    getUriFromRequest({ url: 'https://cozydrive?fqdn=fo++o.b+++ar.ba+++z+' })
+  ).toBe('https://foo.bar.baz/')
+})
+
 test('it returns an url with the correct scheme if provided', () => {
   expect(
     getUriFromRequest({ url: 'https://cozydrive?fqdn=http://foo.bar.baz' })


### PR DESCRIPTION
# Description

The Nuagerie encodes the whitespaces in '+signs'.
So to handle that, we remove the + signs from the fqdn.
And replace them with nothing. This fixes the issue.
Unit test added.

Addresses this [Trello ticket](https://trello.com/c/KpQAg6Bq/453-%F0%9F%90%9B-un-espace-dans-lurl-du-cozy-au-login-fait-planter-lapp)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Even URLs like `f oo o o ba arr bazzz` will be concatenated correctly.

- [x] Unit test
- [x] Manual test

**Test Configuration**:
* PC OS: WIN10/WSL(Ubuntu 20)
* Web Browser: Edge
* Phone OS: Android 8
* Phone Browser: Samsung

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
