### PR TITLE
fix: Link autolock and biometry only on activation

### DIFF
--- a/src/libs/intents/setBiometryState.ts
+++ b/src/libs/intents/setBiometryState.ts
@@ -11,7 +11,8 @@ export const BiometryEmitter = new EventEmitter()
 
 const updateBiometrySetting = async (activated: boolean): Promise<boolean> => {
   await storeData(StorageKeys.BiometryActivated, activated)
-  await storeData(StorageKeys.AutoLockEnabled, activated)
+  if (!activated && !(await getData(StorageKeys.AutoLockEnabled)))
+    await storeData(StorageKeys.AutoLockEnabled, true)
   const newData = Boolean(await getData(StorageKeys.BiometryActivated))
 
   BiometryEmitter.emit('change', newData)


### PR DESCRIPTION
Previously it was also linked on biometry deactivation which we do not want