### PR TITLE
fix: Get initial offline route correctly

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -141,7 +141,7 @@ const App = ({ setClient }) => {
       <Root.Screen
         name={routes.error}
         component={ErrorScreen}
-        options={{ type: initialRoute.root }}
+        initialParams={{ type: initialRoute.root }}
       />
 
       <Root.Screen

--- a/src/config/dev.ts
+++ b/src/config/dev.ts
@@ -1,6 +1,7 @@
 export const devConfig = {
   disableGetIndex: false, // Make cozy-app hosted by webpack-dev-server work with HTTPServer
   forceHideSplashScreen: false, // Hide react-native splash screen renders in development mode,
-  ignoreLogBox: true, // Hide react-native logbox renders in development mode,
-  sentry: false // Allow Sentry logging in development mode
+  ignoreLogBox: false, // Hide react-native logbox renders in development mode,
+  forceOffline: false, // Force offline mode in development mode,
+  sentry: false // Allow Sentry logging in development mode,
 }

--- a/src/libs/services/NetService.js
+++ b/src/libs/services/NetService.js
@@ -3,9 +3,10 @@ import NetInfo from '@react-native-community/netinfo'
 import Minilog from '@cozy/minilog'
 
 import strings from '/strings.json'
+import { devConfig } from '/config/dev'
 import { reset } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
-import { showSplashScreen } from './SplashScreenService'
+import { showSplashScreen } from '/libs/services/SplashScreenService'
 
 const log = Minilog('NetService')
 
@@ -46,9 +47,11 @@ const handleOffline = () =>
 
 const toggleNetWatcher = makeNetWatcher()
 
-export const NetService = {
+const NetService = {
   handleOffline,
-  isConnected,
-  isOffline,
-  toggleNetWatcher
+  isConnected: devConfig.forceOffline ? Promise.resolve(false) : isConnected,
+  isOffline: devConfig.forceOffline ? Promise.resolve(true) : isOffline,
+  toggleNetWatcher: devConfig.forceOffline ? () => {} : toggleNetWatcher
 }
+
+export { NetService }


### PR DESCRIPTION
Strangely enough, the error page used `options` instead of `initialParams` to set the error type. So in some cases there was nothing to display because we didn't have any params even if the ErrorScreen was asked.