### PR TITLE
feat: Add cache control on HttpServer responses

### DIFF
--- a/android/app/src/main/java/io/cozy/flagship/mobile/httpserver/HttpServer.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/httpserver/HttpServer.java
@@ -27,6 +27,7 @@ public class HttpServer extends CozySimpleWebServer
   private static final String LOGTAG = "WebServer";
 
   private static final int SECURITY_KEY_LENGTH = 22;
+  private static final int CACHE_1_YEAR = 31536000;
   private String securityKey;
 
   public HttpServer(String localAddr, int port, File wwwroot) throws IOException {
@@ -61,7 +62,9 @@ public class HttpServer extends CozySimpleWebServer
 
       String filePath = urlParts.ResourcePath;
 
-      return super.respond(Collections.unmodifiableMap(header), session, filePath);
+      Response response = super.respond(Collections.unmodifiableMap(header), session, filePath);
+      response.addHeader("Cache-Control", "max-age=" + CACHE_1_YEAR + ", public, immutable");
+      return response;
     } catch (Exception e) {
       Log.e(LOGTAG, e.getMessage());
       return newFixedLengthResponse(Response.Status.BAD_REQUEST, NanoHTTPD.MIME_HTML, e.getMessage());

--- a/ios/HttpServer/HttpServer.swift
+++ b/ios/HttpServer/HttpServer.swift
@@ -78,7 +78,7 @@ class HttpServer: NSObject {
     let basePath = "/"
     let directoryPath = self.www_root
     let indexFilename = "index.html"
-    let cacheAge: UInt = 0
+    let cache1Year: UInt = 31536000
     let allowRangeRequests = true
 
     webServer.addHandler { requestMethod, requestURL, requestHeaders, urlPath, urlQuery in
@@ -125,7 +125,7 @@ class HttpServer: NSObject {
         }
 
         if (response != nil) {
-          response?.cacheControlMaxAge = cacheAge
+          response?.cacheControlMaxAge = cache1Year
           response?.setValue("GET", forAdditionalHeader: "Access-Control-Request-Method")
           response?.setValue("OriginX-Requested-With, Content-Type, Accept, Cache-Control, Range,Access-Control-Allow-Origin", forAdditionalHeader: "Access-Control-Request-Headers")
           response?.setValue("*", forAdditionalHeader: "Access-Control-Allow-Origin")


### PR DESCRIPTION
As HttpServer returns files from local assets and with unique IDs we
can consider that those are immutable and we can set cache-control on
them