### PR TITLE
fix: Konnector's WebView Media behavior

### DIFF
--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -128,6 +128,7 @@ class LauncherView extends Component {
           <>
             <View>
               <WebView
+                mediaPlaybackRequiresUserAction={true}
                 ref={ref => (this.pilotWebView = ref)}
                 originWhitelist={['*']}
                 source={{
@@ -159,6 +160,7 @@ class LauncherView extends Component {
                 </TouchableOpacity>
               </View>
               <WebView
+                mediaPlaybackRequiresUserAction={true}
                 ref={ref => (this.workerWebview = ref)}
                 originWhitelist={['*']}
                 useWebKit={true}


### PR DESCRIPTION
On Android, by default, the webview will require
an user itereaction to play a video with the
autoplay attribute.

By default, on iOS, the webview will play the
"autoplay" video. Even if the fullscreen mode
is true.

It resulted that, when we run the hidden content
script, sometimes video has been played in
fullscreen.

By requesting the user interaction on the media
we avoid this issue and save bandwidth to the user.


(React Native Webview issue: https://github.com/react-native-webview/react-native-webview/issues/2369) 