### PR TITLE
fix: Fix typo in flags formatting

### DIFF
--- a/src/libs/httpserver/indexDataFetcher.js
+++ b/src/libs/httpserver/indexDataFetcher.js
@@ -26,7 +26,7 @@ export const fetchAppDataForSlug = async (slug, client) => {
 
   let cozyDataString = JSON.stringify(cozyData)
   cozyDataString = replaceAll(cozyDataString, '"', '&#34;')
-  cozyDataAttributes.Flags = cozyDataAttributes.Flags.replaceAll('"', '&#34;')
+  cozyDataAttributes.Flags = replaceAll(cozyDataAttributes.Flags, '"', '&#34;')
 
   return {
     cookie,


### PR DESCRIPTION
# Description

For some reason, the unit test didn't detect a breaking typo. ReplaceAll is not a string method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit test
- [x] Live app

**Test Configuration**:
* PC OS: WIN10/WSL(Ubuntu 20)
* Phone OS: Android 11

# Checklist:

- [x] I have performed a self-review of my code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
