### PR TITLE
feat: Add new dev setting for dev cozy-apps

### DIFF
--- a/src/config/local.js
+++ b/src/config/local.js
@@ -1,4 +1,5 @@
 export const localConfig = {
-  ignoreLogBox: true,
-  sentry: false
+  disableGetIndex: false, // Make cozy-app hosted by webpack-dev-server work with HTTPServer
+  ignoreLogBox: true, // Hide react-native logbox renders in development mode
+  sentry: false // Allow Sentry logging in development mode
 }

--- a/src/libs/httpserver/indexGenerator.js
+++ b/src/libs/httpserver/indexGenerator.js
@@ -12,6 +12,7 @@ import {
   setCurrentAppVersionForFqdnAndSlug
 } from '../cozyAppBundle/cozyAppBundleConfiguration'
 import { replaceAll } from '../functions/stringHelpers'
+import { localConfig } from '/config/local'
 
 const log = Minilog('IndexGenerator')
 
@@ -44,6 +45,8 @@ const initLocalBundleIfNotExist = async (fqdn, slug) => {
 }
 
 export const getIndexForFqdnAndSlug = async (fqdn, slug) => {
+  if (localConfig.disableGetIndex) return false // Make cozy-app hosted by webpack-dev-server work with HTTPServer
+
   await initLocalBundleIfNotExist(fqdn, slug)
 
   const appConfiguration = await getCurrentAppConfigurationForFqdnAndSlug(


### PR DESCRIPTION
For 'yarn start' cozy-apps, the simplest way is to return false
in the getIndexForFqdnAndSlug() function. So let's add a setting
in the dev config file to handle it easily.