### PR TITLE
feat: Allow to disable indexGenerator test locally

### DIFF
--- a/src/libs/httpserver/indexGenerator.spec.js
+++ b/src/libs/httpserver/indexGenerator.spec.js
@@ -1,6 +1,7 @@
 import RN from 'react-native'
 import RNFS from 'react-native-fs'
 
+import { devConfig } from '/config/dev'
 import { fillIndexWithData, getIndexForFqdnAndSlug } from './indexGenerator'
 
 import {
@@ -46,7 +47,9 @@ jest.mock('./httpPaths', () => ({
       .getBaseRelativePathForFqdnAndSlugAndCurrentVersion
 }))
 
-describe('indexGenerator', () => {
+const ifTestEnabled = devConfig.disableGetIndex ? describe.skip : describe
+
+ifTestEnabled('indexGenerator', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     getCurrentAppConfigurationForFqdnAndSlug.mockResolvedValue({})


### PR DESCRIPTION
When using disableGetIndex which is very frequent in dev,
this test will always fail. Seems easy enough to disable it.
This will never happen in the CI since we will never commit
disableGetIndex=true to the repo (unless as a mistake)
