### PR TITLE
fix(routes): specify stack routes when useAppBootstrap resolves initial screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ## 🔧 Tech
 
+* Specify correct stack routes when app bootstraps ([PR #331](https://github.com/cozy/cozy-react-native/pull/331))
 
 # 0.0.16
 

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -102,7 +102,7 @@ export const useAppBootstrap = client => {
 
             return setInitialScreen({
               stack: routes.instanceCreation,
-              root: routes.nested,
+              root: routes.stack,
               params: {
                 onboardUrl
               }
@@ -112,7 +112,7 @@ export const useAppBootstrap = client => {
 
             return setInitialScreen({
               stack: routes.authenticate,
-              root: routes.nested,
+              root: routes.stack,
               params: {
                 fqdn
               }

--- a/src/hooks/useAppBootstrap.spec.js
+++ b/src/hooks/useAppBootstrap.spec.js
@@ -61,6 +61,64 @@ afterEach(() => {
   expect(mockRemove).toHaveBeenCalledTimes(1)
 })
 
+it('should set routes.stack and instance creation - when onboard_url provided', async () => {
+  // Given
+  const paramOnboardUrl = 'param-onboard-url'
+  const onboardingUrl = `http://localhost:8080/onboarding-url?onboard_url=${paramOnboardUrl}&fqdn=param-fqdn`
+  Linking.getInitialURL.mockResolvedValueOnce(onboardingUrl)
+
+  const { result, waitForValueToChange } = renderHook(() => useAppBootstrap())
+
+  await waitForValueToChange(() => result.current.isLoading)
+
+  expect(result.current).toStrictEqual({
+    client: undefined,
+    initialScreen: {
+      params: {
+        onboardUrl: paramOnboardUrl
+      },
+      stack: routes.instanceCreation,
+      root: routes.stack
+    },
+    initialRoute: {
+      stack: undefined,
+      root: undefined
+    },
+    isLoading: false
+  })
+
+  expect(mockHideSplashScreen).toHaveBeenCalledTimes(1)
+})
+
+it('should set routes.stack and authenticate - when onboard_url not provided', async () => {
+  // Given
+  const paramFqdn = `param-fqdn`
+  const onboardingUrl = `http://localhost:8080/onboarding-url?fqdn=${paramFqdn}`
+  Linking.getInitialURL.mockResolvedValueOnce(onboardingUrl)
+
+  const { result, waitForValueToChange } = renderHook(() => useAppBootstrap())
+
+  await waitForValueToChange(() => result.current.isLoading)
+
+  expect(result.current).toStrictEqual({
+    client: undefined,
+    initialScreen: {
+      stack: routes.authenticate,
+      root: routes.stack,
+      params: {
+        fqdn: paramFqdn
+      }
+    },
+    initialRoute: {
+      stack: undefined,
+      root: undefined
+    },
+    isLoading: false
+  })
+
+  expect(mockHideSplashScreen).toHaveBeenCalledTimes(1)
+})
+
 it('Should handle welcome page', async () => {
   const { result, waitForValueToChange } = renderHook(() => useAppBootstrap())
 


### PR DESCRIPTION


* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [x] Updated README & CHANGELOG, if necessary

