### PR TITLE
fix: Force androidXBrowser version to 1.4.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         compileSdkVersion = 31
         targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
+        androidXBrowser = "1.4.0"
     }
     repositories {
         google()


### PR DESCRIPTION
`react-native-inappbrowser` has an unfixed dependency to androidXBrowser

Since androidXBrowser `1.5.0-alpha01` has been released on October 24th we encounter a build error due to a compileSdkVersion mismatch

This commit temporarily fix this by forcing androidXBrowser version to `1.4.0`

This should be revert when issue is resolved on react-native-inappbrowser side

Related issue: proyecto26/react-native-inappbrowser#386
