### PR TITLE
fix: Do not intercept `/?refreshToken` requests in Android

### DIFF
--- a/android/app/src/main/java/io/cozy/flagship/mobile/webview/IndexInjectionWebViewManager.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/webview/IndexInjectionWebViewManager.java
@@ -58,7 +58,8 @@ public class IndexInjectionWebViewManager extends RNCWebViewManager {
       Uri uri = request.getUrl();
 
       String path = uri.getPath();
-      if (path != null && (path.equals("/") || path.equals("/index.html"))) {
+      String refreshTokenParam = uri.getQueryParameter("refreshToken");
+      if ((path != null && (path.equals("/") || path.equals("/index.html"))) && refreshTokenParam == null) {
         String htmlToInject = ((IndexInjectionWebView) view).getInjectedIndex();
 
         if (htmlToInject == null) {


### PR DESCRIPTION
With the HttpServer, Android is configured to inject the local
`index.html` on each request to `/` or to `/index.html`

As local `index.html` is generated before loading the webView and
because it is not updated after that, if the cozy-app in webView
requires to refresh its token, then `/?refreshToken` is requested and
will be intercepted to serve the same `index.html` with the same
expired token

Instead it should be served from the cozy-stack with a new refreshed
token

So we don't want to intercept those requests if `refreshToken`
parameter is set
