### PR TITLE
feat: bump app version to 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.13
+# 0.0.14
 
 ## ✨ Features
 
@@ -8,6 +8,21 @@
 
 ## 🔧 Tech
 
+
+# 0.0.13
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+* Allow unsecure HTTP on Android in order to serve local assets ([PR #253](https://github.com/cozy/cozy-react-native/pull/253))
+
+## 🔧 Tech
+
+* Improve Client Side Connectors template ([PR #236](https://github.com/cozy/cozy-react-native/pull/236))
+* Implement HttpServer to serve local assets for all cozy-apps ([PR #255](https://github.com/cozy/cozy-react-native/pull/255)
+* Improve error handling when downloading local assets ([PR #256](https://github.com/cozy/cozy-react-native/pull/256)
 
 # 0.0.12
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1201
-        versionName "0.0.12"
+        versionCode 1301
+        versionName "0.0.13"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.12</string>
+	<string>0.0.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0001201</string>
+	<string>0001301</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.13
- creates a new entry for next 0.0.14 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs