### PR TITLE
fix: Add NSFaceIDUsageDescription to iOS info.plist

### DIFF
--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -85,5 +85,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Permet le déverouillage de l'application en utilisant FaceID</string>
 </dict>
 </plist>


### PR DESCRIPTION
NSFaceIDUsageDescription is required to request FaceID permissions from the application

More info:
https://developer.apple.com/documentation/bundleresources/information_property_list/nsfaceidusagedescription
