### PR TITLE
fix: Inject body css classnames before load

### DIFF
--- a/src/components/webviews/jsInteractions/jsCozyInjection.js
+++ b/src/components/webviews/jsInteractions/jsCozyInjection.js
@@ -22,17 +22,4 @@ export const jsCozyGlobal = (routeName, isSecureProtocol) => `
   window.cozy.ClientConnectorLauncher = 'react-native'
   window.cozy.flagship = ${makeMetadata(routeName)}
   window.cozy.isSecureProtocol = ${isSecureProtocol || 'false'}
-
-  window.addEventListener('load', event => {
-    window.document.body.classList.add(
-      'flagship-app',
-      'flagship-os-${Platform.OS}',
-      'flagship-route-${routeName}'
-    )
-    // make the webapp non-zoomable
-    var meta = document.createElement('meta')
-    meta.setAttribute('name', 'viewport')
-    meta.setAttribute('content', 'width = device-width, initial-scale = 1.0, minimum-scale = 1.0, maximum-scale = 1.0, user-scalable = no')
-    document.getElementsByTagName('head')[0].appendChild(meta)
-  })
 `

--- a/src/libs/httpserver/helpers.js
+++ b/src/libs/httpserver/helpers.js
@@ -1,7 +1,24 @@
+import { Platform } from 'react-native'
+
 import { statusBarHeight, getNavbarHeight } from '/libs/dimensions'
+import { navigationRef } from '/libs/RootNavigation'
 
 export const addCSS = HTMLstring => {
   const style = `<style>body {--flagship-top-height: ${statusBarHeight}px; --flagship-bottom-height: ${getNavbarHeight()}px;}</style>`
 
   return HTMLstring.replace('</head>', style + '</head>')
+}
+
+export const addBodyClasses = HTMLstring => {
+  const bodyClasses = `class="flagship-app flagship-os-${
+    Platform.OS
+  } flagship-route-${navigationRef.getCurrentRoute().name}"`
+
+  return HTMLstring.replace('<body', `<body ${bodyClasses}`)
+}
+
+export const addMetaAttributes = HTMLstring => {
+  const metaAttributes = `<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />`
+
+  return HTMLstring.replace('</head>', metaAttributes + '</head>')
 }

--- a/src/libs/httpserver/helpers.spec.js
+++ b/src/libs/httpserver/helpers.spec.js
@@ -1,10 +1,43 @@
+import { compose } from '/libs/functions/compose'
 import { statusBarHeight, getNavbarHeight } from '/libs/dimensions'
+import {
+  addBodyClasses,
+  addCSS,
+  addMetaAttributes
+} from '/libs/httpserver/helpers'
 
-import { addCSS } from './helpers'
+jest.mock('/libs/RootNavigation.js', () => ({
+  navigationRef: {
+    getCurrentRoute: jest.fn().mockReturnValue({ name: 'home' })
+  }
+}))
 
 it('should return a stringified HTML with added CSS', () => {
   const html = `<html><head></head><body></body></html>`
   const expected = `<html><head><style>body {--flagship-top-height: ${statusBarHeight}px; --flagship-bottom-height: ${getNavbarHeight()}px;}</style></head><body></body></html>`
 
   expect(addCSS(html)).toEqual(expected)
+})
+
+it('should return a stringified HTML with added body classes', () => {
+  const html = `<html><head></head><body></body></html>`
+  const expected = `<html><head></head><body class="flagship-app flagship-os-ios flagship-route-home"></body></html>`
+
+  expect(addBodyClasses(html)).toEqual(expected)
+})
+
+it('should return a stringified HTML with added meta tags', () => {
+  const html = `<html><head></head><body></body></html>`
+  const expected = `<html><head><meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" /></head><body></body></html>`
+
+  expect(addMetaAttributes(html)).toEqual(expected)
+})
+
+it('should be able to handle composition', () => {
+  const html = `<html><head></head><body></body></html>`
+  const expected = `<html><head><style>body {--flagship-top-height: 20px; --flagship-bottom-height: 0px;}</style><meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" /></head><body class="flagship-app flagship-os-ios flagship-route-home"></body></html>`
+
+  expect(compose(addCSS, addBodyClasses, addMetaAttributes)(html)).toEqual(
+    expected
+  )
 })

--- a/src/libs/httpserver/httpServerProvider.js
+++ b/src/libs/httpserver/httpServerProvider.js
@@ -7,12 +7,13 @@ import React, {
 
 import Minilog from '@cozy/minilog'
 
+import { compose } from '/libs/functions/compose'
 import { getServerBaseFolder } from './httpPaths'
 import HttpServer from './HttpServer'
 import { setCookie } from './httpCookieManager'
 import { fillIndexWithData, getIndexForFqdnAndSlug } from './indexGenerator'
 import { fetchAppDataForSlug } from './indexDataFetcher'
-import { addCSS } from './helpers'
+import { addCSS, addBodyClasses, addMetaAttributes } from './helpers'
 import { queryResultToCrypto } from '../../components/webviews/CryptoWebView/cryptoObservable/cryptoObservable'
 
 const log = Minilog('HttpServerProvider')
@@ -95,7 +96,7 @@ export const HttpServerProvider = props => {
         indexData: templateValues
       })
 
-      return addCSS(computedHtml)
+      return compose(addCSS, addBodyClasses, addMetaAttributes)(computedHtml)
     } catch (err) {
       log.error(
         `Error while generating Index.html for ${slug}. Cozy-stack version will be used instead. Error was: ${err.message}`


### PR DESCRIPTION
# Description

This will allow removing some flickering on app loading

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

**Test Configuration**:
* PC OS: WIN10/WSL(Ubuntu 20)
* Phone OS: Android 11

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
