### PR TITLE
chore(automerge): allow merge after one collaborator approval instead of member

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,5 +1,5 @@
 minApprovals:
-  MEMBER: 1
+  COLLABORATOR: 1
 requiredLabels:
 - merge
 reportStatus: true


### PR DESCRIPTION
to make this working: 

https://github.com/cozy/cozy-react-native/pull/329/checks?check_run_id=7238230860


I guess, it's because the [ASSOCIATION](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation=) is too high. ps : if it does not work, i will try NONE.
#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Updated README & CHANGELOG, if necessary

