### PR TITLE
feat: Use production URL for ClouderyView

### DIFF
--- a/src/strings.json
+++ b/src/strings.json
@@ -15,8 +15,8 @@
       "backButton": "RETOUR À MON COZY"
     }
   },
-  "clouderyiOSUri": "https://staging-manager.cozycloud.cc/v2/cozy/start?redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
-  "clouderyAndroidUri": "https://staging-manager.cozycloud.cc/v2/cozy/start?redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "clouderyiOSUri": "https://manager.cozycloud.cc/v2/cozy/start?redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "clouderyAndroidUri": "https://manager.cozycloud.cc/v2/cozy/start?redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
   "defaultHttpScheme": "https://",
   "emptyString": "",
   "environments": {


### PR DESCRIPTION
Cloudery's staging URL was used during development phase

Now that production Cloudery has been updated with latest features we
can use it's production URL in the app