### PR TITLE
fix: Correctly declare intent schemes to prevent conflicts

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,11 @@
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
           <data android:scheme="cozy" />
+        </intent-filter>
+        <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
           <data android:scheme="https"
             android:host="links.mycozy.cloud"
             android:pathPrefix="/flagship" />


### PR DESCRIPTION
When including multiple data into the same intent-filter, their rules
are merged and combined

In our case the merge would allow `https://links.mycozy.cloud/flagship`
and `cozy://flagship` to open the app but would prevent `cozy://` or
any other form that do not contains the `/flagship` path prefix to open
the app

To fix this we can split those data elements into two separate
intent-filters

With this form, the two rules would be applied with an `OR` instead of
being merged as a single rule

More info:
https://developer.android.com/training/app-links/deep-linking#adding-filters

