### PR TITLE
fix: Reapply home cookie on focus

### DIFF
--- a/src/libs/httpserver/httpCookieManager.js
+++ b/src/libs/httpserver/httpCookieManager.js
@@ -57,6 +57,8 @@ const parseCookie = cookieString => {
   }
 }
 
+export let setHomeCookie
+
 /**
  * Set the cookie into the device by using CookieManager
  *
@@ -72,7 +74,7 @@ const parseCookie = cookieString => {
  * @param {CozyClient} client - CozyClient instance
  * @returns {Promise<boolean>}
  */
-export const setCookie = async (cookieString, client) => {
+export const setCookie = async (cookieString, client, slug) => {
   const cookie = parseCookie(cookieString)
 
   const appUrl = client.getStackClient().uri
@@ -87,6 +89,10 @@ export const setCookie = async (cookieString, client) => {
     secure: isSecure,
     httpOnly: cookie.httpOnly,
     sameSite: 'None' // This must be force to 'None' so iOS accepts to send it through "html injected" webview
+  }
+
+  if (slug === 'home') {
+    setHomeCookie = () => CookieManager.set(appUrl, stackCookie, true)
   }
 
   return CookieManager.set(appUrl, stackCookie, true)

--- a/src/libs/httpserver/httpServerProvider.js
+++ b/src/libs/httpserver/httpServerProvider.js
@@ -77,7 +77,7 @@ export const HttpServerProvider = props => {
 
     const { cookie, templateValues } = await fetchAppDataForSlug(slug, client)
 
-    await setCookie(cookie, client)
+    await setCookie(cookie, client, slug)
     const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug)
 
     if (!rawHtml) {

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -9,6 +9,7 @@ import { consumeRouteParameter } from '/libs/functions/routeHelpers'
 import { resetUIState } from '/libs/intents/setFlagshipUI'
 import { statusBarHeight, getNavbarHeight } from '/libs/dimensions'
 import { useSession } from '/hooks/useSession'
+import { setHomeCookie } from '/libs/httpserver/httpCookieManager'
 
 const injectedJavaScriptBeforeContentLoaded = () => `
   window.addEventListener('load', (event) => {
@@ -35,6 +36,8 @@ const HomeView = ({ route, navigation, setLauncherContext }) => {
   useEffect(() => {
     const unsubscribe = navigation.addListener('focus', () => {
       nativeIntent?.call(uri, 'closeApp')
+
+      setHomeCookie?.()
 
       if (uri) {
         const konnectorParam = consumeRouteParameter(


### PR DESCRIPTION
# Description

The homepage loses its cookie when going to other apps because it is overwritten and never written again. This is a simple fix here to call a cookie setter when the homepage gains focus again. It might be brittle and should be better implemented

Addresses this [Trello ticket](https://trello.com/c/K7pho4X6/458-%F0%9F%90%9B-r%C3%A9gression-0012-erreur-dans-la-modale-des-connecteurs)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually

- [x] Open home, open drive, go back home, open connector => works

**Test Configuration**:
* PC OS: WIN10/WSL(Ubuntu 20)
* Phone OS: Android 11

# Checklist:

- [x] I have performed a self-review of my code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
