### PR TITLE
fix: Do not serve `cozy-settings` through HttpServer on iOS

### DIFF
--- a/src/libs/httpserver/indexGenerator.js
+++ b/src/libs/httpserver/indexGenerator.js
@@ -21,7 +21,12 @@ const log = Minilog('IndexGenerator')
 // the list slugs to be injected using HttpServer
 // Instead those slugs will be served from cozy-stack
 const slugBlocklist = [
-  { platform: 'ios', slug: 'mespapiers' } // mespapiers cannot be injected until we fix window.history bug on iOS
+  // mespapiers cannot be injected until we fix window.history bug on iOS
+  { platform: 'ios', slug: 'mespapiers' },
+
+  // settings cannot be injected until we modernize it by doing all queries through
+  // cozy-client and correctly handle `https` override with `isSecureProtocol` parameter
+  { platform: 'ios', slug: 'settings' }
 ]
 
 const initLocalBundleIfNotExist = async (fqdn, slug) => {


### PR DESCRIPTION
Current HttpServer implementation needs the iOS' WebView to serve `index.html` with an `http` scheme in order to allow 3rd party cookies that are needed to communicate with both the local server and the cozy-stack

Due to this mechanism we had to implement support for `isSecureProtocol` param on cozy-client so connection to cozy-stack would be done using `https` even if the WebView's url is using `http`

Unfortunately `cozy-settings` still does some queries to cozy-client without using cozy-client and so the `https` override is not handled

To fix this, we temporarily disable HttpServer for `cozy-settings` on iOS until we fix this behaviour

