### PR TITLE
fix: Unzoom homepage when backing from Pass

### DIFF
--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -10,6 +10,7 @@ import { consumeRouteParameter } from '/libs/functions/routeHelpers'
 import { resetUIState } from '/libs/intents/setFlagshipUI'
 import { statusBarHeight, getNavbarHeight } from '/libs/dimensions'
 import { useSession } from '/hooks/useSession'
+import { AppState } from 'react-native'
 
 const injectedJavaScriptBeforeContentLoaded = () => `
   window.addEventListener('load', (event) => {
@@ -25,6 +26,16 @@ const HomeView = ({ route, navigation, setLauncherContext }) => {
   const nativeIntent = useNativeIntent()
   const session = useSession()
   const didBlurOnce = useRef(false)
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener(
+      'change',
+      nextAppState =>
+        nextAppState === 'active' && nativeIntent?.call(uri, 'closeApp')
+    )
+
+    return () => subscription.remove()
+  }, [nativeIntent, uri])
 
   useEffect(() => {
     const unsubscribe = navigation.addListener('blur', () => {


### PR DESCRIPTION
Just adding a listener to AppState and calling post-me if needed
We don't need to unsubscribe for the listener for now,
as homepage will always be rendered.
Unmounting home means leaving the app.

On that note I think HomeView needs some refactoring.
All these hooks are making the component look far too complex.

I support splitting all that in two files: view and view management
