### PR TITLE
wip: Add manifest content in fetch parameters

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -84,7 +84,7 @@ class ReactNativeLauncher extends Launcher {
       this.setUserData(await this.pilot.call('getUserDataFromWebsite'))
       await this.ensureAccountNameAndFolder()
 
-      const pilotContext = []
+      const pilotContext = { manifest: this.getStartContext().manifest }
       // FIXME not used at the moment since the fetched file will not have the proper "createdByApp"
       // const pilotContext = await this.getPilotContext({
       //   sourceAccountIdentifier: userData.sourceAccountIdentifier,


### PR DESCRIPTION
Now the ccc content script can get the connector manifest content as fetch() parameter
