### PR TITLE
fix: Viewport size on iOS

### DIFF
--- a/src/components/webviews/jsInteractions/jsCozyInjection.js
+++ b/src/components/webviews/jsInteractions/jsCozyInjection.js
@@ -17,9 +17,16 @@ const makeMetadata = routeName =>
 
 export const jsCozyGlobal = (routeName, isSecureProtocol) => `
   if (!window.cozy) window.cozy = {}
-
   window.cozy.isFlagshipApp = true
   window.cozy.ClientConnectorLauncher = 'react-native'
   window.cozy.flagship = ${makeMetadata(routeName)}
   window.cozy.isSecureProtocol = ${isSecureProtocol || 'false'}
+  // We have random issue on iOS when the app's script is executed
+  // before the view port. To fix that, we wait the load Event 
+  // and then we dispatch the resize even to wake up 
+  // cozy-ui's breakpoint.
+  // for instance https://stackoverflow.com/questions/5508455/mobile-safari-window-reports-980px/35987682#35987682
+  window.addEventListener('load', () => {
+    window.dispatchEvent(new Event('resize'));
+  })
 `


### PR DESCRIPTION
We randomly have isMobile equal to
false on iOS. It seems that the app's
script can be executed before having
the dom available. So when runing
the useBreakpoint() the value can be
the one by default: aka 980. Then
the viewport is changed to 390
(base on the meta viewport). But when
the viewport changed, the resize method
is not called.

https://stackoverflow.com/questions/5508455/mobile-safari-window-reports-980px/35987682#35987682

So, to get the right value, we dispatch
a resize event when the DOM is loaded
in order to wakeup UI's breakpoint.
