### PR TITLE
fix(welcome): Preload LoginScreen on WelcomeScreen for performance

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -85,7 +85,9 @@ const App = ({ setClient }) => {
         {params => <CreateInstanceScreen {...params} />}
       </Stack.Screen>
 
-      <Stack.Screen component={WelcomeScreen} name={routes.welcome} />
+      <Stack.Screen name={routes.welcome}>
+        {params => <WelcomeScreen setClient={setClient} {...params} />}
+      </Stack.Screen>
     </Stack.Navigator>
   )
 

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { StyleSheet, View, Platform } from 'react-native'
+import { BackHandler, Platform, StyleSheet, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Minilog from '@cozy/minilog'
 
@@ -40,7 +40,13 @@ const ERROR_STEP = 'ERROR_STEP'
 
 const OAUTH_USER_CANCELED_ERROR = 'USER_CANCELED'
 
-const LoginSteps = ({ navigation, route, setClient }) => {
+const LoginSteps = ({
+  disabledFocus,
+  goBack,
+  navigation,
+  route,
+  setClient
+}) => {
   const { showSplashScreen } = useSplashScreen()
   const [state, setState] = useState({
     step: CLOUDERY_STEP
@@ -49,6 +55,24 @@ const LoginSteps = ({ navigation, route, setClient }) => {
   useEffect(() => {
     log.debug(`Enter state ${state.step}`)
   }, [state])
+
+  const handleBackPress = useCallback(() => {
+    if (goBack) {
+      setState({
+        step: CLOUDERY_STEP
+      })
+      goBack()
+      return true
+    }
+    return false
+  }, [goBack])
+
+  useEffect(() => {
+    BackHandler.addEventListener('hardwareBackPress', handleBackPress)
+
+    return () =>
+      BackHandler.removeEventListener('hardwareBackPress', handleBackPress)
+  }, [handleBackPress])
 
   useEffect(() => {
     if (state.loginData && state.step === PASSWORD_STEP) {
@@ -299,7 +323,12 @@ const LoginSteps = ({ navigation, route, setClient }) => {
   }, [])
 
   if (state.step === CLOUDERY_STEP) {
-    return <ClouderyView setInstanceData={setInstanceData} />
+    return (
+      <ClouderyView
+        disabledFocus={disabledFocus}
+        setInstanceData={setInstanceData}
+      />
+    )
   }
 
   if (state.step === PASSWORD_STEP) {
@@ -369,7 +398,13 @@ const LoginSteps = ({ navigation, route, setClient }) => {
   }
 }
 
-export const LoginScreen = ({ navigation, route, setClient }) => {
+export const LoginScreen = ({
+  disabledFocus,
+  goBack,
+  navigation,
+  route,
+  setClient
+}) => {
   const colors = getColors()
   const insets = useSafeAreaInsets()
   return (
@@ -382,7 +417,13 @@ export const LoginScreen = ({ navigation, route, setClient }) => {
       ]}
     >
       <View style={{ height: statusBarHeight }} />
-      <LoginSteps navigation={navigation} route={route} setClient={setClient} />
+      <LoginSteps
+        navigation={navigation}
+        route={route}
+        setClient={setClient}
+        disabledFocus={disabledFocus}
+        goBack={goBack}
+      />
       <View
         style={{
           height: Platform.OS === 'ios' ? insets.bottom : getNavbarHeight()

--- a/src/screens/welcome/WelcomeScreen.jsx
+++ b/src/screens/welcome/WelcomeScreen.jsx
@@ -1,18 +1,17 @@
-import React from 'react'
-import { StyleSheet, View, Platform } from 'react-native'
+import React, { useState } from 'react'
+import { BackHandler, StyleSheet, View, Platform } from 'react-native'
 
 import WebView from 'react-native-webview'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { WelcomePage } from '/components/html/WelcomePage'
 import { makeHTML } from '/components/makeHTML'
-import { routes } from '/constants/routes'
 import { makeHandlers } from '/libs/functions/makeHandlers'
-import { navigate } from '/libs/RootNavigation'
 import { getColors } from '/theme/colors'
 import { getNavbarHeight } from '/libs/dimensions'
+import { LoginScreen } from '/screens/login/LoginScreen'
 
-export const WelcomeScreen = () => {
+const WelcomeView = ({ setIsWelcomeModalDisplayed }) => {
   const colors = getColors()
   const insets = useSafeAreaInsets()
   return (
@@ -26,7 +25,7 @@ export const WelcomeScreen = () => {
     >
       <WebView
         onMessage={makeHandlers({
-          onContinue: () => navigate(routes.authenticate)
+          onContinue: () => setIsWelcomeModalDisplayed(false)
         })}
         source={{ html: makeHTML(WelcomePage) }}
         style={{
@@ -41,8 +40,41 @@ export const WelcomeScreen = () => {
     </View>
   )
 }
+
+export const WelcomeScreen = ({ navigation, route, setClient }) => {
+  const [isWelcomeModalDisplayed, setIsWelcomeModalDisplayed] = useState(true)
+
+  const handleBackPress = () => {
+    if (isWelcomeModalDisplayed) {
+      BackHandler.exitApp()
+    } else {
+      setIsWelcomeModalDisplayed(true)
+    }
+  }
+
+  return (
+    <>
+      <LoginScreen
+        style={styles.view}
+        disabledFocus={isWelcomeModalDisplayed}
+        navigation={navigation}
+        route={route}
+        setClient={setClient}
+        goBack={handleBackPress}
+      />
+      {isWelcomeModalDisplayed && (
+        <WelcomeView setIsWelcomeModalDisplayed={setIsWelcomeModalDisplayed} />
+      )}
+    </>
+  )
+}
+
 const styles = StyleSheet.create({
   view: {
-    flex: 1
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%'
   }
 })


### PR DESCRIPTION
When opening the app, the first displayed screen is WelcomeScreen, and
when clicking on `CONTINUE` we go to the LoginScreen

This navigation may slow the user experience, also it may produce a
blank screen to quickly flash when LoginScreen is mounted

To prevent those problems we want to pre-load the LoginScreen behind
the WelcomeScreen

ReactNativation Router is not able to pre-load routes, so we mount the
LoginScreen inside of the WelcomScreen and handle navigation manually
between those screens

Note that we handle the back button to navigate inside of the
ClouderyView, and we handle the back button in the LoginScreen to reset
the steps when going back to the WelcomeScreen. But we do not handle
the navigation between LoginScreen's steps yet



DoD:

Lorsqu'on ouvre l'application + pas de session :

* [x]  On affiche l'écran Welcome
* [x] Si on fait back on quitte l'application
* [x]  Si on click sur "c'est parti" on arrive sur l'écran de login (sans chargement)
* [x]  Si on fait back on revient sur l'écran Welcome

Lorsqu'on est connecté à un compte

* [x]  Si on déconnecte le compte on arrive sur l'écran Login
* [x] Si on fait back à ce niveau alors on quitte l'app
