### PR TITLE
fix: Don't intercept cozy download links

### DIFF
--- a/src/components/webviews/ReloadInterceptorWebView.js
+++ b/src/components/webviews/ReloadInterceptorWebView.js
@@ -11,6 +11,7 @@ import { userAgentDefault } from '/constants/userAgent'
 
 import { navigateToApp } from '/libs/functions/openApp'
 import {
+  checkIsCozyDownloadLink,
   checkIsReload,
   checkIsRedirectOutside,
   checkIsSameApp,
@@ -51,6 +52,16 @@ const interceptNavigation = ({
       onReloadInterception()
       return false
     }
+  }
+
+  const isCozyDownloadLink = checkIsCozyDownloadLink({
+    currentUrl: targetUri,
+    destinationUrl: initialRequest.url,
+    subdomainType
+  })
+
+  if (isCozyDownloadLink) {
+    return true
   }
 
   const newSlug = checkIsSlugSwitch({

--- a/src/libs/functions/urlHelpers.js
+++ b/src/libs/functions/urlHelpers.js
@@ -84,6 +84,35 @@ export const checkIsSlugSwitch = ({
   }
 }
 
+export const checkIsCozyDownloadLink = ({
+  currentUrl,
+  destinationUrl,
+  subdomainType = 'flat'
+}) => {
+  try {
+    const currentUrlData = deconstructCozyWebLinkWithSlug(
+      currentUrl,
+      subdomainType
+    )
+    const destinationUrlData = new URL(destinationUrl)
+
+    const currentCozy = `${currentUrlData.cozyName}.${currentUrlData.cozyBaseDomain}`
+
+    if (currentCozy !== destinationUrlData.host) {
+      return false
+    }
+
+    if (destinationUrlData.pathname.startsWith('/files/downloads/')) {
+      return true
+    }
+
+    return false
+  } catch (err) {
+    log.error('Error while calling checkIsSlugSwitch', err)
+    return false
+  }
+}
+
 export const checkIsSameApp = ({
   currentUrl,
   destinationUrl,

--- a/src/libs/functions/urlHelpers.spec.js
+++ b/src/libs/functions/urlHelpers.spec.js
@@ -1,6 +1,7 @@
 import RN from 'react-native'
 
 import {
+  checkIsCozyDownloadLink,
   checkIsReload,
   checkIsRedirectOutside,
   checkIsSameApp,
@@ -195,6 +196,98 @@ describe('urlHelpers', () => {
       (currentUrl, destinationUrl, subdomainType, result) => {
         expect(
           checkIsSlugSwitch({ currentUrl, destinationUrl, subdomainType })
+        ).toEqual(result)
+      }
+    )
+  })
+
+  describe('checkIsCozyDownloadLink', () => {
+    it.each([
+      [
+        'http://drive.claude.mycozy.cloud',
+        'http://drive.claude.mycozy.cloud',
+        'nested',
+        false
+      ],
+      [
+        'http://drive.claude.mycozy.cloud#hash1',
+        'http://drive.claude.mycozy.cloud#hash2',
+        'nested',
+        false
+      ],
+      [
+        'http://drive.claude.mycozy.cloud/path1',
+        'http://drive.claude.mycozy.cloud/path2',
+        'nested',
+        false
+      ],
+      [
+        'http://drive.claude.mycozy.cloud/path1#hash1',
+        'http://drive.claude.mycozy.cloud/path1#hash2',
+        'nested',
+        false
+      ],
+      [
+        'http://drive.claude.mycozy.cloud',
+        'http://notes.claude.mycozy.cloud',
+        'nested',
+        false
+      ],
+      [
+        'http://drive.claude.mycozy.cloud',
+        'http://google.com',
+        'nested',
+        false
+      ],
+      [
+        'http://claude-drive.mycozy.cloud',
+        'http://claude-drive.mycozy.cloud',
+        'flat',
+        false
+      ],
+      [
+        'http://claude-drive.mycozy.cloud#hash1',
+        'http://claude-drive.mycozy.cloud#hash2',
+        'flat',
+        false
+      ],
+      [
+        'http://claude-drive.mycozy.cloud/path1',
+        'http://claude-drive.mycozy.cloud/path2',
+        'flat',
+        false
+      ],
+      [
+        'http://claude-drive.mycozy.cloud/path1#hash1',
+        'http://claude-drive.mycozy.cloud/path1#hash2',
+        'flat',
+        false
+      ],
+      [
+        'http://claude-drive.mycozy.cloud',
+        'http://claude-notes.mycozy.cloud',
+        'flat',
+        false
+      ],
+      ['http://claude-drive.mycozy.cloud', 'http://google.com', 'flat', false],
+      ['http://claude-drive.mycozy.cloud', 'google.com', 'flat', false],
+      [
+        'http://claude-drive.cozy.works',
+        'https://claude.cozy.works/files/downloads/SOME_ID/SOME_NAME.SOME_EXTENSION?Dl=1',
+        'flat',
+        true
+      ],
+      [
+        'http://drive.claude.cozy.works',
+        'https://claude.cozy.works/files/downloads/SOME_ID/SOME_NAME.SOME_EXTENSION?Dl=1',
+        'nested',
+        true
+      ]
+    ])(
+      'should compare %p with %p with %p subdomain and return sCozyDownloadLink=%p',
+      (currentUrl, destinationUrl, subdomainType, result) => {
+        expect(
+          checkIsCozyDownloadLink({ currentUrl, destinationUrl, subdomainType })
         ).toEqual(result)
       }
     )


### PR DESCRIPTION
On Android, download links are functional and are handled automatically
by the webView

With current implementation, those are intercepted by
`interceptNavigation` as they are considered as outgoing links. So
nothing happens when clicking on download links

Instead we want `interceptNavigation` to let the navigation happen

On iOS, download links are disabled until we correctly handle downloads
from the iOS webView. So this commit should not impact iOS yet