### PR TITLE
fix: Handle 2FA through 401 and 403 errors

### DIFF
--- a/src/libs/clientHelpers/loginFlagship.js
+++ b/src/libs/clientHelpers/loginFlagship.js
@@ -31,14 +31,18 @@ export const loginFlagship = async ({
     return loginResult
   } catch (e) {
     if (e.status === 401) {
-      if (twoFactorAuthenticationData) {
+      if (e?.reason?.two_factor_token) {
         return {
-          two_factor_token: twoFactorAuthenticationData.token
+          two_factor_token: e.reason.two_factor_token
         }
       } else {
         return {
           invalidPassword: true
         }
+      }
+    } else if (e.status === 403 && twoFactorAuthenticationData) {
+      return {
+        two_factor_token: twoFactorAuthenticationData.token
       }
     } else {
       throw e

--- a/src/libs/clientHelpers/loginFlagship.spec.js
+++ b/src/libs/clientHelpers/loginFlagship.spec.js
@@ -84,7 +84,31 @@ describe('Client', () => {
       expect(result).toStrictEqual({ invalidPassword: true })
     })
 
-    it('should handle 401 result and correlate two_factor_token when 2FA is provided', async () => {
+    it('should handle 401 result and correlate two_factor_token when no 2FA is provided but reason is filled with two_factor_token', async () => {
+      const loginData = {
+        passwordHash: 'SOME_PASSWORD_HASH'
+      }
+
+      stackClient.loginFlagship.mockImplementation(() => {
+        const error = new Error()
+        error.status = 401
+        error.reason = {
+          two_factor_token: 'SOME_2FA_TOKEN'
+        }
+
+        throw error
+      })
+
+      const result = await loginFlagship({
+        client,
+        loginData,
+        undefined
+      })
+
+      expect(result).toStrictEqual({ two_factor_token: 'SOME_2FA_TOKEN' })
+    })
+
+    it('should handle 403 result and correlate two_factor_token when 2FA is provided', async () => {
       const loginData = {
         passwordHash: 'SOME_PASSWORD_HASH'
       }
@@ -96,7 +120,7 @@ describe('Client', () => {
 
       stackClient.loginFlagship.mockImplementation(() => {
         const error = new Error()
-        error.status = 401
+        error.status = 403
 
         throw error
       })


### PR DESCRIPTION
Previous cozy-stack implementation used a `202` result to ask for 2FA
authentication

Now it uses a `401` error for this scenario when login with only
password, and a `403` error when entering the wrong 2FA code
