### PR TITLE
feat: bump app version to 0.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.0.18
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+
+## 🔧 Tech
+
+
 # 0.0.17
 
 ## ✨ Features
@@ -5,6 +16,7 @@
 
 ## 🐛 Bug Fixes
 
+* Prevent UI flickering in cozy-home by injecting CSS in the WebView ([PR #318](https://github.com/cozy/cozy-react-native/pull/318))
 
 ## 🔧 Tech
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1601
-        versionName "0.0.16"
+        versionCode 1701
+        versionName "0.0.17"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.16</string>
+	<string>0.0.17</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0001601</string>
+	<string>0001701</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.17
- creates a new entry for next 0.0.18 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs