### PR TITLE
fix(screen-orientation): prevent screen orientation to use landscape mode (iOS)

### DIFF
--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -60,6 +60,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Afin de prendre des photos pour Drive ou MesPapiers afin d'importer des documents</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>UIAppFonts</key>
@@ -75,11 +77,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string>Afin de prendre des photos pour Drive ou MesPapiers afin d&apos;importer des documents</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
Only allowing Portrait:
<img width="463" alt="Capture d’écran 2022-06-23 à 11 32 31" src="https://user-images.githubusercontent.com/8363334/175267332-4b6f4e2a-0ed3-4a8e-99b8-8a22984aeb51.png">

<img width="797" alt="Capture d’écran 2022-06-23 à 11 28 20" src="https://user-images.githubusercontent.com/8363334/175266833-2a77cb6e-309e-4eb9-b4df-1d8a43365707.png">
<img width="403" alt="Capture d’écran 2022-06-23 à 11 28 28" src="https://user-images.githubusercontent.com/8363334/175266821-39dc253f-cbec-4ca5-8b66-28b03f2fc41a.png">


#### Checklist

* [x] Faithful integration of the mockups at all screen sizes
* [x] Tested on iOS
* [x] Updated README & CHANGELOG, if necessary
