### PR TITLE
fix: Log errors in catch statements

### DIFF
--- a/src/libs/functions/iconTable.js
+++ b/src/libs/functions/iconTable.js
@@ -110,7 +110,7 @@ const clearPersistentIconTable = async () => {
   try {
     await AsyncStorage.removeItem(strings.APPS_ICONS)
   } catch (error) {
-    log.info(strings.errors.clearPersistentIconTable, error)
+    log.error(strings.errors.clearPersistentIconTable, error)
   }
 }
 

--- a/src/libs/services/NetService.js
+++ b/src/libs/services/NetService.js
@@ -13,7 +13,7 @@ export const _netInfoChangeHandler = (state, callbackRoute = routes.stack) => {
   try {
     state.isConnected && reset(callbackRoute)
   } catch (error) {
-    log.debug(error)
+    log.error(error)
   }
 }
 


### PR DESCRIPTION
Using log.error will get caught by Sentry
