### PR TITLE
WIP: Refactor: Remove usage of `lodash/get`

### DIFF
--- a/connectors/blablacar/src/index.js
+++ b/connectors/blablacar/src/index.js
@@ -1,7 +1,6 @@
 import ContentScript from '../../connectorLibs/ContentScript'
 import {kyScraper as ky} from '../../connectorLibs/utils'
 import Minilog from '@cozy/minilog'
-import get from 'lodash/get'
 
 const log = Minilog('ContentScript')
 Minilog.enable()
@@ -53,7 +52,7 @@ class BlablacarContentScript extends ContentScript {
       ],
       phone: [
         {
-          number: get(session, 'phone.raw_input'),
+          number: session?.phone?.raw_input,
         },
       ],
     }

--- a/connectors/connectorLibs/ContentScript.js
+++ b/connectors/connectorLibs/ContentScript.js
@@ -1,4 +1,3 @@
-import get from 'lodash/get'
 import waitFor from 'p-wait-for'
 import Minilog from '@cozy/minilog'
 
@@ -313,7 +312,7 @@ export default class ContentScript {
   calculateFileKey(file, fileIdAttributes) {
     return fileIdAttributes
       .sort()
-      .map(key => get(file, key))
+      .map(key => file?.[key])
       .join('####')
   }
 
@@ -407,7 +406,7 @@ export default class ContentScript {
 }
 
 function sendContentScriptReadyEvent() {
-  if (get(window, 'ReactNativeWebView.postMessage')) {
+  if (window?.ReactNativeWebView?.postMessage) {
     window.ReactNativeWebView.postMessage(
       JSON.stringify({ message: 'NEW_WORKER_INITIALIZING' })
     )

--- a/connectors/edf/src/index.js
+++ b/connectors/edf/src/index.js
@@ -1,7 +1,6 @@
 import ContentScript from '../../connectorLibs/ContentScript'
 import {kyScraper as ky} from '../../connectorLibs/utils'
 import Minilog from '@cozy/minilog'
-import get from 'lodash/get'
 import {format} from 'date-fns'
 import waitFor from 'p-wait-for'
 import {formatHousing} from './utils'
@@ -174,7 +173,7 @@ class EdfContentScript extends ContentScript {
     }
 
     const contractNumber = parseFloat(
-      get(result, 'feSouscriptionResponse.tradeNumber'),
+      result?.feSouscriptionResponse?.tradeNumber,
     )
     const subPath = contracts.folders[contractNumber]
     if (!subPath) {
@@ -187,10 +186,10 @@ class EdfContentScript extends ContentScript {
     const isMonthly =
       result.monthlyPaymentAllowedStatus === 'MENS' &&
       result.paymentSchedule &&
-      get(result, 'paymentSchedule.deadlines')
+      result?.paymentSchedule?.deadlines
 
     if (isMonthly) {
-      const startDate = new Date(get(result, 'paymentSchedule.startDate'))
+      const startDate = new Date(result?.paymentSchedule?.startDate)
       const bills = result.paymentSchedule.deadlines
         .filter(bill => bill.payment === 'EFFECTUE')
         .map(bill => ({
@@ -232,9 +231,7 @@ class EdfContentScript extends ContentScript {
         })
       const filename = `${format(
         new Date(
-          get(
-            paymentDocuments[0],
-            'listOfPaymentsByAccDTO[0].lastPaymentDocument.creationDate',
+          paymentDocuments[0]?.listOfPaymentsByAccDTO?.[0]?.lastPaymentDocument?.creationDate,
           ),
         ),
         'yyyy',
@@ -513,7 +510,7 @@ class EdfContentScript extends ContentScript {
     const context = await ky
       .get(BASE_URL + '/services/rest/context/getCustomerContext')
       .json()
-    const mail = get(context, 'bp.mail')
+    const mail = context?.bp?.mail
     if (mail) {
       return {
         sourceAccountIdentifier: mail,

--- a/connectors/edf/src/utils.js
+++ b/connectors/edf/src/utils.js
@@ -1,5 +1,4 @@
 import Minilog from '@cozy/minilog'
-import get from 'lodash/get'
 
 const log = Minilog('Utils')
 
@@ -110,7 +109,7 @@ export function convertConsumption(yearlyData = [], monthlyData = []) {
 }
 
 export function getEnergyTypeFromContract(contract) {
-  return get(contract, 'subscribeOffer.energy') === 'ELECTRICITE'
+  return contract?.subscribeOffer?.energy === 'ELECTRICITE'
     ? 'electricity'
     : 'gas'
 }
@@ -132,12 +131,12 @@ export function formatHousing(
 ) {
   const consumptions = {
     electricity: convertConsumption(
-      get(rawConsumptions, 'elec.yearlyElecEnergies'),
-      get(rawConsumptions, 'elec.monthlyElecEnergies'),
+      rawConsumptions?.elec?.yearlyElecEnergies,
+      rawConsumptions?.elec?.monthlyElecEnergies,
     ),
     gas: convertConsumption(
-      get(rawConsumptions, 'gas.yearlyGasEnergies'),
-      get(rawConsumptions, 'gas.monthlyGasEnergies'),
+      rawConsumptions?.gas?.yearlyGasEnergies,
+      rawConsumptions?.gas?.monthlyGasEnergies,
     ),
   }
 
@@ -150,9 +149,9 @@ export function formatHousing(
         vendor: 'edfclientside',
         contract_number: c.number,
         energy_type: energyType,
-        contract_type: get(c, 'subscribeOffer.offerName'),
+        contract_type: c?.subscribeOffer?.offerName,
         powerkVA: parseInt(
-          get(contractElec, 'supplyContractParameters.SUBSCRIBED_POWER'),
+          contractElec?.supplyContractParameters?.SUBSCRIBED_POWER,
           10,
         ),
         [energyType + '_consumptions']: consumptions[energyType],
@@ -179,7 +178,7 @@ export function formatHousing(
         heatingSystem.principalHeatingSystemType,
       ),
       water_heating_system: convertWaterHeatingSystem(
-        get(equipment, 'sanitoryHotWater.sanitoryHotWaterType'),
+        equipment?.sanitoryHotWater?.sanitoryHotWaterType,
       ),
       baking_types: convertBakingTypes(equipment.cookingEquipment),
       address: detail.adress,

--- a/src/components/ui/icons/BackTo.jsx
+++ b/src/components/ui/icons/BackTo.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { SvgXml } from 'react-native-svg'
+
+const xml = `
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M5.94894 4.26604C11.3395 5.01614 14.6534 8.2776 15.9702 11.9514C16.1535 12.4642 15.5195 12.8631 15.1185 12.4933C12.9636 10.4937 9.65382 9.56332 5.94894 9.56332V12.0586C5.94894 12.3348 5.72508 12.5586 5.44894 12.5586C5.31853 12.5586 5.19328 12.5077 5.0999 12.4166L0.347222 7.78311C-0.107546 7.33975 -0.116789 6.61167 0.326577 6.1569L5.09987 1.502C5.29758 1.30922 5.61414 1.31321 5.80692 1.51092C5.89798 1.6043 5.94894 1.72956 5.94894 1.85999V4.26604Z"/>
+</svg>
+`
+
+class SVG extends React.Component {
+  render() {
+    return (
+      <SvgXml
+        xml={xml}
+        width={this.props.width}
+        height={this.props.height}
+        fill={this.props.color}
+      />
+    )
+  }
+}
+
+export const BackTo = SVG

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { Q, models } from 'cozy-client'
 import Minilog from '@cozy/minilog'
-import get from 'lodash/get'
 import set from 'lodash/set'
 
 import { saveFiles, saveBills, saveIdentity } from './connectorLibs'
@@ -144,7 +143,7 @@ export default class Launcher {
   async ensureAccountNameAndFolder() {
     const { trigger, account, client } = this.getStartContext()
 
-    const firstRun = !get(account, 'auth.accountName')
+    const firstRun = !account?.auth?.accountName
     if (!firstRun) {
       return
     }

--- a/src/libs/connectorLibs/hydrateAndFilter.js
+++ b/src/libs/connectorLibs/hydrateAndFilter.js
@@ -1,4 +1,3 @@
-import get from 'lodash/get'
 import uniqBy from 'lodash/uniqBy'
 import { Q } from 'cozy-client'
 import Minilog from '@cozy/minilog'
@@ -68,7 +67,7 @@ const hydrateAndFilter = async (documents = [], doctype, options = {}) => {
   const createHash = item => {
     return keys
       .map(key => {
-        let result = get(item, key)
+        let result = item?.[key]
         if (key === 'date') {
           result = new Date(result)
         }

--- a/src/libs/connectorLibs/saveFiles.js
+++ b/src/libs/connectorLibs/saveFiles.js
@@ -171,10 +171,9 @@ function noMetadataDeduplicationWarning(options) {
     )
   }
 
-  const sourceAccountIdentifier = get(
-    options,
-    'sourceAccountOptions.sourceAccountIdentifier'
-  )
+  const sourceAccountIdentifier =
+    options?.sourceAccountOptions?.sourceAccountIdentifier
+
   if (!sourceAccountIdentifier) {
     log.warn(
       'No sourceAccountIdentifier is defined in options, file deduplication will be based on file path'
@@ -185,10 +184,8 @@ function noMetadataDeduplicationWarning(options) {
 async function getFileIfExists(entry, options) {
   const fileIdAttributes = options.fileIdAttributes
   const slug = options.manifest.slug
-  const sourceAccountIdentifier = get(
-    options,
-    'sourceAccountOptions.sourceAccountIdentifier'
-  )
+  const sourceAccountIdentifier =
+    options?.sourceAccountOptions?.sourceAccountIdentifier
 
   const isReadyForFileMetadata =
     fileIdAttributes && slug && sourceAccountIdentifier
@@ -330,7 +327,7 @@ const defaultShouldReplaceFile = (file, entry, options) => {
   const shouldForceMetadataAttr = attr => {
     const result =
       !getAttribute(file, `metadata.${attr}`) &&
-      get(entry, `fileAttributes.metadata.${attr}`)
+      entry?.fileAttributes?.metadata?.[attr]
     if (result) {
       log.debug(`filereplacement: adding ${attr} metadata`)
     }
@@ -339,11 +336,10 @@ const defaultShouldReplaceFile = (file, entry, options) => {
   // replace all files with meta if there is file metadata to add
   const fileHasNoMetadata = !getAttribute(file, 'metadata')
   const fileHasNoId = !getAttribute(file, 'metadata.fileIdAttributes')
-  const entryHasMetadata = !!get(entry, 'fileAttributes.metadata')
-  const hasSourceAccountIdentifierOption = !!get(
-    options,
-    'sourceAccountOptions.sourceAccountIdentifier'
-  )
+  const entryHasMetadata = !!entry?.fileAttributes?.metadata
+  const hasSourceAccountIdentifierOption =
+    !!options?.sourceAccountOptions?.sourceAccountIdentifier
+
   const fileHasSourceAccountIdentifier = !!getAttribute(
     file,
     'cozyMetadata.sourceAccountIdentifier'
@@ -458,7 +454,7 @@ function getValOrFnResult(val, ...args) {
 function calculateFileKey(entry, fileIdAttributes) {
   return fileIdAttributes
     .sort()
-    .map(key => get(entry, key))
+    .map(key => entry?.[key])
     .join('####')
 }
 
@@ -497,7 +493,7 @@ function getFilePath({ file, entry, options }) {
 }
 
 function getAttribute(obj, attribute) {
-  return get(obj, `attributes.${attribute}`, get(obj, attribute))
+  return obj?.attributes?.[attribute] || obj?.[attribute]
 }
 
 async function getOrCreateDestinationPath(entry, saveOptions) {

--- a/src/libs/connectorLibs/updateOrCreate.js
+++ b/src/libs/connectorLibs/updateOrCreate.js
@@ -1,5 +1,4 @@
 import Minilog from '@cozy/minilog'
-import get from 'lodash/get'
 import { Q } from 'cozy-client'
 const log = Minilog('updateOrCreate')
 
@@ -27,8 +26,7 @@ const updateOrCreate = async (
     const toUpdate = existings.find(doc =>
       matchingAttributes.reduce(
         (isMatching, matchingAttribute) =>
-          isMatching &&
-          get(doc, matchingAttribute) === get(entry, matchingAttribute),
+          isMatching && doc?.[matchingAttribute] === entry?.[matchingAttribute],
         true
       )
     )

--- a/src/libs/functions/routeHelpers.js
+++ b/src/libs/functions/routeHelpers.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash'
-
 /**
  * Retrieve the specified route parameter and remove it from the navigation state
  * @param {string} paramName - Name of the parameter to retrieve
@@ -8,7 +6,7 @@ import { get } from 'lodash'
  * @returns the route parameter's value
  */
 export const consumeRouteParameter = (paramName, route, navigation) => {
-  const param = get(route, `params.${paramName}`)
+  const param = route?.params?.[paramName]
 
   if (param !== undefined) {
     navigation.setParams({ [paramName]: undefined })

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -1,6 +1,11 @@
+import Minilog from '@cozy/minilog'
+import { withClient } from 'cozy-client'
+import debounce from 'lodash/debounce'
+import get from 'lodash/get'
 import React, { Component } from 'react'
-import { WebView } from 'react-native-webview'
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native'
+import { WebView } from 'react-native-webview'
+
 // TODO find a proper way to load a connector only when needed
 import amazonConnector from '../../../connectors/amazon/dist/webviewScript'
 import templateConnector from '../../../connectors/template/dist/webviewScript'
@@ -11,13 +16,9 @@ import edfConnector from '../../../connectors/edf/dist/webviewScript'
 import soshConnector from '../../../connectors/sosh/dist/webviewScript'
 import { BackTo } from '/components/ui/icons/BackTo'
 import { statusBarHeight } from '/libs/dimensions'
-import ReactNativeLauncher from '../../libs/ReactNativeLauncher'
+import ReactNativeLauncher from '/libs/ReactNativeLauncher'
 import { getColors } from '/theme/colors'
 import strings from '/strings.json'
-import debounce from 'lodash/debounce'
-import { withClient } from 'cozy-client'
-import { get } from 'lodash'
-import Minilog from '@cozy/minilog'
 
 const log = Minilog('LauncherView')
 

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { WebView } from 'react-native-webview'
-import { StyleSheet, View, Text, TouchableOpacity, Image } from 'react-native'
+import { StyleSheet, View, Text, TouchableOpacity } from 'react-native'
 // TODO find a proper way to load a connector only when needed
 import amazonConnector from '../../../connectors/amazon/dist/webviewScript'
 import templateConnector from '../../../connectors/template/dist/webviewScript'
@@ -9,13 +9,19 @@ import googleConnector from '../../../connectors/google-takeout/dist/webviewScri
 import blablacarConnector from '../../../connectors/blablacar/dist/webviewScript'
 import edfConnector from '../../../connectors/edf/dist/webviewScript'
 import soshConnector from '../../../connectors/sosh/dist/webviewScript'
+import { BackTo } from '/components/ui/icons/BackTo'
+import { statusBarHeight } from '/libs/dimensions'
 import ReactNativeLauncher from '../../libs/ReactNativeLauncher'
+import { getColors } from '/theme/colors'
+import strings from '/strings.json'
 import debounce from 'lodash/debounce'
 import { withClient } from 'cozy-client'
 import { get } from 'lodash'
 import Minilog from '@cozy/minilog'
 
 const log = Minilog('LauncherView')
+
+const colors = getColors()
 
 const DEBUG = false
 
@@ -151,12 +157,12 @@ class LauncherView extends Component {
                 <TouchableOpacity
                   activeOpacity={0.5}
                   onPress={this.onStopExecution}
+                  style={styles.headerTouchableStyle}
                 >
-                  <Image
-                    source={require('../../assets/cross.png')}
-                    resizeMode="cover"
-                    style={styles.cross}
-                  />
+                  <BackTo color={colors.primaryColor} width={16} height={16} />
+                  <Text style={styles.headerTextStyle}>
+                    {strings.connectors.worker.backButton}
+                  </Text>
                 </TouchableOpacity>
               </View>
               <WebView
@@ -264,15 +270,24 @@ const styles = StyleSheet.create({
     width: 0,
     flex: 0
   },
-  cross: {
-    width: 16,
-    height: 16,
-    position: 'absolute',
-    top: 50,
-    right: 20
-  },
   headerStyle: {
-    height: 80
+    flexDirection: 'row',
+    alignContent: 'center',
+    paddingHorizontal: 8,
+    paddingTop: statusBarHeight + 8,
+    paddingBottom: 8
+  },
+  headerTouchableStyle: {
+    flexDirection: 'row',
+    paddingVertical: 8,
+    paddingHorizontal: 6
+  },
+  headerTextStyle: {
+    marginLeft: 10,
+    fontSize: 13,
+    fontWeight: '700',
+    lineHeight: 16,
+    color: colors.primaryColor
   }
 })
 

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -1,7 +1,6 @@
 import Minilog from '@cozy/minilog'
 import { withClient } from 'cozy-client'
 import debounce from 'lodash/debounce'
-import get from 'lodash/get'
 import React, { Component } from 'react'
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native'
 import { WebView } from 'react-native-webview'
@@ -79,7 +78,7 @@ class LauncherView extends Component {
     this.launcher.setStartContext({
       ...this.props.launcherContext,
       client: this.props.client,
-      manifest: get(this, 'state.connector.manifest')
+      manifest: this?.state?.connector?.manifest
     })
   }
 
@@ -88,7 +87,7 @@ class LauncherView extends Component {
     this.launcher.setStartContext({
       ...this.props.launcherContext,
       client: this.props.client,
-      manifest: get(this, 'state.connector.manifest')
+      manifest: this?.state?.connector?.manifest
     })
     const initConnectorError = await this.initConnector()
 
@@ -109,7 +108,7 @@ class LauncherView extends Component {
           pilotWebView: this.pilotWebView,
           workerWebview: this.workerWebview
         },
-        contentScript: get(this, 'state.connector.content')
+        contentScript: this?.state?.connector?.content
       })
     }
     await this.launcher.start({ initConnectorError })
@@ -139,7 +138,7 @@ class LauncherView extends Component {
                 ref={ref => (this.pilotWebView = ref)}
                 originWhitelist={['*']}
                 source={{
-                  uri: get(this, 'state.connector.manifest.vendor_link')
+                  uri: this?.state?.connector?.manifest?.vendor_link
                 }}
                 useWebKit={true}
                 javaScriptEnabled={true}
@@ -147,10 +146,9 @@ class LauncherView extends Component {
                 sharedCookiesEnabled={true}
                 onMessage={this.onPilotMessage}
                 onError={this.onPilotError}
-                injectedJavaScriptBeforeContentLoaded={get(
-                  this,
-                  'state.connector.content'
-                )}
+                injectedJavaScriptBeforeContentLoaded={
+                  this?.state?.connector?.content
+                }
               />
             </View>
             <View style={workerStyle}>
@@ -179,10 +177,9 @@ class LauncherView extends Component {
                 sharedCookiesEnabled={true}
                 onMessage={this.onWorkerMessage}
                 onError={this.onWorkerError}
-                injectedJavaScriptBeforeContentLoaded={get(
-                  this,
-                  'state.connector.content'
-                )}
+                injectedJavaScriptBeforeContentLoaded={
+                  this?.state?.connector?.content
+                }
               />
             </View>
           </>

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { get } from 'lodash'
 import { useFocusEffect } from '@react-navigation/native'
 
 import { useClient, generateWebLink } from 'cozy-client'
@@ -116,7 +115,7 @@ const HomeView = ({ route, navigation, setLauncherContext }) => {
       route={route}
       logId="HomeView"
       onMessage={async event => {
-        const data = get(event, 'nativeEvent.data')
+        const data = event?.nativeEvent?.data
 
         if (data) {
           const { methodName, message, value } = JSON.parse(data)

--- a/src/strings.json
+++ b/src/strings.json
@@ -9,6 +9,11 @@
   "SESSION_CREATED_FLAG": "SESSION_CREATED_FLAG",
   "appTouched": "appTouched",
   "authLogin": "/auth/login?redirect=",
+  "connectors": {
+    "worker": {
+      "backButton": "RETOUR À MON COZY"
+    }
+  },
   "clouderyiOSUri": "https://staging-manager.cozycloud.cc/v2/cozy/start?redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3F%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
   "clouderyAndroidUri": "https://staging-manager.cozycloud.cc/v2/cozy/start?redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
   "defaultHttpScheme": "https://",


### PR DESCRIPTION
> **Warning**
> This PR is still in draft until we discuss about the changes

___

I initiate this PR to remove dependency to `lodash/get`

I did not run related tests yet but I pushed this PR so we can start discussion about it

Here are other usages of lodash that we can discuss about:

- Imports that seems problematic:
  - [SaveBills.js](https://github.com/cozy/cozy-react-native/blob/master/src/libs/connectorLibs/saveBills.js#L4) that do `import _ from 'lodash'` for using `cloneDeepWith`, `cloneDeep` and `isArray`
    - Proposition: replace them with specific `lodash/xxx` imports
- Other imports that looks ok:
  - lodash/uniqueId
  - lodash/set
  - lodash/uniqBy
  - lodash/omit
  - lodash/debounce