### PR TITLE
fix: Handle tar_prefix when downloading cozy-app bundles

### DIFF
--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -364,3 +364,20 @@ export const fetchCozyAppVersion = async (slug, client) => {
 
   return version
 }
+
+export const fetchCozyAppArchiveInfoForVersion = async (
+  slug,
+  version,
+  client
+) => {
+  const stackClient = client.getStackClient()
+
+  const { tar_prefix: tarPrefix = '' } = await stackClient.fetchJSON(
+    'GET',
+    `/registry/${slug}/${version}`
+  )
+
+  return {
+    tarPrefix
+  }
+}


### PR DESCRIPTION
When downloading cozy-app bundle from `apps/:slug/download/:version`,
sometimes the cozy-app assets are stored directly in the archive's
root, but sometimes they are stored in a subfolder

To handle that, the registry uses the `tar_prefix` attribute

This attribute defines the subfolder's relative path where the cozy-app
assets are stored

So we want to apply this subfolder into the `folder` attribute from
`cozyAppBundleConfiguration`