### PR TITLE
Fix/force cookies on remount

### DIFF
--- a/src/components/webviews/CozyWebview.spec.js
+++ b/src/components/webviews/CozyWebview.spec.js
@@ -15,6 +15,9 @@ jest.mock('react-native-fs', () => ({
 jest.mock('react-native-file-viewer', () => ({
   open: jest.fn()
 }))
+jest.mock('@react-native-cookies/cookies', () => ({
+  set: jest.fn()
+}))
 
 const mockGoBack = jest.fn()
 const mockUseIsFocused = jest.fn()

--- a/src/components/webviews/CryptoWebView/CryptoWebView.spec.js
+++ b/src/components/webviews/CryptoWebView/CryptoWebView.spec.js
@@ -13,6 +13,12 @@ jest.mock('./cryptoObservable/cryptoObservable', () => ({
   unsubscribeFromCrypto: jest.fn()
 }))
 
+jest.mock('cozy-client', () => ({
+  useClient: jest.fn().mockReturnValue({})
+}))
+jest.mock('@react-native-cookies/cookies', () => ({
+  set: jest.fn()
+}))
 jest.mock('react-native-webview', () => {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const React = require('react')

--- a/src/components/webviews/SupervisedWebView.js
+++ b/src/components/webviews/SupervisedWebView.js
@@ -1,12 +1,14 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { View } from 'react-native'
 import { WebView } from 'react-native-webview'
 
 import Minilog from '@cozy/minilog'
+import { useClient } from 'cozy-client'
 
 import ProgressBar from '/components/Bar'
 import { default as paletteValues } from '/theme/palette.json'
 import { styles } from './SupervisedWebView.styles'
+import { resyncCookies } from '/libs/httpserver/httpCookieManager'
 
 const log = Minilog('SupervisedWebView')
 
@@ -63,6 +65,7 @@ const initialState = {
  * - note: navigating to `chrome://crash` as stated in the Android documentation won't work as the WebView would prevent the navitation to any local resource
  */
 export const SupervisedWebView = React.forwardRef((props, ref) => {
+  const client = useClient()
   const [state, setState] = useState({
     ...initialState,
     key: 0
@@ -96,11 +99,19 @@ export const SupervisedWebView = React.forwardRef((props, ref) => {
         setState(oldState => ({ ...oldState, ...initialState }))
       }
     },
-    [shouldBeLoaded, isLoaded]
+    [shouldBeLoaded, isLoaded, reloadWebView]
   )
 
-  const reloadWebView = () => {
+  const reloadWebView = useCallback(async () => {
     log.debug('Trying to reload the WebView')
+
+    if (client) {
+      // In some scenario CookieManager cookies are not applied to the WebView on
+      // iOS reload (when killed while app in background state)
+      // To prevent this we enforce resetting cookies
+      await resyncCookies(client)
+    }
+
     setState(oldState => ({
       ...oldState,
       key: oldState.key + 1,
@@ -111,7 +122,7 @@ export const SupervisedWebView = React.forwardRef((props, ref) => {
         ? RELOAD_MAX_DELAY_IN_MS
         : RELOAD_DELAY_IN_MS
     }))
-  }
+  }, [client])
 
   return (
     <>

--- a/src/libs/httpserver/httpCookieManager.js
+++ b/src/libs/httpserver/httpCookieManager.js
@@ -109,6 +109,22 @@ export const getCookie = async client => {
   return cookies?.[appUrl]
 }
 
+/**
+ * Re-fill CookieManager by using cookie stored in AsyncStorage
+ *
+ * @param {CozyClient} client - CozyClient instance
+ * @returns {Promise<boolean>}
+ */
+export const resyncCookies = async client => {
+  const appUrl = client.getStackClient().uri
+
+  const cookies = await loadCookiesFromAsyncStorage()
+
+  const stackCookie = cookies?.[appUrl]
+
+  return CookieManager.set(appUrl, stackCookie, true)
+}
+
 const setCookieIntoAsyncStorage = async (client, cookie) => {
   const appUrl = client.getStackClient().uri
 

--- a/src/libs/httpserver/httpCookieManager.spec.js
+++ b/src/libs/httpserver/httpCookieManager.spec.js
@@ -3,7 +3,7 @@ import CookieManager from '@react-native-cookies/cookies'
 
 import { createMockClient } from 'cozy-client/dist/mock'
 
-import { getCookie, setCookie } from './httpCookieManager'
+import { getCookie, resyncCookies, setCookie } from './httpCookieManager'
 
 import strings from '/strings.json'
 
@@ -379,6 +379,33 @@ describe('httpCookieManager', () => {
       const result = await getCookie(client)
 
       expect(result).toBe(undefined)
+    })
+  })
+
+  describe('resyncCookies', () => {
+    it(`should resyncCookies cookie from AsyncStorage`, async () => {
+      client.getStackClient = jest.fn(() => ({
+        uri: 'http://claude.mycozy.cloud'
+      }))
+
+      AsyncStorage.getItem.mockResolvedValue(MOCK_LOCAl_STORAGE)
+
+      await resyncCookies(client)
+
+      expect(CookieManager.set).toHaveBeenCalledWith(
+        'http://claude.mycozy.cloud',
+        {
+          name: 'SOME_COOKIE_NAME',
+          value: 'SOME_COOKIE_VALUE',
+          domain: '.SOME_COOKIE_DOMAIN',
+          path: '/',
+          version: '1',
+          secure: false,
+          httpOnly: true,
+          sameSite: 'None'
+        },
+        true
+      )
     })
   })
 })

--- a/src/screens/login/components/ClouderyView.spec.js
+++ b/src/screens/login/components/ClouderyView.spec.js
@@ -8,7 +8,12 @@ import { act } from 'react-dom/test-utils'
 const mockGetNextUrl = jest.fn()
 
 jest.mock('cozy-client', () => ({
-  rootCozyUrl: jest.fn()
+  rootCozyUrl: jest.fn(),
+  useClient: jest.fn().mockReturnValue({})
+}))
+
+jest.mock('@react-native-cookies/cookies', () => ({
+  set: jest.fn()
 }))
 
 jest.mock('react-native-webview', () => {

--- a/src/screens/login/components/PasswordView.spec.js
+++ b/src/screens/login/components/PasswordView.spec.js
@@ -4,6 +4,12 @@ import { PasswordView } from './PasswordView'
 
 const mockSpy = jest.fn()
 
+jest.mock('cozy-client', () => ({
+  useClient: jest.fn().mockReturnValue({})
+}))
+jest.mock('@react-native-cookies/cookies', () => ({
+  set: jest.fn()
+}))
 jest.mock('react-native-webview', () => {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const React = require('react')


### PR DESCRIPTION
When calling `/apps/:slug/open` from cozy-stack, the returned cookie
doesn't contain any expiration date

So the resulting cookie is a session based cookie which may be
problematic as we have no control of its lifecycle when the WebView is
unmount by the OS then remount by the `SupervisedWebView` component

To gain more control on its lifecycle we chose to apply a 10 years
expiration date as it would be in our web apps

___

When the app's WebViews are unmount by the OS for memory management,
they are remount by the `SupervisedWebView` component

Sometimes the WebView doesn't re-use previously set cookies and the
cozy-app lose authentication to the cozy-stack

To prevent this we found that re-setting the CookieManager with cookies
from the app's local storage would force the WebView to use the