### PR TITLE
feat: Bump app version to 0.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.27
+# 0.0.28
 
 ## ✨ Features
 
@@ -8,6 +8,31 @@
 
 ## 🔧 Tech
 
+
+# 0.0.27
+
+## ✨ Features
+
+* Add auto-lock when app goes to background ([PR #415](https://github.com/cozy/cozy-react-native/pull/415))
+* Add biometric lock/unlock feature ([PR #402](https://github.com/cozy/cozy-react-native/pull/402) and [PR #428](https://github.com/cozy/cozy-react-native/pull/428) and [PR #433](https://github.com/cozy/cozy-react-native/pull/433))
+* Add `Red` in Client Side Connectors ([PR #372](https://github.com/cozy/cozy-react-native/pull/372))
+* Add `Sfr` in Client Side Connectors ([PR #375](https://github.com/cozy/cozy-react-native/pull/375))
+* Add `TotalEnergie` in Client Side Connectors ([PR #390](https://github.com/cozy/cozy-react-native/pull/390))
+* Add `AlanConnector` in Client Side Connectors ([PR #421](https://github.com/cozy/cozy-react-native/pull/421))
+* Add `Orange` in Client Side Connectors ([PR #254](https://github.com/cozy/cozy-react-native/pull/254))
+* Add autologin on `Sosh` Client Side Connector ([PR #299](https://github.com/cozy/cozy-react-native/pull/299))
+
+## 🐛 Bug Fixes
+
+* Correctly embed URL in Android's Share feature ([PR #417](https://github.com/cozy/cozy-react-native/pull/417))
+* Correctly re-set user's session when the app is resumed after a long period of inactivity ([PR #427](https://github.com/cozy/cozy-react-native/pull/427) and [PR #425](https://github.com/cozy/cozy-react-native/pull/425))
+* Disable HttpServer optimisation for cozy-settings that would prevent this cozy-app to work on iOS ([PR #416](https://github.com/cozy/cozy-react-native/pull/416))
+
+## 🔧 Tech
+
+* Remove some UI unnecessary re-renders ([PR #423](https://github.com/cozy/cozy-react-native/pull/423) and [PR #424](https://github.com/cozy/cozy-react-native/pull/424))
+* Handle HttpServer deactivation in unit-tests ([PR #426](https://github.com/cozy/cozy-react-native/pull/426))
+* Improve file upload API for Client Side Connectors ([PR #422](https://github.com/cozy/cozy-react-native/pull/422))
 
 # 0.0.26
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2601
-        versionName "0.0.26"
+        versionCode 2701
+        versionName "0.0.27"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.26</string>
+	<string>0.0.27</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0002601</string>
+	<string>0002701</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.27
- creates a new entry for next 0.0.28 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs