### PR TITLE
fix: Do not use `html` as a condition to display CozyProxyWebView

### DIFF
--- a/src/components/webviews/CozyProxyWebView.js
+++ b/src/components/webviews/CozyProxyWebView.js
@@ -110,7 +110,7 @@ export const CozyProxyWebView = ({ slug, href, style, ...props }) => {
 
   return (
     <View style={{ ...styles.view, ...style }}>
-      {state.source && state.html ? (
+      {state.source ? (
         <CozyWebView
           source={state.source}
           nativeConfig={state.nativeConfig}


### PR DESCRIPTION
Since `source` and `html` are now sync, and because `html` should be
null when `source` targets the cozy-stack, then we should not use
`html` as a condition to display the WebView

If it was used as a condition we would not be able to display cozy-apps
from cozy-stack as `html` is null in that case (it is used only when
cozy-apps are served from local assets)

Related PR: #374