### PR TITLE
fix: Do not try to set initialRoute before client is loaded

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -116,17 +116,17 @@ const App = ({ setClient }) => {
 
 const WrappedApp = () => {
   const colors = getColors()
-  const [client, setClient] = useState(null)
+  const [client, setClient] = useState(undefined)
 
-  // Handling client init
   useEffect(() => {
     const handleClientInit = async () => {
       try {
-        setClient((await getClient()) || undefined)
+        setClient((await getClient()) || null)
       } catch {
-        setClient(undefined)
+        setClient(null)
       }
     }
+
     handleClientInit()
   }, [])
 
@@ -151,13 +151,16 @@ const WrappedApp = () => {
     </NavigationContainer>
   )
 
-  return client ? (
-    <CozyProvider client={client}>
-      <Nav />
-    </CozyProvider>
-  ) : (
-    <Nav />
-  )
+  if (client === null) return <Nav />
+
+  if (client)
+    return (
+      <CozyProvider client={client}>
+        <Nav />
+      </CozyProvider>
+    )
+
+  return null
 }
 
 const Wrapper = () => {

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -150,7 +150,7 @@ export const useAppBootstrap = client => {
     }
 
     initialRoute === 'fetching' && initialScreen === 'fetching' && doAsync()
-  }, [initialRoute, initialScreen, client, hideSplashScreen])
+  }, [client, initialRoute, initialScreen, hideSplashScreen])
 
   // Handling app readiness
   useEffect(() => {


### PR DESCRIPTION
Removing check about client nullity would trigger the hook too early
and the consequence is to have incorrect screen briefly appearing and
splashscreen to disappear too early

Related commit: 81f881b5bde4dfec6c1235a83a5f2dc99ce1fa9a

___

> **Warning**
> This PR is a revert from [fix: Update appBoostrap after client changes](https://github.com/cozy/cozy-react-native/commit/81f881b5bde4dfec6c1235a83a5f2dc99ce1fa9a)
> Before merging this we should investigate why this initial commit was needed (I don't experience the described bug with the revert)
> Note that this seems to be the expected behaviour as client is first initialised to `null`, then when we succeeded or failed to load the client it is edited with the retrieved value, or `undefined` otherwise.