### PR TITLE
fix: Set blue color for the background

### DIFF
--- a/src/screens/login/components/PasswordView.js
+++ b/src/screens/login/components/PasswordView.js
@@ -126,6 +126,7 @@ const PasswordForm = ({
         onMessage={processMessage}
         originWhitelist={['*']}
         source={{ html }}
+        style={{ backgroundColor: colors.primaryColor }}
       />
       {loading && (
         <View


### PR DESCRIPTION
On iOS, currently if we scroll on the PasswordView we have a blank background, it's not very elegant.
![IMG_0313](https://user-images.githubusercontent.com/1107936/179466355-165d391b-8e1b-4efa-bd9c-6f11c35d4e64.PNG)
 