### PR TITLE
feat: Adding requestOptions possibility in saveFiles

### DIFF
--- a/connectors/connectorLibs/ContentScript.js
+++ b/connectors/connectorLibs/ContentScript.js
@@ -209,7 +209,7 @@ export default class ContentScript {
     const filteredEntries = this.filterOutExistingFiles(entries, options)
     for (const entry of filteredEntries) {
       if (entry.fileurl) {
-        entry.blob = await ky.get(entry.fileurl).blob()
+        entry.blob = await ky.get(entry.fileurl, entry.requestOptions).blob()
         delete entry.fileurl
       }
       if (entry.blob) {


### PR DESCRIPTION
Adding entry.requestOption to saveFiles allowing to give options such has specific headers.
This was mandatory to get AlanCCC working properly as the pilot needed a tokenBearer to download documents.
It might be useful for other CCC later.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

