### PR TITLE
fix: Onboarding android link

### DIFF
--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -53,7 +53,9 @@ const handleError = async webviewErrorEvent => {
  * @returns {import('react').ComponentClass}
  */
 export const ClouderyView = ({ setInstanceData }) => {
-  const [uri] = useState(strings.clouderyUri)
+  const [uri] = useState(
+    Platform.OS === 'ios' ? strings.clouderyiOSUri : strings.clouderyAndroidUri
+  )
   const [loading, setLoading] = useState(true)
   const [checkInstanceData, setCheckInstanceData] = useState()
   const webviewRef = useRef()

--- a/src/strings.json
+++ b/src/strings.json
@@ -9,7 +9,8 @@
   "SESSION_CREATED_FLAG": "SESSION_CREATED_FLAG",
   "appTouched": "appTouched",
   "authLogin": "/auth/login?redirect=",
-  "clouderyUri": "https://staging-manager.cozycloud.cc/v2/cozy/start?redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3F%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "clouderyiOSUri": "https://staging-manager.cozycloud.cc/v2/cozy/start?redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3F%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "clouderyAndroidUri": "https://staging-manager.cozycloud.cc/v2/cozy/start?redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
   "defaultHttpScheme": "https://",
   "emptyString": "",
   "environments": {


### PR DESCRIPTION
UniversalLinks are not working on Android
when used during a 302 redirection.

So let's use a custom schema to handle that
on Android since it works pretty well.
