### PR TITLE
fix: Do not `setUri` on HomeView's blur if no `trackedWebviewInnerUri`

### DIFF
--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -38,7 +38,9 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
   useEffect(() => {
     const unsubscribe = navigation.addListener('blur', () => {
       didBlurOnce.current = true
-      setUri(trackedWebviewInnerUri)
+      if (trackedWebviewInnerUri) {
+        setUri(trackedWebviewInnerUri)
+      }
     })
 
     return unsubscribe


### PR DESCRIPTION
#82 introduced `trackedWebviewInnerUri` state to keep track of WebView's URI

On HomeView's blur, we would synchronize latest
`trackedWebviewInnerUri` state into the `uri` state

If the first user's action into the WebView is to open a cozy-app, then the HomeView's would blur with `trackedWebviewInnerUri` being null (because no navigation occurred inside of the WebView to trigger the `setTrackedWebviewInnerUri` event)

This would result to calling `setUri(null)` in the blur event

This behaviour was invisible to the user as `uri` would be set to cozy-home's root URL directly after that

But a side effect of this is the CozyProxyWebView being unmount and remount, which would trigger the `index.html` generation process, which is unwanted

By conditionally calling `setUri` based on `trackedWebviewInnerUri` nullity will prevent this behaviour
