### PR TITLE
feat: add confirmation dialog when login out from lock screen

### DIFF
--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -5,6 +5,12 @@
     "contactUs": "Un problème, une suggestion ? Contactez-nous à",
     "unknown_error": "Une erreur inattendue s'est produite, veuillez ré-essayer."
   },
+  "logout_dialog": {
+    "cancel": "Annuler",
+    "confirm": "Déconnecter",
+    "content": "Êtes-vous sûr de vouloir vous déconnecter de votre Cozy ?",
+    "title": "Déconnexion"
+  },
   "screens": {
     "cozyNotFound": {
       "body": "Nous n'avons trouvé aucun Cozy à cette adresse. Il s'agit peut-être d'une erreur de frappe. Pour le savoir, vérifiez l'adresse de votre Cozy dans l'e-mail que nous vous avons envoyé au moment de sa création.",

--- a/src/screens/lock/LockScreen.tsx
+++ b/src/screens/lock/LockScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native'
 
 import { Button } from '/ui/Button'
+import { ConfirmDialog } from '/ui/CozyDialogs/ConfirmDialog'
 import { Container } from '/ui/Container'
 import { CozyCircle } from '/ui/Icons/CozyCircle'
 import { Eye } from '/ui/Icons/Eye'
@@ -23,9 +24,9 @@ import { TextField } from '/ui/TextField'
 import { Tooltip } from '/ui/Tooltip'
 import { Typography } from '/ui/Typography'
 import { getBiometryIcon } from '/screens/lock/functions/lockScreenFunctions'
+import { palette } from '/ui/palette'
 import { translation } from '/locales'
 import { useLockScreenProps } from '/screens/lock/hooks/useLockScreen'
-import { palette } from '/ui/palette'
 
 const LockView = ({
   biometryEnabled,
@@ -33,19 +34,44 @@ const LockView = ({
   fqdn,
   handleBiometry,
   handleInput,
+  hasLogoutDialog,
   input,
   logout,
   mode,
   passwordVisibility,
+  toggleLogoutDialog,
   toggleMode,
   togglePasswordVisibility,
   tryUnlock,
   uiError
 }: LockViewProps): JSX.Element => (
   <Container>
+    {hasLogoutDialog && (
+      <ConfirmDialog
+        actions={
+          <>
+            <Button onPress={toggleLogoutDialog}>
+              <Typography variant="button">
+                {translation.logout_dialog.cancel}
+              </Typography>
+            </Button>
+
+            <Button onPress={logout} variant="secondary">
+              <Typography color="textSecondary" variant="button">
+                {translation.logout_dialog.confirm}
+              </Typography>
+            </Button>
+          </>
+        }
+        content={translation.logout_dialog.content}
+        onClose={toggleLogoutDialog}
+        title={translation.logout_dialog.title}
+      />
+    )}
+
     <Grid container direction="column" justifyContent="space-between">
       <Grid justifyContent="space-between">
-        <IconButton onPress={logout}>
+        <IconButton onPress={toggleLogoutDialog}>
           <Icon icon={LogoutFlipped} />
         </IconButton>
 
@@ -115,7 +141,7 @@ const LockView = ({
           onPress={toggleMode}
           style={{ alignSelf: 'flex-start', marginVertical: 16 }}
         >
-          <Typography variant="underline" color="secondary">
+          <Typography color="textSecondary" variant="underline">
             {mode === 'PIN' ? translation.ui.buttons.forgotPin : null}
 
             {mode === 'password' ? translation.ui.buttons.forgotPassword : null}
@@ -125,7 +151,7 @@ const LockView = ({
 
       <Grid direction="column">
         <Button onPress={tryUnlock}>
-          <Typography variant="button">
+          <Typography color="primary" variant="button">
             {translation.ui.buttons.unlock}
           </Typography>
         </Button>

--- a/src/screens/lock/LockScreenTypes.ts
+++ b/src/screens/lock/LockScreenTypes.ts
@@ -1,26 +1,28 @@
+import { BiometryType } from 'react-native-biometrics'
 import { Route } from '@react-navigation/native'
 import { TextInputProps, TouchableWithoutFeedbackProps } from 'react-native'
-import { BiometryType } from 'react-native-biometrics'
 
 export interface LockScreenProps {
   route: CallbackRouteProp
 }
 
 export interface LockViewProps {
+  biometryEnabled: boolean
+  biometryType: BiometryType | null
+  fqdn: string
+  handleBiometry: () => Promise<void>
+  handleInput: TextInputProps['onChangeText']
+  hasLogoutDialog: boolean
   input: string
   logout: () => void
-  handleInput: TextInputProps['onChangeText']
+  mode?: 'password' | 'PIN'
+  passwordVisibility: boolean
+  toggleLogoutDialog: () => void
   toggleMode: TouchableWithoutFeedbackProps['onPress']
+  togglePasswordVisibility: TouchableWithoutFeedbackProps['onPress']
   tryUnlock: TouchableWithoutFeedbackProps['onPress'] &
     TextInputProps['onSubmitEditing']
-  fqdn: string
-  mode?: 'password' | 'PIN'
   uiError?: string
-  togglePasswordVisibility: TouchableWithoutFeedbackProps['onPress']
-  passwordVisibility: boolean
-  handleBiometry: () => Promise<void>
-  biometryType: BiometryType | null
-  biometryEnabled: boolean
 }
 
 export type CallbackRouteProp =

--- a/src/screens/lock/hooks/useLockScreen.ts
+++ b/src/screens/lock/hooks/useLockScreen.ts
@@ -25,11 +25,12 @@ import { openForgotPasswordLink } from '/libs/functions/openForgotPasswordLink'
 export const useLockScreenProps = (route?: RouteProp): LockViewProps => {
   const [biometryEnabled, setBiometryEnabled] = useState(false)
   const [biometryType, setBiometryType] = useState<BiometryType | null>(null)
+  const [hasLogoutDialog, toggleLogoutDialog] = useState(false)
   const [input, setInput] = useState('')
+  const [isOnBackground, setIsOnBackground] = useState(false)
   const [mode, setMode] = useState<'password' | 'PIN'>()
   const [passwordVisibility, _togglePasswordVisibility] = useState(false)
   const [uiError, setUiError] = useState('')
-  const [isOnBackground, setIsOnBackground] = useState(false)
   const client = useClient()
   const { fqdn } = getFqdnFromClient(client)
 
@@ -153,6 +154,8 @@ export const useLockScreenProps = (route?: RouteProp): LockViewProps => {
   return {
     biometryEnabled,
     biometryType,
+    hasLogoutDialog,
+    toggleLogoutDialog: (): void => toggleLogoutDialog(!hasLogoutDialog),
     uiError,
     input,
     logout,

--- a/src/ui/Button/index.tsx
+++ b/src/ui/Button/index.tsx
@@ -3,18 +3,19 @@ import { TouchableOpacity, TouchableOpacityProps } from 'react-native'
 
 import { styles } from '/ui/Button/styles'
 
-type ButtonProps = TouchableOpacityProps
+type ButtonProps = TouchableOpacityProps & { variant?: 'primary' | 'secondary' }
 
 export const Button = ({
   children,
   disabled,
   onPress,
   style,
+  variant = 'primary',
   ...props
 }: ButtonProps): JSX.Element => (
   <TouchableOpacity
     onPress={onPress}
-    style={[styles.button, style]}
+    style={[styles.button, styles[variant], style]}
     disabled={disabled}
     {...props}
   >

--- a/src/ui/Button/styles.ts
+++ b/src/ui/Button/styles.ts
@@ -4,10 +4,17 @@ import { palette } from '/ui/palette'
 
 export const styles = StyleSheet.create({
   button: {
-    backgroundColor: palette.Common.white,
     borderRadius: 2,
     paddingHorizontal: 16,
     paddingVertical: 11,
     width: '100%'
+  },
+  primary: {
+    backgroundColor: palette.Common.white,
+    borderColor: 'rgba(29, 33, 42, 0.16)',
+    borderWidth: 1
+  },
+  secondary: {
+    backgroundColor: palette.Primary['600']
   }
 })

--- a/src/ui/CozyDialogs/ConfirmDialog.tsx
+++ b/src/ui/CozyDialogs/ConfirmDialog.tsx
@@ -1,0 +1,48 @@
+import React, { ReactElement } from 'react'
+import { Modal, Pressable, StyleProp, View, ViewStyle } from 'react-native'
+
+import { Cross } from '/ui/Icons/Cross'
+import { Icon } from '/ui/Icon'
+import { IconButton } from '/ui/IconButton'
+import { Typography } from '/ui/Typography'
+import { styles } from '/ui/CozyDialogs/styles'
+
+interface ConfirmDialogProps {
+  actions: ReactElement<{
+    children: ReactElement<{ style: StyleProp<ViewStyle> }>[]
+  }>
+  content: string
+  onClose: () => void
+  title: string
+}
+
+export const ConfirmDialog = ({
+  actions,
+  content,
+  onClose,
+  title
+}: ConfirmDialogProps): JSX.Element => (
+  <Modal onRequestClose={onClose} statusBarTranslucent transparent>
+    <Pressable style={styles.dialogContainer} onPress={onClose}>
+      <View style={styles.dialog}>
+        <View style={styles.header}>
+          <Typography variant="h3">{title}</Typography>
+
+          <IconButton onPress={onClose}>
+            <Icon icon={Cross} />
+          </IconButton>
+        </View>
+
+        <View style={styles.content}>
+          <Typography>{content}</Typography>
+        </View>
+
+        <View style={styles.footer}>
+          {actions.props.children.map(child =>
+            React.cloneElement(child, { style: styles.actions })
+          )}
+        </View>
+      </View>
+    </Pressable>
+  </Modal>
+)

--- a/src/ui/CozyDialogs/styles.ts
+++ b/src/ui/CozyDialogs/styles.ts
@@ -1,0 +1,50 @@
+import { StyleSheet } from 'react-native'
+
+import { palette } from '/ui/palette'
+
+export const styles = StyleSheet.create({
+  actions: {
+    marginHorizontal: 4,
+    width: '50%'
+  },
+  content: {
+    marginBottom: 24,
+    paddingHorizontal: 32
+  },
+  dialog: {
+    alignSelf: 'center',
+    backgroundColor: palette.Common.white,
+    borderRadius: 8,
+    boxShadow:
+      '0px 0px 0px 0.5px rgba(29, 33, 42, 0.12), 0px 8px 12px -5px rgba(29, 33, 42, 0.18), 0px 9px 36px 5px rgba(29, 33, 42, 0.17)',
+    justifyself: 'center'
+  },
+  dialogContainer: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    display: 'flex',
+    height: '100%',
+    justifyContent: 'center',
+    padding: 24,
+    width: '100%'
+  },
+  footer: {
+    alignItems: 'stretch',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginLeft: -4,
+    marginRight: 12,
+    paddingBottom: 24,
+    paddingHorizontal: 32
+  },
+  header: {
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 24,
+    paddingHorizontal: 32,
+    paddingTop: 24
+  }
+})

--- a/src/ui/Icons/Cross.tsx
+++ b/src/ui/Icons/Cross.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { CommonPathProps, SvgXml } from 'react-native-svg'
+
+export const Cross = (props?: CommonPathProps): JSX.Element => (
+  <SvgXml
+    {...props}
+    xml='&lt;svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"&gt;&lt;g id="icons/16/icon-cross"&gt;&lt;path id="Shape" fill-rule="evenodd" clip-rule="evenodd" d="M8 6.58579L13.2929 1.29289C13.6834 0.902369 14.3166 0.902369 14.7071 1.29289C15.0976 1.68342 15.0976 2.31658 14.7071 2.70711L9.41421 8L14.7071 13.2929C15.0976 13.6834 15.0976 14.3166 14.7071 14.7071C14.3166 15.0976 13.6834 15.0976 13.2929 14.7071L8 9.41421L2.70711 14.7071C2.31658 15.0976 1.68342 15.0976 1.29289 14.7071C0.902369 14.3166 0.902369 13.6834 1.29289 13.2929L6.58579 8L1.29289 2.70711C0.902369 2.31658 0.902369 1.68342 1.29289 1.29289C1.68342 0.902369 2.31658 0.902369 2.70711 1.29289L8 6.58579Z" fill="#1D212A" fill-opacity="0.72"/&gt;&lt;/g&gt;&lt;/svg&gt;'
+  />
+)

--- a/src/ui/Typography/index.tsx
+++ b/src/ui/Typography/index.tsx
@@ -32,7 +32,7 @@ interface TypographyProps extends TextProps {
 }
 
 export const Typography = ({
-  color = 'primary',
+  color = 'textPrimary',
   children,
   variant = 'body2',
   style,

--- a/src/ui/Typography/styles.ts
+++ b/src/ui/Typography/styles.ts
@@ -8,8 +8,8 @@ export const styles = StyleSheet.create({
   inherit: { color: palette.Primary.ContrastText },
   primary: { color: palette.Primary['600'] },
   secondary: { color: palette.Primary.ContrastText },
-  textPrimary: { color: palette.Primary.ContrastText },
-  textSecondary: { color: palette.Primary.ContrastText },
+  textPrimary: { color: palette.Grey['900'] },
+  textSecondary: { color: palette.Common.white },
   error: { color: palette.Primary.ContrastText },
   h4: {
     fontFamily: 'Lato-Bold',
@@ -41,7 +41,12 @@ export const styles = StyleSheet.create({
   },
   h1: { fontSize: 16 },
   h2: { fontSize: 16 },
-  h3: { fontSize: 16 },
+  h3: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: palette.Grey['900'],
+    lineHeight: 20
+  },
   h5: { fontSize: 16 },
   subtitle1: { fontSize: 16 },
   subtitle2: { fontSize: 16 },


### PR DESCRIPTION
### Feature

When the user clicks on the logout button when on unlock screen, ask him to confirm the action.

### Implementation

Leveraging the <Modal> RN component to display a simple modal. Using the cozy-ui ConfirmationDialog API and cozy-ui/figma style variables. There is an issue with the android navigation bar though which stays black when a <Modal> component is rendered

### Thoughts

Starting to have magic numbers in stylesheets (even if they all come from Figma)