### PR TITLE
fix: Android build is failing, suggest solution

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,4 +35,9 @@ allprojects {
         google()
         maven { url 'https://www.jitpack.io' }
     }
+
+    
+    // For unknown reasons at this time, the build fails with Javadoc tasks on JDK11
+    // A temporary workaround for that is to disable Javadoc generation for all modules
+    // tasks.withType(Javadoc).all { enabled = false }
 }


### PR DESCRIPTION
Javadoc fails to correctly operates on some dependencies with jdk11.
This commit adds a commented out line that will fix this issue if needed