### PR TITLE
refactor: Do not wrap async method in React's EventHandler

### DIFF
--- a/src/screens/lock/LockScreen.tsx
+++ b/src/screens/lock/LockScreen.tsx
@@ -50,7 +50,7 @@ const LockView = ({
         </IconButton>
 
         {biometryType && biometryEnabled ? (
-          <IconButton onPress={(): void => void handleBiometry()}>
+          <IconButton onPress={handleBiometry}>
             <Icon icon={getBiometryIcon(biometryType)} />
           </IconButton>
         ) : null}

--- a/src/screens/lock/LockScreenTypes.ts
+++ b/src/screens/lock/LockScreenTypes.ts
@@ -18,7 +18,7 @@ export interface LockViewProps {
   uiError?: string
   togglePasswordVisibility: TouchableWithoutFeedbackProps['onPress']
   passwordVisibility: boolean
-  handleBiometry: () => Promise<void>
+  handleBiometry: () => void
   biometryType: BiometryType | null
   biometryEnabled: boolean
 }

--- a/src/screens/lock/hooks/useLockScreen.ts
+++ b/src/screens/lock/hooks/useLockScreen.ts
@@ -137,10 +137,14 @@ export const useLockScreenProps = (route?: RouteProp): LockViewProps => {
     void asyncCore()
   }
 
-  const handleBiometry = async (): Promise<void> => {
-    const { success } = await promptBiometry()
-    success && onUnlock()
-    // TODO: handle failure
+  const handleBiometry = (): void => {
+    const doHandleBiometry = async (): Promise<void> => {
+      const { success } = await promptBiometry()
+      success && onUnlock()
+      // TODO: handle failure
+    }
+
+    void doHandleBiometry()
   }
 
   const togglePasswordVisibility = (): void =>


### PR DESCRIPTION
This is a test of refactoring to check how we can mitigate the `no-misused-promise` ESLint error.