### PR TITLE
fix: Accept Camera Usage

### DIFF
--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -78,6 +78,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Afin de prendre des photos pour Drive ou MesPapiers afin d&apos;importer des documents</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
In order to get access to input file from the HTML to the
Camera we need to add the permission to the plist file.

To do later: Handle i18n on this file.
