### PR TITLE
Feat/rn cookie manager

### DIFF
--- a/connectors/connectorLibs/ContentScript.js
+++ b/connectors/connectorLibs/ContentScript.js
@@ -40,8 +40,8 @@ export default class ContentScript {
       'fillText',
       'storeFromWorker',
       'clickAndWait',
-      'getWebViewCookies',
-      'getWebViewCookie'
+      'getCookiesByDomain',
+      'getCookieByDomainAndName'
     ]
 
     if (options.additionalExposedMethodsNames) {
@@ -266,41 +266,40 @@ export default class ContentScript {
   }
 
   /**
-   * Bridge to the getWebViewCookies method from the RNlauncher.
+   * Bridge to the getCookiesByDomain method from the RNlauncher.
    *
    * @param {String} domain
    */
-  async getWebViewCookies(domain) {
-    return await this.bridge.call('getWebViewCookies', domain)
+  async getCookiesByDomain(domain) {
+    return await this.bridge.call('getCookiesByDomain', domain)
   }
 
   /**
-   * Bridge to the getCookie method from the RNlauncher.
+   * Bridge to the getCookieFromKeychainByName method from the RNlauncher.
    *
    * @param {String} domain
    */
-  async getCookie(cookieName) {
-    return await this.bridge.call('getCookie', cookieName)
+  async getCookieFromKeychainByName(cookieName) {
+    return await this.bridge.call('getCookieFromKeychainByName', cookieName)
   }
 
   /**
-   * Bridge to the saveCookie method from the RNlauncher.
+   * Bridge to the saveCookieToKeychain method from the RNlauncher.
    *
    * @param {String} domain
    */
-  async saveCookie(cookieValue) {
-    this.onlyIn(PILOT_TYPE, 'saveCookie')
-    return await this.bridge.call('saveCookie', cookieValue)
+  async saveCookieToKeychain(cookieValue) {
+    this.onlyIn(PILOT_TYPE, 'saveCookieToKeychain')
+    return await this.bridge.call('saveCookieToKeychain', cookieValue)
   }
 
-  async getWebViewCookie(cookieDomain, cookieName) {
-    this.onlyIn(WORKER_TYPE, 'getWebViewCookie')
+  async getCookieByDomainAndName(cookieDomain, cookieName) {
+    this.onlyIn(WORKER_TYPE, 'getCookieByDomainAndName')
     const expectedCookie = await this.bridge.call(
-      'getWebViewCookie',
+      'getCookieByDomainAndName',
       cookieDomain,
       cookieName
     )
-    this.log(JSON.stringify(expectedCookie))
     return expectedCookie
   }
 

--- a/connectors/connectorLibs/ContentScript.js
+++ b/connectors/connectorLibs/ContentScript.js
@@ -40,6 +40,8 @@ export default class ContentScript {
       'fillText',
       'storeFromWorker',
       'clickAndWait',
+      'getCookies',
+      'getWebViewCookie'
     ]
 
     if (options.additionalExposedMethodsNames) {
@@ -261,6 +263,45 @@ export default class ContentScript {
   async saveIdentity(identity) {
     this.onlyIn(PILOT_TYPE, 'saveIdentity')
     return await this.bridge.call('saveIdentity', identity)
+  }
+
+  /**
+   * Bridge to the getCookies method from the RNlauncher.
+   *
+   * @param {String} domain
+   */
+  async getCookies(domain) {
+    return await this.bridge.call('getCookies', domain)
+  }
+
+  /**
+   * Bridge to the getCookies method from the RNlauncher.
+   *
+   * @param {String} domain
+   */
+  async getCookieFromKeychain(cookieName) {
+    return await this.bridge.call('getCookieFromKeychain', cookieName)
+  }
+
+  /**
+   * Bridge to the saveCookie method from the RNlauncher.
+   *
+   * @param {String} domain
+   */
+  async saveCookie(cookieValue) {
+    this.onlyIn(PILOT_TYPE, 'saveCookie')
+    return await this.bridge.call('saveCookie', cookieValue)
+  }
+
+  async getWebViewCookie(cookieDomain, cookieName) {
+    this.onlyIn(WORKER_TYPE, 'getWebViewCookie')
+    const expectedCookie = await this.bridge.call(
+      'getWebViewCookie',
+      cookieDomain,
+      cookieName
+    )
+    this.log(JSON.stringify(expectedCookie))
+    return expectedCookie
   }
 
   /**

--- a/connectors/connectorLibs/ContentScript.js
+++ b/connectors/connectorLibs/ContentScript.js
@@ -40,7 +40,7 @@ export default class ContentScript {
       'fillText',
       'storeFromWorker',
       'clickAndWait',
-      'getCookies',
+      'getWebViewCookies',
       'getWebViewCookie'
     ]
 
@@ -266,21 +266,21 @@ export default class ContentScript {
   }
 
   /**
-   * Bridge to the getCookies method from the RNlauncher.
+   * Bridge to the getWebViewCookies method from the RNlauncher.
    *
    * @param {String} domain
    */
-  async getCookies(domain) {
-    return await this.bridge.call('getCookies', domain)
+  async getWebViewCookies(domain) {
+    return await this.bridge.call('getWebViewCookies', domain)
   }
 
   /**
-   * Bridge to the getCookies method from the RNlauncher.
+   * Bridge to the getCookie method from the RNlauncher.
    *
    * @param {String} domain
    */
-  async getCookieFromKeychain(cookieName) {
-    return await this.bridge.call('getCookieFromKeychain', cookieName)
+  async getCookie(cookieName) {
+    return await this.bridge.call('getCookie', cookieName)
   }
 
   /**

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -357,7 +357,7 @@ class ReactNativeLauncher extends Launcher {
       log.info('Cookie Object', { accountId, cookieObject })
       if (existingCookies !== null) {
         log.info('gettin existing cookie condition')
-        await removeCookie(accountId)
+        await removeCookie(accountId, cookieObject.name)
       }
       await saveCookie({ accountId, cookieObject })
     } catch (err) {

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -260,6 +260,7 @@ class ReactNativeLauncher extends Launcher {
    * This method is callable by the content script.
    *
    * @param {String} options.cookieDomain : Domain's name where to get cookies from.
+   * @return object | {null}
    */
   async getWebViewCookies(cookieDomain) {
     const { manifest } = this.startContext
@@ -274,11 +275,7 @@ class ReactNativeLauncher extends Launcher {
       )
     }
     try {
-      log.info(
-        `getWebViewCookies on this domain : ${cookieDomain} for account ${this.startContext.account.id}`
-      )
       const cookies = await CookieManager.get(cookieDomain)
-      log.info('CookieManager.get =>', cookies)
       return cookies
     } catch (err) {
       throw new Error(`Error in worker: ${err.message}`)
@@ -291,11 +288,11 @@ class ReactNativeLauncher extends Launcher {
    *
    * @param {String} cookieDomain : Domain to recover cookies from .
    * @param {String} cookieName : Name of the wanted cookie.
+   * @return null | object
    */
   async getWebViewCookie(cookieDomain, cookieName) {
     log.info('Starting getWebViewCookie in RNLauncher')
     let expectedCookie = null
-    log.info(`for this cookie : ${cookieName} for domain ${cookieDomain}`)
     try {
       const cookies = await this.getWebViewCookies(cookieDomain)
       if (cookies[cookieName]) {
@@ -312,13 +309,13 @@ class ReactNativeLauncher extends Launcher {
    * This method is callable by the content script.
    *
    * @param {String} options.cookieName : wanted cookie's by its name.
+   * @return object | null
    */
   async getCookie(cookieName) {
     log.info('Starting getCookie in RNLauncher')
     try {
       const { account } = this.startContext
       const accountId = account.id
-      log.info('Checking if cookie is present with this name :', cookieName)
       const existingCookies = await getCookie({
         accountId,
         cookieName
@@ -345,18 +342,11 @@ class ReactNativeLauncher extends Launcher {
     try {
       const { account } = this.startContext
       const accountId = account.id
-      log.info(
-        'Checking if cookie is present with this payload :',
-        cookieObject
-      )
       const existingCookies = await getCookie({
         accountId,
         cookieName: cookieObject.name
       })
-      log.info('Cookie from keychain', existingCookies)
-      log.info('Cookie Object', { accountId, cookieObject })
       if (existingCookies !== null) {
-        log.info('gettin existing cookie condition')
         await removeCookie(accountId, cookieObject.name)
       }
       await saveCookie({ accountId, cookieObject })

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -260,8 +260,6 @@ class ReactNativeLauncher extends Launcher {
    * This method is callable by the content script.
    *
    * @param {String} options.cookieDomain : Domain's name where to get cookies from.
-   * @param {String} options.konnectorSlug : Slug of the konnector triggering the function.
-   * @param {String} options.idAccount : Id of the account triggering the function.
    */
   async getWebViewCookies(cookieDomain) {
     const { manifest } = this.startContext
@@ -318,13 +316,11 @@ class ReactNativeLauncher extends Launcher {
   async getCookie(cookieName) {
     log.info('Starting getCookie in RNLauncher')
     try {
-      const { account, manifest } = this.startContext
+      const { account } = this.startContext
       const accountId = account.id
-      const konnectorSlug = manifest.slug
       log.info('Checking if cookie is present with this name :', cookieName)
       const existingCookies = await getCookie({
         accountId,
-        konnectorSlug,
         cookieName
       })
       if (existingCookies === null) {
@@ -347,25 +343,23 @@ class ReactNativeLauncher extends Launcher {
   async saveCookie(cookieObject) {
     log.info('Starting saveCookie in RNLauncher')
     try {
-      const { account, manifest } = this.startContext
+      const { account } = this.startContext
       const accountId = account.id
-      const konnectorSlug = manifest.slug
       log.info(
         'Checking if cookie is present with this payload :',
         cookieObject
       )
       const existingCookies = await getCookie({
         accountId,
-        konnectorSlug,
         cookieName: cookieObject.name
       })
       log.info('Cookie from keychain', existingCookies)
-      log.info('Cookie Object', { accountId, konnectorSlug, cookieObject })
+      log.info('Cookie Object', { accountId, cookieObject })
       if (existingCookies !== null) {
         log.info('gettin existing cookie condition')
-        await removeCookie(accountId, konnectorSlug)
+        await removeCookie(accountId)
       }
-      await saveCookie({ accountId, konnectorSlug, cookieObject })
+      await saveCookie({ accountId, cookieObject })
     } catch (err) {
       throw new Error(`Error in worker during saveCookie: ${err.message}`)
     }

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -265,8 +265,15 @@ class ReactNativeLauncher extends Launcher {
    */
   async getCookies(cookieDomain) {
     const { manifest } = this.startContext
+    if (manifest.cookie_domains === undefined) {
+      throw new Error(
+        'getCookies cannot be called without cookie_domains declared in manifest'
+      )
+    }
     if (!manifest.cookie_domains.includes(cookieDomain)) {
-      throw new Error('Cookie domain not declared in the manifest')
+      throw new Error(
+        `Cookie domain ${cookieDomain} not declared in the manifest`
+      )
     }
     try {
       log.info(
@@ -298,11 +305,12 @@ class ReactNativeLauncher extends Launcher {
         konnectorSlug,
         cookieName
       })
-      if (existingCookies !== null) {
-        return existingCookies
+      if (existingCookies === null) {
+        log.info(
+          `No cookie named "${cookieName}" has been found, returning null`
+        )
       }
-      log.info(`No cookie named "${cookieName}" has been found, retunring null`)
-      return null
+      return existingCookies
     } catch (err) {
       throw new Error(
         `Error in worker during getCookieFromKeychain: ${err.message}`
@@ -329,7 +337,7 @@ class ReactNativeLauncher extends Launcher {
       const existingCookies = await getCookie({
         accountId,
         konnectorSlug,
-        cookieObject
+        cookieName: cookieObject.name
       })
       log.info('Cookie from keychain', existingCookies)
       log.info('Cookie Object', { accountId, konnectorSlug, cookieObject })

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -136,7 +136,7 @@ describe('ReactNativeLauncher', () => {
       expect(result).toEqual(false)
     })
   })
-  describe('getWebViewCookies', () => {
+  describe('getCookiesByDomain', () => {
     it('should return cookies from CookieManager', async () => {
       CookieManager.get.mockResolvedValue({ value: 'SOME COOKIE' })
       launcher.setStartContext({
@@ -147,7 +147,7 @@ describe('ReactNativeLauncher', () => {
           cookie_domains: ['.cozy.io']
         }
       })
-      const result = await launcher.getWebViewCookies('.cozy.io')
+      const result = await launcher.getCookiesByDomain('.cozy.io')
       expect(result).toStrictEqual({ value: 'SOME COOKIE' })
       expect(CookieManager.get).toHaveBeenCalledWith('.cozy.io')
     })
@@ -159,8 +159,8 @@ describe('ReactNativeLauncher', () => {
         },
         manifest: {}
       })
-      await expect(launcher.getWebViewCookies('.cozy.io')).rejects.toThrow(
-        'getWebViewCookies cannot be called without cookie_domains declared in manifest'
+      await expect(launcher.getCookiesByDomain('.cozy.io')).rejects.toThrow(
+        'getCookiesByDomain cannot be called without cookie_domains declared in manifest'
       )
     })
     it('should throw error if cookie_domains does not declare requested domain', async () => {
@@ -173,7 +173,7 @@ describe('ReactNativeLauncher', () => {
           cookie_domains: ['.somedomain']
         }
       })
-      await expect(launcher.getWebViewCookies('.cozy.io')).rejects.toThrow(
+      await expect(launcher.getCookiesByDomain('.cozy.io')).rejects.toThrow(
         'Cookie domain .cozy.io not declared in the manifest'
       )
     })
@@ -187,11 +187,11 @@ describe('ReactNativeLauncher', () => {
           cookie_domains: ['apeculiarsite.com']
         }
       })
-      const result = await launcher.getWebViewCookies('apeculiarsite.com')
+      const result = await launcher.getCookiesByDomain('apeculiarsite.com')
       expect(result).toStrictEqual({})
     })
   })
-  describe('getWebViewCookie', () => {
+  describe('getCookieByDomainAndName', () => {
     it('should return cookie from CookieManager', async () => {
       CookieManager.get.mockResolvedValue({
         SOME_COOKIE_NAME: 'SOME COOKIE VALUE',
@@ -205,7 +205,7 @@ describe('ReactNativeLauncher', () => {
           cookie_domains: ['.cozy.io']
         }
       })
-      const result = await launcher.getWebViewCookie(
+      const result = await launcher.getCookieByDomainAndName(
         '.cozy.io',
         'SOME_COOKIE_NAME'
       )
@@ -224,9 +224,9 @@ describe('ReactNativeLauncher', () => {
         manifest: {}
       })
       await expect(
-        launcher.getWebViewCookie('.cozy.io', 'SOME_COOKIE_NAME')
+        launcher.getCookieByDomainAndName('.cozy.io', 'SOME_COOKIE_NAME')
       ).rejects.toThrow(
-        'getWebViewCookies cannot be called without cookie_domains declared in manifest'
+        'getCookiesByDomain cannot be called without cookie_domains declared in manifest'
       )
     })
     it('should throw error if cookie_domains does not declare requested domain', async () => {
@@ -243,7 +243,7 @@ describe('ReactNativeLauncher', () => {
         }
       })
       await expect(
-        launcher.getWebViewCookie('.cozy.io', 'SOME_COOKIE_NAME')
+        launcher.getCookieByDomainAndName('.cozy.io', 'SOME_COOKIE_NAME')
       ).rejects.toThrow('Cookie domain .cozy.io not declared in the manifest')
     })
     it('should return null if CookieManager does not contain the requested cookie', async () => {
@@ -259,14 +259,14 @@ describe('ReactNativeLauncher', () => {
           cookie_domains: ['apeculiarsite.com']
         }
       })
-      const result = await launcher.getWebViewCookie(
+      const result = await launcher.getCookieByDomainAndName(
         'apeculiarsite.com',
         'SOME_NON_EXISTING_COOKIE_NAME'
       )
       expect(result).toBeNull()
     })
   })
-  describe('getCookie', () => {
+  describe('getCookieFromKeychainByName', () => {
     it('should return cookie with given name', async () => {
       getCookie.mockResolvedValue({
         value: 'tokenvalue',
@@ -280,7 +280,7 @@ describe('ReactNativeLauncher', () => {
           id: 'cozyKonnector'
         }
       })
-      const result = await launcher.getCookie('token')
+      const result = await launcher.getCookieFromKeychainByName('token')
       expect(result).toEqual({
         value: 'tokenvalue',
         name: 'token',
@@ -300,11 +300,11 @@ describe('ReactNativeLauncher', () => {
           id: 'cozyKonnector'
         }
       })
-      const result = await launcher.getCookie('token')
+      const result = await launcher.getCookieFromKeychainByName('token')
       expect(result).toBeNull()
     })
   })
-  describe('saveCookie', () => {
+  describe('saveCookieToKeychain', () => {
     it('should save given cookie into the keychain', async () => {
       getCookie.mockResolvedValue(null)
       launcher.setStartContext({
@@ -312,7 +312,7 @@ describe('ReactNativeLauncher', () => {
           id: 'cozyKonnector'
         }
       })
-      await launcher.saveCookie({
+      await launcher.saveCookieToKeychain({
         value: 'tokenvalue',
         name: 'token',
         path: null,
@@ -348,7 +348,7 @@ describe('ReactNativeLauncher', () => {
           id: 'cozyKonnector'
         }
       })
-      await launcher.saveCookie({
+      await launcher.saveCookieToKeychain({
         value: 'tokenvalue',
         name: 'token',
         path: null,

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -278,9 +278,6 @@ describe('ReactNativeLauncher', () => {
       launcher.setStartContext({
         account: {
           id: 'cozyKonnector'
-        },
-        manifest: {
-          slug: 'konnectorSlug'
         }
       })
       const result = await launcher.getCookie('token')
@@ -293,7 +290,6 @@ describe('ReactNativeLauncher', () => {
       })
       expect(getCookie).toHaveBeenCalledWith({
         accountId: 'cozyKonnector',
-        konnectorSlug: 'konnectorSlug',
         cookieName: 'token'
       })
     })
@@ -302,9 +298,6 @@ describe('ReactNativeLauncher', () => {
       launcher.setStartContext({
         account: {
           id: 'cozyKonnector'
-        },
-        manifest: {
-          slug: 'konnectorSlug'
         }
       })
       const result = await launcher.getCookie('token')
@@ -317,9 +310,6 @@ describe('ReactNativeLauncher', () => {
       launcher.setStartContext({
         account: {
           id: 'cozyKonnector'
-        },
-        manifest: {
-          slug: 'konnectorSlug'
         }
       })
       await launcher.saveCookie({
@@ -331,13 +321,11 @@ describe('ReactNativeLauncher', () => {
       })
       expect(getCookie).toHaveBeenCalledWith({
         accountId: 'cozyKonnector',
-        konnectorSlug: 'konnectorSlug',
         cookieName: 'token'
       })
       expect(removeCookie).not.toHaveBeenCalled()
       expect(saveCookie).toHaveBeenCalledWith({
         accountId: 'cozyKonnector',
-        konnectorSlug: 'konnectorSlug',
         cookieObject: {
           value: 'tokenvalue',
           name: 'token',
@@ -358,9 +346,6 @@ describe('ReactNativeLauncher', () => {
       launcher.setStartContext({
         account: {
           id: 'cozyKonnector'
-        },
-        manifest: {
-          slug: 'konnectorSlug'
         }
       })
       await launcher.saveCookie({
@@ -372,16 +357,11 @@ describe('ReactNativeLauncher', () => {
       })
       expect(getCookie).toHaveBeenCalledWith({
         accountId: 'cozyKonnector',
-        konnectorSlug: 'konnectorSlug',
         cookieName: 'token'
       })
-      expect(removeCookie).toHaveBeenCalledWith(
-        'cozyKonnector',
-        'konnectorSlug'
-      )
+      expect(removeCookie).toHaveBeenCalledWith('cozyKonnector')
       expect(saveCookie).toHaveBeenCalledWith({
         accountId: 'cozyKonnector',
-        konnectorSlug: 'konnectorSlug',
         cookieObject: {
           value: 'tokenvalue',
           name: 'token',

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -359,7 +359,7 @@ describe('ReactNativeLauncher', () => {
         accountId: 'cozyKonnector',
         cookieName: 'token'
       })
-      expect(removeCookie).toHaveBeenCalledWith('cozyKonnector')
+      expect(removeCookie).toHaveBeenCalledWith('cozyKonnector', 'token')
       expect(saveCookie).toHaveBeenCalledWith({
         accountId: 'cozyKonnector',
         cookieObject: {

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -136,7 +136,7 @@ describe('ReactNativeLauncher', () => {
       expect(result).toEqual(false)
     })
   })
-  describe('getCookies', () => {
+  describe('getWebViewCookies', () => {
     it('should return cookies from CookieManager', async () => {
       CookieManager.get.mockResolvedValue({ value: 'SOME COOKIE' })
       launcher.setStartContext({
@@ -147,7 +147,7 @@ describe('ReactNativeLauncher', () => {
           cookie_domains: ['.cozy.io']
         }
       })
-      const result = await launcher.getCookies('.cozy.io')
+      const result = await launcher.getWebViewCookies('.cozy.io')
       expect(result).toStrictEqual({ value: 'SOME COOKIE' })
       expect(CookieManager.get).toHaveBeenCalledWith('.cozy.io')
     })
@@ -159,8 +159,8 @@ describe('ReactNativeLauncher', () => {
         },
         manifest: {}
       })
-      await expect(launcher.getCookies('.cozy.io')).rejects.toThrow(
-        'getCookies cannot be called without cookie_domains declared in manifest'
+      await expect(launcher.getWebViewCookies('.cozy.io')).rejects.toThrow(
+        'getWebViewCookies cannot be called without cookie_domains declared in manifest'
       )
     })
     it('should throw error if cookie_domains does not declare requested domain', async () => {
@@ -173,7 +173,7 @@ describe('ReactNativeLauncher', () => {
           cookie_domains: ['.somedomain']
         }
       })
-      await expect(launcher.getCookies('.cozy.io')).rejects.toThrow(
+      await expect(launcher.getWebViewCookies('.cozy.io')).rejects.toThrow(
         'Cookie domain .cozy.io not declared in the manifest'
       )
     })
@@ -187,11 +187,86 @@ describe('ReactNativeLauncher', () => {
           cookie_domains: ['apeculiarsite.com']
         }
       })
-      const result = await launcher.getCookies('apeculiarsite.com')
+      const result = await launcher.getWebViewCookies('apeculiarsite.com')
       expect(result).toStrictEqual({})
     })
   })
-  describe('getCookieFromKeychain', () => {
+  describe('getWebViewCookie', () => {
+    it('should return cookie from CookieManager', async () => {
+      CookieManager.get.mockResolvedValue({
+        SOME_COOKIE_NAME: 'SOME COOKIE VALUE',
+        SOME_COOKIE_NAME_2: 'SOME COOKIE VALUE_2'
+      })
+      launcher.setStartContext({
+        account: {
+          id: 'cozyKonnector'
+        },
+        manifest: {
+          cookie_domains: ['.cozy.io']
+        }
+      })
+      const result = await launcher.getWebViewCookie(
+        '.cozy.io',
+        'SOME_COOKIE_NAME'
+      )
+      expect(result).toStrictEqual('SOME COOKIE VALUE')
+      expect(CookieManager.get).toHaveBeenCalledWith('.cozy.io')
+    })
+    it('should throw error if cookie_domains does not exist', async () => {
+      CookieManager.get.mockResolvedValue({
+        SOME_COOKIE_NAME: 'SOME COOKIE VALUE',
+        SOME_COOKIE_NAME_2: 'SOME COOKIE VALUE_2'
+      })
+      launcher.setStartContext({
+        account: {
+          id: 'cozyKonnector'
+        },
+        manifest: {}
+      })
+      await expect(
+        launcher.getWebViewCookie('.cozy.io', 'SOME_COOKIE_NAME')
+      ).rejects.toThrow(
+        'getWebViewCookies cannot be called without cookie_domains declared in manifest'
+      )
+    })
+    it('should throw error if cookie_domains does not declare requested domain', async () => {
+      CookieManager.get.mockResolvedValue({
+        SOME_COOKIE_NAME: 'SOME COOKIE VALUE',
+        SOME_COOKIE_NAME_2: 'SOME COOKIE VALUE_2'
+      })
+      launcher.setStartContext({
+        account: {
+          id: 'cozyKonnector'
+        },
+        manifest: {
+          cookie_domains: ['.somedomain']
+        }
+      })
+      await expect(
+        launcher.getWebViewCookie('.cozy.io', 'SOME_COOKIE_NAME')
+      ).rejects.toThrow('Cookie domain .cozy.io not declared in the manifest')
+    })
+    it('should return null if CookieManager does not contain the requested cookie', async () => {
+      CookieManager.get.mockResolvedValue({
+        SOME_COOKIE_NAME: 'SOME COOKIE VALUE',
+        SOME_COOKIE_NAME_2: 'SOME COOKIE VALUE_2'
+      })
+      launcher.setStartContext({
+        account: {
+          id: 'cozyKonnector'
+        },
+        manifest: {
+          cookie_domains: ['apeculiarsite.com']
+        }
+      })
+      const result = await launcher.getWebViewCookie(
+        'apeculiarsite.com',
+        'SOME_NON_EXISTING_COOKIE_NAME'
+      )
+      expect(result).toBeNull()
+    })
+  })
+  describe('getCookie', () => {
     it('should return cookie with given name', async () => {
       getCookie.mockResolvedValue({
         value: 'tokenvalue',
@@ -208,7 +283,7 @@ describe('ReactNativeLauncher', () => {
           slug: 'konnectorSlug'
         }
       })
-      const result = await launcher.getCookieFromKeychain('token')
+      const result = await launcher.getCookie('token')
       expect(result).toEqual({
         value: 'tokenvalue',
         name: 'token',
@@ -232,7 +307,7 @@ describe('ReactNativeLauncher', () => {
           slug: 'konnectorSlug'
         }
       })
-      const result = await launcher.getCookieFromKeychain('token')
+      const result = await launcher.getCookie('token')
       expect(result).toBeNull()
     })
   })

--- a/src/libs/ReactNativeLauncherIntegration.spec.js
+++ b/src/libs/ReactNativeLauncherIntegration.spec.js
@@ -1,0 +1,141 @@
+jest.mock('react-native-keychain')
+
+jest.mock('react-native-fs', () => {
+  return {}
+})
+jest.mock('@fengweichong/react-native-gzip', () => {
+  return {}
+})
+jest.mock('@react-native-cookies/cookies', () => {
+  return {
+    get: jest.fn()
+  }
+})
+
+import * as Keychain from 'react-native-keychain'
+import ReactNativeLauncher from './ReactNativeLauncher'
+
+import { GLOBAL_KEY } from './keychain'
+
+describe('ReactNativeLauncherIntegration', () => {
+  const launcher = new ReactNativeLauncher()
+  launcher.pilot = {
+    call: jest.fn()
+  }
+  launcher.worker = {
+    call: jest.fn()
+  }
+
+  beforeEach(() => {
+    console.log = jest.fn() // eslint-disable-line no-console
+  })
+
+  describe('saveCookie', () => {
+    it('should override the cookie if the cookie with given name is already saved in the keychain but do not remove all the others', async () => {
+      const initialCookies = {
+        CSC_COOKIES: {
+          SOME_ACCOUNT_ID: [
+            {
+              value: 'SOME_EXISTING_COOKIE_VALUE',
+              name: 'SOME_EXISTING_COOKIE_NAME',
+              path: null,
+              httpOnly: true,
+              secure: true
+            },
+            {
+              value: 'SOME_EXISTING_COOKIE_VALUE_2',
+              name: 'SOME_EXISTING_COOKIE_NAME_2',
+              path: null,
+              httpOnly: true,
+              secure: true
+            },
+            {
+              value: 'SOME_EXISTING_COOKIE_VALUE_3',
+              name: 'SOME_EXISTING_COOKIE_NAME_3',
+              path: null,
+              httpOnly: true,
+              secure: true
+            }
+          ]
+        }
+      }
+      const cookiesAfterDeletion = {
+        CSC_COOKIES: {
+          SOME_ACCOUNT_ID: [
+            {
+              value: 'SOME_EXISTING_COOKIE_VALUE_2',
+              name: 'SOME_EXISTING_COOKIE_NAME_2',
+              path: null,
+              httpOnly: true,
+              secure: true
+            },
+            {
+              value: 'SOME_EXISTING_COOKIE_VALUE_3',
+              name: 'SOME_EXISTING_COOKIE_NAME_3',
+              path: null,
+              httpOnly: true,
+              secure: true
+            }
+          ]
+        }
+      }
+      jest
+        .spyOn(Keychain, 'getGenericPassword')
+        .mockResolvedValueOnce({
+          password: JSON.stringify(initialCookies)
+        })
+        .mockResolvedValueOnce({
+          password: JSON.stringify(initialCookies)
+        })
+        .mockResolvedValueOnce({
+          password: JSON.stringify(cookiesAfterDeletion)
+        })
+      launcher.setStartContext({
+        account: {
+          id: 'SOME_ACCOUNT_ID'
+        }
+      })
+      await launcher.saveCookie({
+        value: 'SOME_NEW_COOKIE_VALUE',
+        name: 'SOME_EXISTING_COOKIE_NAME',
+        path: null,
+        httpOnly: true,
+        secure: true
+      })
+      expect(Keychain.setGenericPassword).toBeCalledWith(
+        GLOBAL_KEY,
+        JSON.stringify(cookiesAfterDeletion)
+      )
+      expect(Keychain.setGenericPassword).toBeCalledWith(
+        GLOBAL_KEY,
+        JSON.stringify({
+          CSC_COOKIES: {
+            SOME_ACCOUNT_ID: [
+              {
+                value: 'SOME_EXISTING_COOKIE_VALUE_2',
+                name: 'SOME_EXISTING_COOKIE_NAME_2',
+                path: null,
+                httpOnly: true,
+                secure: true
+              },
+              {
+                value: 'SOME_EXISTING_COOKIE_VALUE_3',
+                name: 'SOME_EXISTING_COOKIE_NAME_3',
+                path: null,
+                httpOnly: true,
+                secure: true
+              },
+              {
+                value: 'SOME_NEW_COOKIE_VALUE',
+                name: 'SOME_EXISTING_COOKIE_NAME',
+                path: null,
+                httpOnly: true,
+                secure: true
+              }
+            ]
+          }
+        })
+      )
+    })
+  })
+})

--- a/src/libs/ReactNativeLauncherIntegration.spec.js
+++ b/src/libs/ReactNativeLauncherIntegration.spec.js
@@ -30,7 +30,7 @@ describe('ReactNativeLauncherIntegration', () => {
     console.log = jest.fn() // eslint-disable-line no-console
   })
 
-  describe('saveCookie', () => {
+  describe('saveCookieToKeychain', () => {
     it('should override the cookie if the cookie with given name is already saved in the keychain but do not remove all the others', async () => {
       const initialCookies = {
         CSC_COOKIES: {
@@ -95,7 +95,7 @@ describe('ReactNativeLauncherIntegration', () => {
           id: 'SOME_ACCOUNT_ID'
         }
       })
-      await launcher.saveCookie({
+      await launcher.saveCookieToKeychain({
         value: 'SOME_NEW_COOKIE_VALUE',
         name: 'SOME_EXISTING_COOKIE_NAME',
         path: null,

--- a/src/libs/keychain.spec.js
+++ b/src/libs/keychain.spec.js
@@ -493,11 +493,21 @@ describe('keychain test suite', () => {
             }
           })
         })
-        await removeCookie('SOME_ACCOUNT_ID')
+        await removeCookie('SOME_ACCOUNT_ID', 'SOME_EXISTING_COOKIE_NAME')
         expect(Keychain.setGenericPassword).toBeCalledWith(
           GLOBAL_KEY,
           JSON.stringify({
-            CSC_COOKIES: {}
+            CSC_COOKIES: {
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE_2',
+                  name: 'SOME_EXISTING_COOKIE_NAME_2',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
+            }
           })
         )
       })
@@ -524,7 +534,10 @@ describe('keychain test suite', () => {
             }
           })
         })
-        await removeCookie('SOME_NOT_EXISTING_ACCOUNT_ID')
+        await removeCookie(
+          'SOME_NOT_EXISTING_ACCOUNT_ID',
+          'SOME_EXISTING_COOKIE_NAME'
+        )
         expect(Keychain.setGenericPassword).toBeCalledWith(
           GLOBAL_KEY,
           JSON.stringify({

--- a/src/libs/keychain.spec.js
+++ b/src/libs/keychain.spec.js
@@ -174,17 +174,15 @@ describe('keychain test suite', () => {
       it('should return the cookie with the given name if found in the keychain', async () => {
         const keychainContent = {
           CSC_COOKIES: {
-            SOME_ACCOUNT_ID: {
-              SOME_KONNECTOR_SLUG: [
-                {
-                  value: 'tokenvalue',
-                  name: 'SOME_COOKIE_NAME',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                }
-              ]
-            }
+            SOME_ACCOUNT_ID: [
+              {
+                value: 'tokenvalue',
+                name: 'SOME_COOKIE_NAME',
+                path: null,
+                httpOnly: true,
+                secure: true
+              }
+            ]
           }
         }
         jest
@@ -193,7 +191,6 @@ describe('keychain test suite', () => {
 
         const result = await getCookie({
           accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
           cookieName: 'SOME_COOKIE_NAME'
         })
         expect(result).toStrictEqual({
@@ -207,51 +204,31 @@ describe('keychain test suite', () => {
       it('should return the right cookie with the given name', async () => {
         const keychainContent = {
           CSC_COOKIES: {
-            SOME_ACCOUNT_ID: {
-              SOME_KONNECTOR_SLUG: [
-                {
-                  value: 'cookievalue',
-                  name: 'ANOTHER_COOKIE_NAME',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                },
-                {
-                  value: 'tokenvalue',
-                  name: 'SOME_COOKIE_NAME',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                }
-              ],
-              SOME_OTHER_KONNECTOR_SLUG: [
-                {
-                  value: 'cookievalue',
-                  name: 'ANOTHER_COOKIE_NAME_2',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                },
-                {
-                  value: 'tokenvalue',
-                  name: 'ANOTHER_COOKIE_NAME_3',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                }
-              ]
-            },
-            SOME_OTHER_ACCOUNT_ID: {
-              SOME_OTHER_KONNECTOR_SLUG: [
-                {
-                  value: 'cookievalue',
-                  name: 'ANOTHER_COOKIE_NAME_4',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                }
-              ]
-            }
+            SOME_ACCOUNT_ID: [
+              {
+                value: 'cookievalue',
+                name: 'ANOTHER_COOKIE_NAME',
+                path: null,
+                httpOnly: true,
+                secure: true
+              },
+              {
+                value: 'tokenvalue',
+                name: 'SOME_COOKIE_NAME',
+                path: null,
+                httpOnly: true,
+                secure: true
+              }
+            ],
+            SOME_OTHER_ACCOUNT_ID: [
+              {
+                value: 'cookievalue',
+                name: 'ANOTHER_COOKIE_NAME_2',
+                path: null,
+                httpOnly: true,
+                secure: true
+              }
+            ]
           }
         }
         jest
@@ -260,7 +237,6 @@ describe('keychain test suite', () => {
 
         const result = await getCookie({
           accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
           cookieName: 'SOME_COOKIE_NAME'
         })
         expect(result).toStrictEqual({
@@ -274,17 +250,15 @@ describe('keychain test suite', () => {
       it('should return null if no account found for given accountId', async () => {
         const keychainContent = {
           CSC_COOKIES: {
-            SOME_OTHER_ACCOUNT_ID: {
-              SOME_OTHER_KONNECTOR_SLUG: [
-                {
-                  value: 'cookievalue',
-                  name: 'ANOTHER_COOKIE_NAME_4',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                }
-              ]
-            }
+            SOME_OTHER_ACCOUNT_ID: [
+              {
+                value: 'cookievalue',
+                name: 'ANOTHER_COOKIE_NAME_2',
+                path: null,
+                httpOnly: true,
+                secure: true
+              }
+            ]
           }
         }
         jest
@@ -293,41 +267,6 @@ describe('keychain test suite', () => {
 
         const result = await getCookie({
           accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
-          cookieName: 'SOME_COOKIE_NAME'
-        })
-        expect(result).toBeNull()
-      })
-      it('should return null if no konnectorSlug found for given slug', async () => {
-        const keychainContent = {
-          CSC_COOKIES: {
-            SOME_ACCOUNT_ID: {
-              SOME_OTHER_KONNECTOR_SLUG: [
-                {
-                  value: 'cookievalue',
-                  name: 'ANOTHER_COOKIE_NAME_2',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                },
-                {
-                  value: 'tokenvalue',
-                  name: 'ANOTHER_COOKIE_NAME_3',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                }
-              ]
-            }
-          }
-        }
-        jest
-          .spyOn(Keychain, 'getGenericPassword')
-          .mockResolvedValueOnce({ password: JSON.stringify(keychainContent) })
-
-        const result = await getCookie({
-          accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
           cookieName: 'SOME_COOKIE_NAME'
         })
         expect(result).toBeNull()
@@ -335,17 +274,15 @@ describe('keychain test suite', () => {
       it('should return null if no cookie found with given cookieName', async () => {
         const keychainContent = {
           CSC_COOKIES: {
-            SOME_ACCOUNT_ID: {
-              SOME_KONNECTOR_SLUG: [
-                {
-                  value: 'cookievalue',
-                  name: 'ANOTHER_COOKIE_NAME',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                }
-              ]
-            }
+            SOME_ACCOUNT_ID: [
+              {
+                value: 'cookievalue',
+                name: 'ANOTHER_COOKIE_NAME',
+                path: null,
+                httpOnly: true,
+                secure: true
+              }
+            ]
           }
         }
         jest
@@ -354,7 +291,6 @@ describe('keychain test suite', () => {
 
         const result = await getCookie({
           accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
           cookieName: 'SOME_COOKIE_NAME'
         })
         expect(result).toBeNull()
@@ -362,17 +298,15 @@ describe('keychain test suite', () => {
       it('should throw an Error if no cookieName is given', async () => {
         const keychainContent = {
           CSC_COOKIES: {
-            SOME_ACCOUNT_ID: {
-              SOME_KONNECTOR_SLUG: [
-                {
-                  value: 'tokenvalue',
-                  name: 'SOME_COOKIE_NAME',
-                  path: null,
-                  httpOnly: true,
-                  secure: true
-                }
-              ]
-            }
+            SOME_ACCOUNT_ID: [
+              {
+                value: 'tokenvalue',
+                name: 'SOME_COOKIE_NAME',
+                path: null,
+                httpOnly: true,
+                secure: true
+              }
+            ]
           }
         }
         jest
@@ -382,7 +316,6 @@ describe('keychain test suite', () => {
         await expect(
           getCookie({
             accountId: 'SOME_ACCOUNT_ID',
-            konnectorSlug: 'SOME_KONNECTOR_SLUG',
             cookieName: ''
           })
         ).rejects.toThrow('getCookie cannot be called without a cookieName')
@@ -393,7 +326,6 @@ describe('keychain test suite', () => {
         jest.spyOn(Keychain, 'getGenericPassword').mockResolvedValueOnce(null)
         const cookieToAdd = {
           accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
           cookieObject: {
             value: 'SOME_COOKIE_VALUE',
             name: 'SOME_COOKIE_NAME',
@@ -407,17 +339,15 @@ describe('keychain test suite', () => {
           GLOBAL_KEY,
           JSON.stringify({
             CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_COOKIE_VALUE',
-                    name: 'SOME_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_COOKIE_VALUE',
+                  name: 'SOME_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
             }
           })
         )
@@ -430,7 +360,6 @@ describe('keychain test suite', () => {
         })
         const cookieToAdd = {
           accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
           cookieObject: {
             value: 'SOME_COOKIE_VALUE',
             name: 'SOME_COOKIE_NAME',
@@ -445,42 +374,37 @@ describe('keychain test suite', () => {
           JSON.stringify({
             VAULT: { key: 'value' },
             CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_COOKIE_VALUE',
-                    name: 'SOME_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_COOKIE_VALUE',
+                  name: 'SOME_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
             }
           })
         )
       })
-      it('should save the given cookie when keychain already has some cookies for the given konnector slug', async () => {
+      it('should save the given cookie when keychain already has some cookies for the given konnector accountId', async () => {
         jest.spyOn(Keychain, 'getGenericPassword').mockResolvedValueOnce({
           password: JSON.stringify({
             CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE',
-                    name: 'SOME_EXISTING_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE',
+                  name: 'SOME_EXISTING_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
             }
           })
         })
         const cookieToAdd = {
           accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
           cookieObject: {
             value: 'SOME_COOKIE_VALUE',
             name: 'SOME_COOKIE_NAME',
@@ -494,24 +418,22 @@ describe('keychain test suite', () => {
           GLOBAL_KEY,
           JSON.stringify({
             CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE',
-                    name: 'SOME_EXISTING_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  },
-                  {
-                    value: 'SOME_COOKIE_VALUE',
-                    name: 'SOME_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE',
+                  name: 'SOME_EXISTING_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                },
+                {
+                  value: 'SOME_COOKIE_VALUE',
+                  name: 'SOME_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
             }
           })
         )
@@ -520,23 +442,20 @@ describe('keychain test suite', () => {
         jest.spyOn(Keychain, 'getGenericPassword').mockResolvedValueOnce({
           password: JSON.stringify({
             CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE',
-                    name: 'SOME_EXISTING_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE',
+                  name: 'SOME_EXISTING_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
             }
           })
         })
         const cookieToAdd = {
           accountId: 'SOME_ACCOUNT_ID',
-          konnectorSlug: 'SOME_KONNECTOR_SLUG',
           cookieObject: {
             value: 'SOME_COOKIE_VALUE',
             name: 'SOME_EXISTING_COOKIE_NAME',
@@ -546,43 +465,39 @@ describe('keychain test suite', () => {
           }
         }
         await expect(saveCookie(cookieToAdd)).rejects.toThrow(
-          "Cookie SOME_EXISTING_COOKIE_NAME is already saved in SOME_KONNECTOR_SLUG. You can't add it again."
+          "Cookie SOME_EXISTING_COOKIE_NAME is already saved in SOME_ACCOUNT_ID. You can't add it again."
         )
       })
     })
     describe('removeCookie', () => {
-      it('should remove cookies from the given konnector slug and account id', async () => {
+      it('should remove cookies from the given account id', async () => {
         jest.spyOn(Keychain, 'getGenericPassword').mockResolvedValueOnce({
           password: JSON.stringify({
             CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE',
-                    name: 'SOME_EXISTING_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  },
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE_2',
-                    name: 'SOME_EXISTING_COOKIE_NAME_2',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE',
+                  name: 'SOME_EXISTING_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                },
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE_2',
+                  name: 'SOME_EXISTING_COOKIE_NAME_2',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
             }
           })
         })
-        await removeCookie('SOME_ACCOUNT_ID', 'SOME_KONNECTOR_SLUG')
+        await removeCookie('SOME_ACCOUNT_ID')
         expect(Keychain.setGenericPassword).toBeCalledWith(
           GLOBAL_KEY,
           JSON.stringify({
-            CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {}
-            }
+            CSC_COOKIES: {}
           })
         )
       })
@@ -590,108 +505,46 @@ describe('keychain test suite', () => {
         jest.spyOn(Keychain, 'getGenericPassword').mockResolvedValueOnce({
           password: JSON.stringify({
             CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE',
-                    name: 'SOME_EXISTING_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  },
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE_2',
-                    name: 'SOME_EXISTING_COOKIE_NAME_2',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE',
+                  name: 'SOME_EXISTING_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                },
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE_2',
+                  name: 'SOME_EXISTING_COOKIE_NAME_2',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
             }
           })
         })
-        await removeCookie(
-          'SOME_NOT_EXISTING_ACCOUNT_ID',
-          'SOME_KONNECTOR_SLUG'
-        )
+        await removeCookie('SOME_NOT_EXISTING_ACCOUNT_ID')
         expect(Keychain.setGenericPassword).toBeCalledWith(
           GLOBAL_KEY,
           JSON.stringify({
             CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE',
-                    name: 'SOME_EXISTING_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  },
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE_2',
-                    name: 'SOME_EXISTING_COOKIE_NAME_2',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
-            }
-          })
-        )
-      })
-      it('should not modify the saved keychain if the given konnector slug doesnt exist', async () => {
-        jest.spyOn(Keychain, 'getGenericPassword').mockResolvedValueOnce({
-          password: JSON.stringify({
-            CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE',
-                    name: 'SOME_EXISTING_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  },
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE_2',
-                    name: 'SOME_EXISTING_COOKIE_NAME_2',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
-            }
-          })
-        })
-        await removeCookie(
-          'SOME_ACCOUNT_ID',
-          'SOME_NOT_EXISTING_KONNECTOR_SLUG'
-        )
-        expect(Keychain.setGenericPassword).toBeCalledWith(
-          GLOBAL_KEY,
-          JSON.stringify({
-            CSC_COOKIES: {
-              SOME_ACCOUNT_ID: {
-                SOME_KONNECTOR_SLUG: [
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE',
-                    name: 'SOME_EXISTING_COOKIE_NAME',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  },
-                  {
-                    value: 'SOME_EXISTING_COOKIE_VALUE_2',
-                    name: 'SOME_EXISTING_COOKIE_NAME_2',
-                    path: null,
-                    httpOnly: true,
-                    secure: true
-                  }
-                ]
-              }
+              SOME_ACCOUNT_ID: [
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE',
+                  name: 'SOME_EXISTING_COOKIE_NAME',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                },
+                {
+                  value: 'SOME_EXISTING_COOKIE_VALUE_2',
+                  name: 'SOME_EXISTING_COOKIE_NAME_2',
+                  path: null,
+                  httpOnly: true,
+                  secure: true
+                }
+              ]
             }
           })
         )
@@ -702,7 +555,7 @@ describe('keychain test suite', () => {
             VAULT: { key: 'value' }
           })
         })
-        await removeCookie('SOME_ACCOUNT_ID', 'SOME_KONNECTOR_SLUG')
+        await removeCookie('SOME_ACCOUNT_ID')
         expect(Keychain.setGenericPassword).toBeCalledWith(
           GLOBAL_KEY,
           JSON.stringify({


### PR DESCRIPTION
Making it possible for konnectors to ask the ReactNativeLauncher to treat, get and save cookies from the webviews.
Useful in case where wanted or needed cookies are not reachable with a script like cookies in httpOnly.

It allows the konnectors to ask for saving and retrieving cookies in the keychain.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

