### PR TITLE
fix: Correctly handle `Share` url on Android

### DIFF
--- a/src/components/webviews/jsInteractions/jsEnsureNavigatorShare.ts
+++ b/src/components/webviews/jsInteractions/jsEnsureNavigatorShare.ts
@@ -1,4 +1,4 @@
-import { Share } from 'react-native'
+import { Platform, Share } from 'react-native'
 import { WebViewMessageEvent } from 'react-native-webview/lib/WebViewTypes'
 import { OnAnswerCallback, SubscriberPayload } from './types'
 
@@ -87,7 +87,7 @@ export const tryNavigatorShare = async (
     try {
       const result = await Share.share({
         title,
-        message,
+        message: Platform.OS === 'android' ? `${message} ${url}` : message,
         url
       })
 


### PR DESCRIPTION
As described in the `Share` documentation, the `url` parameter is handled only on iOS

On Android we want to concatenate the `url` parameter to the `message` one so the generated sharing text contains it

More info: https://reactnative.dev/docs/share#share
