### PR TITLE
feat(client): set oauth client settings name as Personal Cloud

### DIFF
--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -1,6 +1,8 @@
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock'
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock.js'
+import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock'
 
+jest.mock('react-native-device-info', () => mockRNDeviceInfo)
 jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage)
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
 

--- a/android/app/src/main/java/io/cozy/flagship/mobile/MainApplication.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.rnfs.RNFSPackage;
 import com.reactlibrary.GzipPackage;
 import com.facebook.react.ReactInstanceManager;

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'CozyReactNative'
+include ':react-native-device-info'
+project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
 include ':react-native-fs'
 project(':react-native-fs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fs/android')
 include ':@fengweichong_react-native-gzip'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -21,6 +21,8 @@ target 'CozyReactNative' do
 
   pod 'GCDWebServer', '~> 3.0'
 
+  pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'
+
   target 'CozyReactNativeTests' do
     inherit! :complete
     # Pods for testing

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -364,6 +364,8 @@ PODS:
     - React-Core
   - RNCAsyncStorage (1.17.7):
     - React-Core
+  - RNDeviceInfo (10.0.2):
+    - React-Core
   - RNFS (2.20.0):
     - React-Core
   - RNGestureHandler (1.10.3):
@@ -480,6 +482,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNBootSplash (from `../node_modules/react-native-bootsplash`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
@@ -588,6 +591,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-bootsplash"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
+  RNDeviceInfo:
+    :path: "../node_modules/react-native-device-info"
   RNFS:
     :path: "../node_modules/react-native-fs"
   RNGestureHandler:
@@ -663,6 +668,7 @@ SPEC CHECKSUMS:
   ReactCommon: 57b69f6383eafcbd7da625bfa6003810332313c4
   RNBootSplash: 8ef5ffa03dadd35f66510b42960ce40f397c98bf
   RNCAsyncStorage: d81ee5c3db1060afd49ea7045ad460eff82d2b7d
+  RNDeviceInfo: 0a7c1d2532aa7691f9b9925a27e43af006db4dae
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNInAppBrowser: 48b95ba7a4eaff5cc223bca338d3e319561dbd1b

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-native": "0.66.4",
     "react-native-android-navbar-height": "git+https://github.com/ConnectyCube/react-native-android-navbar-height.git#main",
     "react-native-bootsplash": "3.2.3",
+    "react-native-device-info": "^10.0.2",
     "react-native-flipper": "^0.146.1",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "1.10.3",

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -1,10 +1,12 @@
 import CozyClient from 'cozy-client'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import Minilog from '@cozy/minilog'
+import { getDeviceName } from 'react-native-device-info'
 
 import { queryResultToCrypto } from '../components/webviews/CryptoWebView/cryptoObservable/cryptoObservable'
 import { loginFlagship } from './clientHelpers/loginFlagship'
 import { normalizeFqdn } from './functions/stringHelpers'
+import { SOFTWARE_ID, SOFTWARE_NAME } from './constants'
 
 import apiKeys from '../api-keys.json'
 import strings from '../strings.json'
@@ -185,9 +187,9 @@ export const createClient = async instance => {
     scope: ['*'],
     oauth: {
       redirectURI: strings.COZY_SCHEME,
-      softwareID: 'amiral',
+      softwareID: SOFTWARE_ID,
       clientKind: 'mobile',
-      clientName: 'Amiral',
+      clientName: `${SOFTWARE_NAME} (${getDeviceName()})`,
       shouldRequireFlagshipPermissions: true,
       certificationConfig: {
         androidSafetyNetApiKey: apiKeys.androidSafetyNetApiKey

--- a/src/libs/constants.js
+++ b/src/libs/constants.js
@@ -1,0 +1,4 @@
+import { translation } from '/locales'
+
+export const SOFTWARE_ID = translation.software.id
+export const SOFTWARE_NAME = translation.software.name

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -2,6 +2,10 @@
   "errors": {
     "contactUs": "Un problème, une suggestion ? Contactez-nous à"
   },
+  "software": {
+    "id": "amiral",
+    "name": "Cloud Personnel"
+  },
   "screens": {
     "cozyNotFound": {
       "title": "L'adresse de ce Cozy n'existe pas.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14572,6 +14572,11 @@ react-native-codegen@^0.0.7:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
+react-native-device-info@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-10.0.2.tgz#17cd96df277cca5a22fb80409527c181a08d4ed1"
+  integrity sha512-6XY8EctYqNEX6EHDoHxz3yONOYxCHKrgEdStP7HZDYzFXb1JB5BFt7UbXDWrmihXUZDv06sBsjN26+Tp0EajXw==
+
 react-native-flipper@^0.146.1:
   version "0.146.1"
   resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.146.1.tgz#b6bbb23edc347597788bdca4c89b58bad425e1a1"


### PR DESCRIPTION
In order to avoid users seeing Amiral connected into their Cozy.

react-native-device-info needs to use JDK 11+, not JDK 8.

To install Open JDK11 on OSX:
`brew install --cask adoptopenjdk11`

To use correct PATH, before running `yarn android`
`PATH="/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/bin:$PATH"`

#### Checklist

* [x] Tested on iOS
* [x] Tested on Android
* [ ] Localized in English and French
* [ ] Updated README & CHANGELOG, if necessary

My Android:

![Capture d’écran 2022-07-21 à 15 22 05](https://user-images.githubusercontent.com/8363334/180226352-f08971f1-152d-482c-b382-7929cc597e5c.png)

My iOS emulator:

![Capture d’écran 2022-07-21 à 11 52 49](https://user-images.githubusercontent.com/8363334/180226384-897a1bdf-2be5-4d22-a64a-ee909776c8dc.png)

