### PR TITLE
feat: Initializing store at start

### DIFF
--- a/connectors/connectorLibs/ContentScript.js
+++ b/connectors/connectorLibs/ContentScript.js
@@ -55,6 +55,7 @@ export default class ContentScript {
     for (const method of exposedMethodsNames) {
       exposedMethods[method] = this[method].bind(this)
     }
+    this.store = {}
     await this.bridge.init({ exposedMethods })
     window.onbeforeunload = () =>
       this.log(
@@ -383,10 +384,6 @@ export default class ContentScript {
    * @param {Object} : any object with data to store
    */
   async storeFromWorker(obj) {
-    if (!this.store) {
-      this.store = {}
-    }
-
     Object.assign(this.store, obj)
   }
 


### PR DESCRIPTION
Slight modification on the ContentScript of CCC to initialize the store at start instead of waiting for first occurence of `sendToPilot` method in konnectors.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

