### PR TITLE
fix: Simplify closeApp method call

### DIFF
--- a/src/components/webviews/CozyWebView.js
+++ b/src/components/webviews/CozyWebView.js
@@ -32,6 +32,7 @@ export const CozyWebView = ({
   trackWebviewInnerUri,
   route,
   injectedJavaScriptBeforeContentLoaded,
+  setParentRef,
   ...rest
 }) => {
   const isSecureProtocol = useIsSecureProtocol()
@@ -128,7 +129,10 @@ export const CozyWebView = ({
       originWhitelist={['http://*', 'https://*', 'intent://*']}
       useWebKit={true}
       javaScriptEnabled={true}
-      ref={ref => setWebviewRef(ref)}
+      ref={ref => {
+        setWebviewRef(ref)
+        setParentRef?.(ref)
+      }}
       TEST_ONLY_setRef={setWebviewRef}
       decelerationRate="normal" // https://github.com/react-native-webview/react-native-webview/issues/1070
       onShouldStartLoadWithRequest={initialRequest => {


### PR DESCRIPTION
Instead of using cozy-intent which requires a handshake,
which we do not necessarily have here (you open an app, change your mind, go back = the handshake never happened, and closeApp can't be called),
we will call directly into the webview the event that triggers
the CSS changes we want to happen when going back to homepage