### PR TITLE
fix: Set correct destination URL when intercepting outgoing links

### DIFF
--- a/src/components/webviews/ReloadInterceptorWebView.js
+++ b/src/components/webviews/ReloadInterceptorWebView.js
@@ -103,7 +103,7 @@ const interceptNavigation = ({
   })
 
   if (isRedirectOutside) {
-    openUrlInAppBrowser(targetUri)
+    openUrlInAppBrowser(initialRequest.url)
     return false
   }
 


### PR DESCRIPTION
In interceptNavigation we should use `initialRequest.url` as destination URL

`targetUri` represents the webView's URL to be displayed when the webView component is created
