### PR TITLE
fix: Handle capabilities as object

### DIFF
--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -5,6 +5,11 @@ import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-
 jest.mock('react-native-device-info', () => mockRNDeviceInfo)
 jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage)
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo)
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+  init: jest.fn(),
+  setTag: jest.fn()
+}))
 
 jest.mock(
   '../src/api-keys.json',

--- a/src/Sentry.js
+++ b/src/Sentry.js
@@ -31,3 +31,7 @@ Sentry.setTag(SentryTags.Version, version)
 export const withSentry = Sentry.wrap
 
 export const setSentryTag = (tag, value) => Sentry.setTag(tag, value)
+
+export const logToSentry = error => {
+  Sentry.captureException(error)
+}

--- a/src/libs/httpserver/indexDataFetcher.js
+++ b/src/libs/httpserver/indexDataFetcher.js
@@ -1,40 +1,60 @@
 import { replaceAll } from '../functions/stringHelpers'
 import { fetchCozyDataForSlug } from '../client'
 import { getCookie } from './httpCookieManager'
+import { logToSentry } from '/Sentry'
 
 export const fetchAppDataForSlug = async (slug, client) => {
-  const storedCookie = await getCookie(client)
-  const cozyDataResult = await fetchCozyDataForSlug(slug, client, storedCookie)
+  try {
+    const storedCookie = await getCookie(client)
+    const cozyDataResult = await fetchCozyDataForSlug(
+      slug,
+      client,
+      storedCookie
+    )
 
-  const { Cookie: cookie, ...cozyDataAttributes } =
-    cozyDataResult.data.attributes
+    const { Cookie: cookie, ...cozyDataAttributes } =
+      cozyDataResult.data.attributes
 
-  const cozyData = {
-    app: {
-      editor: cozyDataAttributes.AppEditor,
-      icon: cozyDataAttributes.IconPath,
-      name: cozyDataAttributes.AppName,
-      prefix: cozyDataAttributes.AppNamePrefix,
-      slug: cozyDataAttributes.AppSlug
-    },
-    capabilities: cozyDataAttributes.Capabilities,
-    domain: cozyDataAttributes.Domain,
-    flags: JSON.parse(cozyDataAttributes.Flags),
-    locale: cozyDataAttributes.Locale,
-    subdomain: cozyDataAttributes.SubDomain,
-    token: cozyDataAttributes.Token,
-    tracking: cozyDataAttributes.Tracking
-  }
-
-  let cozyDataString = JSON.stringify(cozyData)
-  cozyDataString = replaceAll(cozyDataString, '"', '&#34;')
-  cozyDataAttributes.Flags = replaceAll(cozyDataAttributes.Flags, '"', '&#34;')
-
-  return {
-    cookie,
-    templateValues: {
-      ...cozyDataAttributes,
-      CozyData: cozyDataString
+    const cozyData = {
+      app: {
+        editor: cozyDataAttributes.AppEditor,
+        icon: cozyDataAttributes.IconPath,
+        name: cozyDataAttributes.AppName,
+        prefix: cozyDataAttributes.AppNamePrefix,
+        slug: cozyDataAttributes.AppSlug
+      },
+      capabilities: JSON.parse(cozyDataAttributes.Capabilities),
+      domain: cozyDataAttributes.Domain,
+      flags: JSON.parse(cozyDataAttributes.Flags),
+      locale: cozyDataAttributes.Locale,
+      subdomain: cozyDataAttributes.SubDomain,
+      token: cozyDataAttributes.Token,
+      tracking: cozyDataAttributes.Tracking
     }
+
+    let cozyDataString = JSON.stringify(cozyData)
+    cozyDataString = replaceAll(cozyDataString, '"', '&#34;')
+
+    cozyDataAttributes.Flags = replaceAll(
+      cozyDataAttributes.Flags,
+      '"',
+      '&#34;'
+    )
+
+    cozyDataAttributes.Capabilities = replaceAll(
+      cozyDataAttributes.Capabilities,
+      '"',
+      '&#34;'
+    )
+
+    return {
+      cookie,
+      templateValues: {
+        ...cozyDataAttributes,
+        CozyData: cozyDataString
+      }
+    }
+  } catch (error) {
+    logToSentry(error)
   }
 }

--- a/src/libs/httpserver/indexDataFetcher.spec.js
+++ b/src/libs/httpserver/indexDataFetcher.spec.js
@@ -72,11 +72,11 @@ const expectedResult = {
     AppNamePrefix: 'Cozy',
     AppSlug: 'home',
     Capabilities:
-      '{"file_versioning":true,"flat_subdomains":false,"can_auth_with_password":true,"can_auth_with_oidc":false}',
+      '{&#34;file_versioning&#34;:true,&#34;flat_subdomains&#34;:false,&#34;can_auth_with_password&#34;:true,&#34;can_auth_with_oidc&#34;:false}',
     CozyBar: '<script src="https://URL_TO_COZY_BAR_JS"></script>',
     CozyClientJS: '<script src="https://URL_TO_COZY_CLIENT_JS"></script>',
     CozyData:
-      '{&#34;app&#34;:{&#34;editor&#34;:&#34;Cozy&#34;,&#34;icon&#34;:&#34;icon.svg&#34;,&#34;name&#34;:&#34;Home&#34;,&#34;prefix&#34;:&#34;Cozy&#34;,&#34;slug&#34;:&#34;home&#34;},&#34;capabilities&#34;:&#34;{\\&#34;file_versioning\\&#34;:true,\\&#34;flat_subdomains\\&#34;:false,\\&#34;can_auth_with_password\\&#34;:true,\\&#34;can_auth_with_oidc\\&#34;:false}&#34;,&#34;domain&#34;:&#34;cozy.10-0-2-2.nip.io:8080&#34;,&#34;flags&#34;:{&#34;harvest.datacards.files&#34;:true},&#34;locale&#34;:&#34;en&#34;,&#34;subdomain&#34;:&#34;nested&#34;,&#34;token&#34;:&#34;SOME_TOKEN&#34;,&#34;tracking&#34;:&#34;false&#34;}',
+      '{&#34;app&#34;:{&#34;editor&#34;:&#34;Cozy&#34;,&#34;icon&#34;:&#34;icon.svg&#34;,&#34;name&#34;:&#34;Home&#34;,&#34;prefix&#34;:&#34;Cozy&#34;,&#34;slug&#34;:&#34;home&#34;},&#34;capabilities&#34;:{&#34;file_versioning&#34;:true,&#34;flat_subdomains&#34;:false,&#34;can_auth_with_password&#34;:true,&#34;can_auth_with_oidc&#34;:false},&#34;domain&#34;:&#34;cozy.10-0-2-2.nip.io:8080&#34;,&#34;flags&#34;:{&#34;harvest.datacards.files&#34;:true},&#34;locale&#34;:&#34;en&#34;,&#34;subdomain&#34;:&#34;nested&#34;,&#34;token&#34;:&#34;SOME_TOKEN&#34;,&#34;tracking&#34;:&#34;false&#34;}',
     DefaultWallpaper: 'https://URL_TO_WALLPAPER',
     Domain: 'cozy.10-0-2-2.nip.io:8080',
     Favicon: `<link rel="icon" href="https://URL_TO_FAVICON_ICO.ico">`,


### PR DESCRIPTION
Capabilites suffered the same issues as flag object.
Due to multiple stringify and the fact these values are object,
there was a mistake where there were scoped into quotes in the end json
This is not valid JSON so it made the whole app bootstrap crash.
parsing/stringifying JSON is inherently risky, what should we do,
except logging, when an error arises here?
