### PR TITLE
feat: Allow the user to "fake" activate biometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cozy-client-js": "^0.20.0",
     "cozy-device-helper": "^2.2.0",
     "cozy-flags": "^2.9.0",
-    "cozy-intent": "^2.2.0",
+    "cozy-intent": "^2.4.0",
     "cozy-logger": "^1.9.0",
     "cozy-ui": "52.0.1",
     "ky": "0.25.1",

--- a/src/components/webviews/CozyWebView.js
+++ b/src/components/webviews/CozyWebView.js
@@ -19,6 +19,10 @@ import { useSession } from '/hooks/useSession'
 import ReloadInterceptorWebView from '/components/webviews/ReloadInterceptorWebView'
 import { getHostname } from '/libs/functions/getHostname'
 import { useIsSecureProtocol } from '/hooks/useIsSecureProtocol'
+import {
+  BiometryEmitter,
+  makeBiometryInjection
+} from '/libs/intents/setBiometryState'
 
 const log = Minilog('CozyWebView')
 
@@ -109,6 +113,18 @@ export const CozyWebView = ({
   `
 
   const webviewSource = source.html ? source : { uri }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const injectSettings = async () =>
+    webviewRef.injectJavaScript(await makeBiometryInjection())
+
+  useEffect(() => {
+    webviewRef && injectSettings()
+
+    BiometryEmitter.on('change', injectSettings)
+
+    return () => BiometryEmitter.off('change', injectSettings)
+  }, [injectSettings, webviewRef])
 
   return uri ? (
     <ReloadInterceptorWebView

--- a/src/libs/intents/localMethods.js
+++ b/src/libs/intents/localMethods.js
@@ -1,13 +1,14 @@
 import * as RootNavigation from '../RootNavigation'
+import strings from '/strings'
+import { EnvService } from '/libs/services/EnvService'
 import { clearClient } from '../client'
 import { deleteKeychain } from '../keychain'
 import { hideSplashScreen } from '../services/SplashScreenService'
 import { openApp } from '../functions/openApp'
 import { resetSessionToken } from '../functions/session'
+import { openSettingBiometry } from '/libs/intents/setBiometryState'
 import { setFlagshipUI } from './setFlagshipUI'
-import { EnvService } from '/libs/services/EnvService'
 import { showInAppBrowser, closeInAppBrowser } from './InAppBrowser'
-import strings from '/strings'
 
 export const asyncLogout = async () => {
   await clearClient()
@@ -65,13 +66,14 @@ export const internalMethods = {
 export const localMethods = client => {
   return {
     backToHome,
+    closeInAppBrowser,
+    fetchSessionCode: fetchSessionCodeWithClient(client),
     hideSplashScreen,
     logout,
     openApp: (href, app, iconParams) =>
       openApp(RootNavigation, href, app, iconParams),
+    openSettingBiometry,
     setFlagshipUI,
-    showInAppBrowser,
-    closeInAppBrowser,
-    fetchSessionCode: fetchSessionCodeWithClient(client)
+    showInAppBrowser
   }
 }

--- a/src/libs/intents/setBiometryState.spec.ts
+++ b/src/libs/intents/setBiometryState.spec.ts
@@ -1,0 +1,31 @@
+import { StorageKeys, storeData } from '/libs/localStore/storage'
+import { makeBiometryInjection } from '/libs/intents/setBiometryState'
+
+it('should not throw with a null hasBiometry', async () => {
+  const result = await makeBiometryInjection()
+  expect(result).toStrictEqual('window.cozy.flagship.hasBiometry = false;')
+})
+
+it('should handle true value', async () => {
+  await storeData(StorageKeys.BiometryActivated, true)
+  const result = await makeBiometryInjection()
+  expect(result).toStrictEqual('window.cozy.flagship.hasBiometry = true;')
+})
+
+it('should handle truthy value', async () => {
+  await storeData(StorageKeys.BiometryActivated, 'true')
+  const result = await makeBiometryInjection()
+  expect(result).toStrictEqual('window.cozy.flagship.hasBiometry = true;')
+})
+
+it('should handle false value', async () => {
+  await storeData(StorageKeys.BiometryActivated, false)
+  const result = await makeBiometryInjection()
+  expect(result).toStrictEqual('window.cozy.flagship.hasBiometry = false;')
+})
+
+it('should handle falsy value', async () => {
+  await storeData(StorageKeys.BiometryActivated, '')
+  const result = await makeBiometryInjection()
+  expect(result).toStrictEqual('window.cozy.flagship.hasBiometry = false;')
+})

--- a/src/libs/intents/setBiometryState.ts
+++ b/src/libs/intents/setBiometryState.ts
@@ -1,0 +1,47 @@
+import { Alert } from 'react-native'
+import { EventEmitter } from 'events'
+
+import { getData, StorageKeys, storeData } from '../localStore/storage'
+
+export const BiometryEmitter = new EventEmitter()
+
+const updateBiometrySetting = async (activated: boolean): Promise<boolean> => {
+  await storeData(StorageKeys.BiometryActivated, activated)
+  const newData = Boolean(await getData(StorageKeys.BiometryActivated))
+
+  BiometryEmitter.emit('change', newData)
+
+  return newData
+}
+
+export const openSettingBiometry = (): Promise<boolean> => {
+  return new Promise<boolean>(resolve => {
+    Alert.alert(
+      'Biometry Activation',
+      'Do you wish to activate biometric features?',
+      [
+        {
+          text: 'No',
+          onPress: (): void => {
+            updateBiometrySetting(false)
+              .then(v => resolve(v))
+              .catch(e => resolve(e))
+          }
+        },
+        {
+          text: 'Yes',
+          onPress: (): void => {
+            updateBiometrySetting(true)
+              .then(v => resolve(v))
+              .catch(e => resolve(e))
+          }
+        }
+      ]
+    )
+  })
+}
+
+export const makeBiometryInjection = async (): Promise<string> =>
+  `window.cozy.flagship.hasBiometry = ${JSON.stringify(
+    Boolean(await getData(StorageKeys.BiometryActivated))
+  )};`

--- a/src/libs/localStore/storage.spec.ts
+++ b/src/libs/localStore/storage.spec.ts
@@ -1,0 +1,67 @@
+import {
+  getData as initialGetData,
+  storeData as initialStoreData
+} from '/libs/localStore/storage'
+
+const getData = initialGetData as (name: string) => Promise<unknown>
+const storeData = initialStoreData as (
+  name: string,
+  value: unknown
+) => Promise<unknown>
+
+it('should store and retrieve a string value', async () => {
+  const key = 'string'
+  const value = 'test'
+  await storeData(key, value)
+  const result = await getData(key)
+  expect(result).toStrictEqual(value)
+})
+
+it('should store and retrieve an object value', async () => {
+  const key = 'object'
+  const value = { test: 'test' }
+  await storeData(key, value)
+  const result = await getData(key)
+  expect(result).toStrictEqual(value)
+})
+
+it('should store and retrieve an array value', async () => {
+  const key = 'array'
+  const value = ['test', 'test']
+  await storeData(key, value)
+  const result = await getData(key)
+  expect(result).toStrictEqual(value)
+})
+
+it('should store and retrieve a number value', async () => {
+  const key = 'number'
+  const value = 123
+  await storeData(key, value)
+  const result = await getData(key)
+  expect(result).toStrictEqual(value)
+})
+
+it('should store and retrieve a boolean value', async () => {
+  const key = 'boolean'
+  const value = false
+  await storeData(key, value)
+  const result = await getData(key)
+  expect(result).toStrictEqual(value)
+})
+
+it('should store and retrieve a null value', async () => {
+  const key = 'null'
+  const value = null
+  await storeData(key, value)
+  const result = await getData(key)
+  expect(result).toStrictEqual(value)
+})
+
+it('should not store and retrieve an undefined value', async () => {
+  const key = 'undefined'
+  const value = undefined
+  await storeData(key, value)
+  const result = await getData(key)
+  expect(result).not.toStrictEqual(value)
+  expect(result).toStrictEqual(null)
+})

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -1,0 +1,48 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+import { logger } from '/libs/functions/logger'
+
+const log = logger('storage.ts')
+
+const { setItem, getItem } = AsyncStorage
+
+export enum StorageKeys {
+  BiometryActivated = '@cozy_AmiralApp_biometryActivated',
+  Capabilities = '@cozy_AmiralApp_Capabilities',
+  SessionCreatedFlag = 'SESSION_CREATED_FLAG'
+}
+
+interface StorageItems {
+  biometryActivated: boolean
+  capabilities: {
+    hasBiometry: boolean
+    biometryType: 'FaceID' | 'TouchID' | 'Fingerprint' | 'Unknown'
+  }
+  sessionCreatedFlag: string
+}
+
+export const storeData = async (
+  name: StorageKeys,
+  value: StorageItems[keyof StorageItems]
+): Promise<void> => {
+  try {
+    await setItem(name, JSON.stringify(value))
+  } catch (error) {
+    log.error(`Failed to store key "${name}" to persistent storage`, error)
+  }
+}
+
+export const getData = async (
+  name: StorageKeys
+): Promise<StorageItems[keyof StorageItems] | null> => {
+  try {
+    const value = await getItem(name)
+
+    return value !== null
+      ? (JSON.parse(value) as StorageItems[keyof StorageItems])
+      : null
+  } catch (error) {
+    log.error(`Failed to get key "${name}" from persistent storage`, error)
+    return null
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6543,10 +6543,10 @@ cozy-flags@^2.9.0:
   dependencies:
     microee "^0.0.6"
 
-cozy-intent@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.2.0.tgz#bb32115c48bf239338166b90aaa2171f8295b8d5"
-  integrity sha512-DbThgCn3BkHfbe/zzofbzGuzLtSV/dkbuTV+pFKRDxTp3+qe1QsiFZtBS7ClcjPVP/kYKVTPv2gGnpejIgBx5g==
+cozy-intent@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.4.0.tgz#f2e1900798e60e3e63c1c4fce13c79baab91e09f"
+  integrity sha512-bW6Jbn/BnPnKttHWxgOe79jUgYhK5lfVwUP+icxp7ZCt3FNsTYX0bZ36PS8zV3j0F8s11kU8wvtMcRxkQ8R87Q==
   dependencies:
     post-me "0.4.5"
 


### PR DESCRIPTION
### Feature

This allows a user to activate or deactivate his app to be locked using biometry input (fingerprint etc.). Please see [this ticket](https://trello.com/c/BELZvEgc/576-%F0%9F%91%87-biometrie-activer-loption-biom%C3%A9trie-en-fake-jh-1-2j)

### Context

This fits into the broader Epic feature of activating biometry interactions on the Flagship App. The goal here is to implement step by step so multiple PRs are needed, or it would be impossible to review.

### Implementation

Adding a new Native intent to open management of settings
Adding a new lib to provide a facade to AsyncStorage for these settings
Plugging these APIs into CozyWebView so it can work with cozy-apps

### Testing

No specific testing was done as I'm waiting for more real implementations to be here (like fingerprint input).

### Screenshots

![image](https://user-images.githubusercontent.com/12577784/188568978-b38ad014-6db1-451d-ac4c-af3b4a5b98f5.png)

### Thoughts

Not much to say here it's pretty straightforward. Maybe need to create a sort of service or something to handle all the future settings activation/deactivation/injection/real-time injection in a DRY way.
