### PR TITLE
Fix/allow unsecure http on android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:usesCleartextTraffic="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"


### PR DESCRIPTION
As we now use a local HttpServer that serves on unsecure
`http://localhost` then we need to allow unsecure HTTP queries on
Android configuration

This configuration is needed for Android 9 and newer

More info: https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic