### PR TITLE
fix: Prevent app crash when `setFlagshipUI.caller` is `undefined`

### DIFF
--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -72,7 +72,7 @@ export const internalMethods = {
     setFlagshipUI(
       intent,
       EnvService.nameIs(strings.environments.test)
-        ? internalMethods.setFlagshipUI.caller.name
+        ? internalMethods.setFlagshipUI.caller?.name // eslint-disable-line @typescript-eslint/no-unnecessary-condition
         : ''
     )
 }


### PR DESCRIPTION
Based on TS typing, a method's `.caller` cannot be `undefined`

But in practice we encountered some crashes when trying to open cozy apps due to undefined `.caller` (it happens only in dev mode)

So we want to use an optional chaining operator here

Note that this operator was present before, but it has been removed in e6ecf3f2d11594d9cfb044e440b3d05aa81830f3 after the file was migrated to TS, probably due to the linter. So we want to add an `eslint-disable` instruction to prevent rolling back this fix
