### PR TITLE
feat: Bump app version to 0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,25 @@
-# 0.0.25
+# 0.0.26
 
 ## ✨ Features
 
 
 ## 🐛 Bug Fixes
 
+
+## 🔧 Tech
+
+
+# 0.0.25
+
+## ✨ Features
+
+* Intercept downloads on iOS and open QuickLook instead ([PR #399](https://github.com/cozy/cozy-react-native/pull/399))
+* Intercept PDF downloads on Android and open FileViewer instead ([PR #399](https://github.com/cozy/cozy-react-native/pull/399))
+* Add support for Android's Share feature ([PR #406](https://github.com/cozy/cozy-react-native/pull/406))
+
+## 🐛 Bug Fixes
+
+* Correctly handle RefreshTokens queries on Android ([PR #404](https://github.com/cozy/cozy-react-native/pull/404))
 
 ## 🔧 Tech
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2401
-        versionName "0.0.24"
+        versionCode 2501
+        versionName "0.0.25"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.24</string>
+	<string>0.0.25</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0002401</string>
+	<string>0002501</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.25
- creates a new entry for next 0.0.26 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs