### PR TITLE
fix: Do not inject js on undefined WebView in `unzoomHomeView`

### DIFF
--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -12,7 +12,7 @@ import { useSession } from '/hooks/useSession'
 import { AppState } from 'react-native'
 
 const unzoomHomeView = webviewRef => {
-  webviewRef.injectJavaScript(
+  webviewRef?.injectJavaScript(
     'window.dispatchEvent(new Event("closeApp"));true;'
   )
 }


### PR DESCRIPTION
On iOS/Release, the `change` event from `AppState.addEventListener` is
called on first render when WebViewRef can be undefined

So we have to check that it is defined before trying to inject js on it

This bug is specific to iOS in Release mode

This fix will skip the first call to `unzoomHomeView` because
WebViewRef will never be defined at this time. But this is not
problematic as this method only need to be called if `openApp` has been
called earlier. Which would never be the case on first render