### PR TITLE
fix: Disable opening native apps on iOS 15

### DIFF
--- a/src/libs/functions/openApp.js
+++ b/src/libs/functions/openApp.js
@@ -49,7 +49,9 @@ const openAppNative = async appNativeData => {
 
   const canOpenApp = await Linking.canOpenURL(schema)
 
-  if (canOpenApp) {
+  // openURL is temporarily disabled on iOS 15+ until we fix the related cozy-pass crash
+  const majorVersionIOS = +Platform.Version
+  if (canOpenApp && (Platform.OS !== 'ios' || majorVersionIOS < 15)) {
     return Linking.openURL(schema)
   } else {
     return new Promise(resolve => {

--- a/src/libs/functions/openApp.spec.js
+++ b/src/libs/functions/openApp.spec.js
@@ -16,7 +16,8 @@ jest.mock('react-native', () => ({
     openURL: jest.fn()
   },
   Platform: {
-    OS: 'ios'
+    OS: 'ios',
+    Version: '14'
   }
 }))
 
@@ -193,6 +194,49 @@ describe('openApp', () => {
 
       expect(RN.Linking.canOpenURL).toHaveBeenCalledWith('cozypassoverride://')
       expect(RN.Linking.openURL).toHaveBeenCalledWith('cozypassoverride://')
+    })
+  })
+
+  describe(`TEMPORARY CozyPass hack until we fix the openning crash`, () => {
+    it('should ask to open AppStore on iOS 15+ until we fix the CozyPass crash', async () => {
+      RN.Linking.canOpenURL.mockResolvedValue(true)
+      RN.Linking.openURL.mockResolvedValue(false)
+      RN.Platform.OS = 'ios'
+      RN.Platform.Version = '15'
+
+      RN.Alert.alert = jest.fn((title, message, buttons) => {
+        buttons[1].onPress()
+      })
+
+      await openApp(navigation, 'https://appurl', {
+        mobile: {
+          schema: 'cozypass://',
+          id_playstore: 'io.cozy.pass',
+          id_appstore: 'cozy-pass/id1502262449'
+        }
+      })
+
+      expect(RN.Linking.canOpenURL).toHaveBeenCalledWith('cozypass://')
+      expect(RN.Linking.openURL).toHaveBeenCalledWith(
+        'itms-apps://apps.apple.com/id/app/cozy-pass/id1502262449?l=id'
+      )
+    })
+
+    it('should open native app from manifest info on iOS <15', async () => {
+      RN.Linking.canOpenURL.mockResolvedValue(true)
+      RN.Platform.OS = 'ios'
+      RN.Platform.Version = '14.5'
+
+      await openApp(navigation, 'https://appurl', {
+        mobile: {
+          schema: 'cozypass://',
+          id_playstore: 'io.cozy.pass',
+          id_appstore: 'cozy-pass/id1502262449'
+        }
+      })
+
+      expect(RN.Linking.canOpenURL).toHaveBeenCalledWith('cozypass://')
+      expect(RN.Linking.openURL).toHaveBeenCalledWith('cozypass://')
     })
   })
 })


### PR DESCRIPTION
Since iOS 15, CozyPass crashes when opened from `Linking.openURL`

This commit disables this feature and opens the store instead. Then the
user will be able to open CozyPass from the store page

We keep the old behavior on Android and on iOS <15

As CozyPass is the only app opened natively from this feature, we only
adapt based on the OS version without checking the opened app's name

This commit is meant to be temporary and should be reverted when the
CozyPass bug is resolved