### PR TITLE
feat: Improve openApp animation

### DIFF
--- a/src/components/Bar.js
+++ b/src/components/Bar.js
@@ -1,0 +1,183 @@
+// This was taken from https://github.com/oblador/react-native-progress because hacks were needed
+// At this time the fastest was just to copy the file, it has no dependencies
+
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { Animated, Easing, View, I18nManager } from 'react-native'
+
+const INDETERMINATE_WIDTH_FACTOR = 0.6 // 0.3 to 0.6
+const BAR_WIDTH_ZERO_POSITION =
+  INDETERMINATE_WIDTH_FACTOR / (1 + INDETERMINATE_WIDTH_FACTOR)
+
+export default class ProgressBar extends Component {
+  static propTypes = {
+    animated: PropTypes.bool,
+    borderColor: PropTypes.string,
+    borderRadius: PropTypes.number,
+    borderWidth: PropTypes.number,
+    children: PropTypes.node,
+    color: PropTypes.string,
+    height: PropTypes.number,
+    indeterminate: PropTypes.bool,
+    indeterminateAnimationDuration: PropTypes.number,
+    onLayout: PropTypes.func,
+    progress: PropTypes.number,
+    style: PropTypes.any,
+    unfilledColor: PropTypes.string,
+    width: PropTypes.number,
+    useNativeDriver: PropTypes.bool,
+    animationConfig: PropTypes.object,
+    animationType: PropTypes.oneOf(['decay', 'timing', 'spring'])
+  }
+
+  static defaultProps = {
+    animated: true,
+    borderRadius: 4,
+    borderWidth: 1,
+    color: 'rgba(0, 122, 255, 1)',
+    height: 6,
+    indeterminate: false,
+    indeterminateAnimationDuration: 1000,
+    progress: 0,
+    width: 150,
+    useNativeDriver: false,
+    animationConfig: { bounciness: 0 },
+    animationType: 'spring'
+  }
+
+  constructor(props) {
+    super(props)
+    const progress = Math.min(Math.max(props.progress, 0), 1)
+    this.state = {
+      width: 0,
+      progress: new Animated.Value(
+        props.indeterminate ? INDETERMINATE_WIDTH_FACTOR : progress
+      ),
+      animationValue: new Animated.Value(BAR_WIDTH_ZERO_POSITION)
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.indeterminate) {
+      this.animate()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.indeterminate !== this.props.indeterminate) {
+      if (this.props.indeterminate) {
+        this.animate()
+      } else {
+        Animated.spring(this.state.animationValue, {
+          toValue: BAR_WIDTH_ZERO_POSITION,
+          useNativeDriver: this.props.useNativeDriver
+        }).start()
+      }
+    }
+    if (
+      prevProps.indeterminate !== this.props.indeterminate ||
+      prevProps.progress !== this.props.progress
+    ) {
+      const progress = this.props.indeterminate
+        ? INDETERMINATE_WIDTH_FACTOR
+        : Math.min(Math.max(this.props.progress, 0), 1)
+
+      if (this.props.animated) {
+        const { animationType, animationConfig } = this.props
+        Animated[animationType](this.state.progress, {
+          ...animationConfig,
+          toValue: progress,
+          useNativeDriver: this.props.useNativeDriver
+        }).start()
+      } else {
+        this.state.progress.setValue(progress)
+      }
+    }
+  }
+
+  handleLayout = event => {
+    if (!this.props.width) {
+      this.setState({ width: event.nativeEvent.layout.width })
+    }
+    if (this.props.onLayout) {
+      this.props.onLayout(event)
+    }
+  }
+
+  animate() {
+    this.state.animationValue.setValue(0)
+    Animated.timing(this.state.animationValue, {
+      toValue: 1,
+      duration: this.props.indeterminateAnimationDuration,
+      easing: Easing.linear,
+      isInteraction: false,
+      useNativeDriver: this.props.useNativeDriver
+    }).start(endState => {
+      if (endState.finished) {
+        this.animate()
+      }
+    })
+  }
+
+  render() {
+    const {
+      borderColor,
+      borderRadius,
+      borderWidth,
+      children,
+      color,
+      height,
+      style,
+      unfilledColor,
+      width,
+      ...restProps
+    } = this.props
+
+    const innerWidth = Math.max(0, width || this.state.width) - borderWidth * 2
+    const containerStyle = {
+      width,
+      borderWidth,
+      borderColor: borderColor || color,
+      borderRadius,
+      overflow: 'hidden',
+      backgroundColor: unfilledColor
+    }
+    const progressStyle = {
+      backgroundColor: color,
+      borderRadius: 100, // Added
+      height,
+      transform: [
+        {
+          translateX: this.state.animationValue.interpolate({
+            inputRange: [0, 1],
+            outputRange: [innerWidth * -INDETERMINATE_WIDTH_FACTOR, innerWidth]
+          })
+        },
+        {
+          translateX: this.state.progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [innerWidth / (I18nManager.isRTL ? 2 : -2), 0]
+          })
+        },
+        {
+          // Interpolation a temp workaround for https://github.com/facebook/react-native/issues/6278
+          scaleX: this.state.progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0.0001, 1]
+          })
+        }
+      ]
+    }
+
+    return (
+      <View
+        style={[containerStyle, style]}
+        onLayout={this.handleLayout}
+        {...restProps}
+      >
+        <Animated.View style={progressStyle} />
+        {children}
+      </View>
+    )
+  }
+}

--- a/src/components/webviews/CozyWebView.js
+++ b/src/components/webviews/CozyWebView.js
@@ -158,10 +158,12 @@ export const CozyWebView = ({
           return true
         }
       }}
-      onLoad={({ nativeEvent }) => {
+      onLoad={event => {
         if (trackWebviewInnerUri) {
-          trackWebviewInnerUri(nativeEvent.url)
+          trackWebviewInnerUri(event.nativeEvent.url)
         }
+
+        rest.onLoad?.(event)
       }}
       onMessage={async m => {
         tryCrypto(m, log, logId, onAnswer)

--- a/src/screens/cozy-app/CozyAppScreen.js
+++ b/src/screens/cozy-app/CozyAppScreen.js
@@ -31,6 +31,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
   } = UIState
   const [isReady, setReady] = useState(false)
   const [isFirstHalf, setFirstHalf] = useState(false)
+  const [shouldExitAnimation, setShouldExitAnimation] = useState(false)
 
   useEffect(() => {
     flagshipUI.on('change', state => {
@@ -72,6 +73,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
           <Animation
             onFirstHalf={setFirstHalf}
             onFinished={setReady}
+            shouldExit={shouldExitAnimation}
             params={route.params.iconParams}
             slug={route.params.slug}
           />
@@ -84,6 +86,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
           navigation={navigation}
           route={route}
           logId="AppScreen"
+          onLoadEnd={() => setShouldExit(true)}
         />
       </View>
 

--- a/src/screens/cozy-app/CozyAppScreen.styles.js
+++ b/src/screens/cozy-app/CozyAppScreen.styles.js
@@ -34,5 +34,9 @@ export const styles = StyleSheet.create({
     flex: 1, // Allows full height for loading animation
     opacity: 1
   },
-  immersiveHeight: 0
+  immersiveHeight: 0,
+  progressBarContainer: {
+    width: '60%',
+    display: 'flex'
+  }
 })


### PR DESCRIPTION
On webapp load, trigger the second half of the openApp Animation

Copy-pasted a 3rd party lib for it to work.
Could not customise it from outside

https://user-images.githubusercontent.com/12577784/174832652-b4cfdd2f-7743-46dc-a9cc-170a80b13fed.mp4

