### PR TITLE
fix: Handle 404 error on `fetchCozyAppArchiveInfoForVersion()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,9 @@ Verify that the Cozy you are login into is using the last version of `cozy-home`
 3. Error on app `Tried to register two views with the same name RCTIndexInjectionWebView`
 
 This may happen after development's HotReload occurs. When encountered just restart the app. This should not happen on production.
+
+4. Cozy-app `cozy-notes` is not working when served locally
+
+`cozy-notes` bundle relies on a specific `tar_prefix`. When served from local `--appDir` then no `tar_prefix` is applied. However the Cozy's registry sends info from production app which has a defined `tar_prefix`.
+This would break the app as ReactNative will try to serve local assets using a non-existing directory.
+To prevent conflict on this, please increase your local `cozy-notes`'s version in the built `manifest.webapp` for a version that does not exist in production (i.e: `"version": "0.0.X.notexisting"`)

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -372,12 +372,22 @@ export const fetchCozyAppArchiveInfoForVersion = async (
 ) => {
   const stackClient = client.getStackClient()
 
-  const { tar_prefix: tarPrefix = '' } = await stackClient.fetchJSON(
-    'GET',
-    `/registry/${slug}/${version}`
-  )
+  try {
+    const { tar_prefix: tarPrefix = '' } = await stackClient.fetchJSON(
+      'GET',
+      `/registry/${slug}/${version}`
+    )
 
-  return {
-    tarPrefix
+    return {
+      tarPrefix
+    }
+  } catch (e) {
+    if (e.status === 404) {
+      return {
+        tarPrefix: ''
+      }
+    }
+
+    throw e
   }
 }


### PR DESCRIPTION
When working on a local dev environment the CozyAppBundle retrieval
code may encounter 2 kind of errors

First one: If a cozy-app is served through cozy-stack's `--appDir`
param, then calling `/registry/:slug/:version` for this cozy-app may
result in a 404 error, which would break the CozyAppBundle retrieval
scenario

This is the case if the developer incremented the cozy-app's version
and if this new version doesn't exist in Cozy's registry

For now we call this endpoint in order to retrieve the cozy-app's
`tar_prefix` info

Second one: If the registry returns a non-empty `tar_prefix` value and
if the cozy-app is served through `--appDir` param, then the
`tar_prefix` will be wrong as the cozy-stack will pack the cozy-app on
demand and will do it without any `tar_prefix` (here the configuration
is different between local dev and production releases)

By handling 404 error on `/registry/:slug/:version` and by returning
empty `tar_prefix` if it happens, then this should partially fix both
problems

First problem would be completely fixed

Second problem would be fixed only if the served app is using a new
version. If using a version that exists on Cozy's registry then the
problem would remain