### PR TITLE
fix: Intercept outgoing navigation also on Android

### DIFF
--- a/src/components/webviews/ReloadInterceptorWebView.js
+++ b/src/components/webviews/ReloadInterceptorWebView.js
@@ -55,7 +55,22 @@ const ReloadInterceptorWebView = React.forwardRef((props, ref) => {
 
   if (!source.html) {
     // Blocking this feature, when source={{ uri }} is set
-    return <SupervisedWebView {...props} ref={ref} {...userAgent} />
+    return (
+      <SupervisedWebView
+        {...props}
+        ref={ref}
+        {...userAgent}
+        onShouldStartLoadWithRequest={initialRequest => {
+          const isRedirect = isRedirectOutside(initialRequest.url, targetUri)
+
+          if (isRedirect) {
+            return false
+          }
+
+          return onShouldStartLoadWithRequest(initialRequest)
+        }}
+      />
+    )
   }
 
   return (


### PR DESCRIPTION
In previous commit we removed reload interception for Android as the
method was not reachable with Android's WebView configuration

But we still want to intercept navigations that leave the app (i.e
change of url domain) like in 4ddb2ace27bbd913451373d6ea660e0ca1cd1b00

This prevents some scenario where a cozy-app use `window.location.href`
to handle navigation (i.e: opening `notes` from `drive`) instead of
calling `openApp`

When this happens, the new cozy-app is loaded with the new URL but the
`index.html` route still returns the inject `html` content from the
previous cozy-app (using `nativeConfig` and `injectedIndex` props)

By intercepting navigation we prevents this scenario to happen and we
can warn the developer that the navigation is done the wrong way by
logging an error message in the console

Related PR: #382