### PR TITLE
feat: Bump app version to 0.0.27 and change Android targetSDK for `31`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.29
+# 0.0.30
 
 ## ✨ Features
 
@@ -8,6 +8,28 @@
 
 ## 🔧 Tech
 
+
+# 0.0.29
+
+## ✨ Features
+
+* Add unlock by PIN feature ([PR #432](https://github.com/cozy/cozy-react-native/pull/432))
+* Improve Lock Screen UI ([PR #442](https://github.com/cozy/cozy-react-native/pull/442))
+* Add `Veolia Eau` in Client Side Connectors ([PR #430](https://github.com/cozy/cozy-react-native/pull/430))
+* Add `Gaz Tarif Réglementé` in Client Side Connectors ([PR #437](https://github.com/cozy/cozy-react-native/pull/437))
+
+## 🐛 Bug Fixes
+
+* Fix bugs related to lock/unlock feature ([PR #441](https://github.com/cozy/cozy-react-native/pull/441) and [PR #453](https://github.com/cozy/cozy-react-native/pull/453))
+* Fix `TotalEnergie` Client Side Connectors ([PR #448](https://github.com/cozy/cozy-react-native/pull/448))
+* Fix app crash when opening a cozy-app ([PR #449](https://github.com/cozy/cozy-react-native/pull/449))
+
+## 🔧 Tech
+
+* Improve project's documentation about Java JDK requirement ([PR #447](https://github.com/cozy/cozy-react-native/pull/447))
+* Improve project's documentation about Sentry configuration ([PR #445](https://github.com/cozy/cozy-react-native/pull/445))
+* Force `androidXBrowser` version to 1.4.0 ([PR #446](https://github.com/cozy/cozy-react-native/pull/446))
+* Add `Hermes` to iOS linked libraries ([PR #451](https://github.com/cozy/cozy-react-native/pull/451))
 
 # 0.0.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,28 @@
-# 0.0.30
+# 0.0.31
 
 ## ✨ Features
 
 
 ## 🐛 Bug Fixes
 
+
+## 🔧 Tech
+
+
+# 0.0.30
+
+## ✨ Features
+
+* Handle iOS authorization for FaceID ([PR #457](https://github.com/cozy/cozy-react-native/pull/457))
+* Add confirmation dialog when login out from Lock screen ([PR #467](https://github.com/cozy/cozy-react-native/pull/467))
+
+## 🐛 Bug Fixes
+
+* Fix imported files naming format (date) for `TotalEnergie` Client Side Connectors ([PR #461](https://github.com/cozy/cozy-react-native/pull/461))
+* Autolock is not automatically disabled anymore when Biometry is disabled ([PR #459](https://github.com/cozy/cozy-react-native/pull/459))
+* Correctly handle status bar and navigation bar colors on Lock screen ([PR #458](https://github.com/cozy/cozy-react-native/pull/458))
+* Prevent app to be instantaneously locked when opening a file from cozy-drive ([PR #465](https://github.com/cozy/cozy-react-native/pull/465))
+* Fix a scenario where the Offline error screen was blank ([PR #469](https://github.com/cozy/cozy-react-native/pull/469))
 
 ## 🔧 Tech
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.28
+# 0.0.29
 
 ## ✨ Features
 
@@ -8,6 +8,19 @@
 
 ## 🔧 Tech
 
+
+# 0.0.28
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+* Fix iOS FaceID crash due to missing permissions declaration ([PR #435](https://github.com/cozy/cozy-react-native/pull/435))
+
+## 🔧 Tech
+
+* Activate Hermes engine ([PR #260](https://github.com/cozy/cozy-react-native/pull/260))
 
 # 0.0.27
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2901
-        versionName "0.0.29"
+        versionCode 3001
+        versionName "0.0.30"
         multiDexEnabled true
     }
     splits {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2701
-        versionName "0.0.27"
+        versionCode 2801
+        versionName "0.0.28"
         multiDexEnabled true
     }
     splits {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2801
-        versionName "0.0.28"
+        versionCode 2901
+        versionName "0.0.29"
         multiDexEnabled true
     }
     splits {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,6 +55,7 @@
       <activity
         android:name="com.zoontek.rnbootsplash.RNBootSplashActivity"
         android:theme="@style/BootTheme"
+        android:exported="false"
         android:launchMode="singleTask">
         <intent-filter>
           <action android:name="android.intent.action.MAIN" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 31
-        targetSdkVersion = 30
+        targetSdkVersion = 31
         ndkVersion = "21.4.7075529"
         androidXBrowser = "1.4.0"
     }

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.29</string>
+	<string>0.0.30</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0002901</string>
+	<string>0003001</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.28</string>
+	<string>0.0.29</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0002801</string>
+	<string>0002901</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.27</string>
+	<string>0.0.28</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0002701</string>
+	<string>0002801</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.30
- change Android targetSDK for `31` ([more info](https://developer.android.com/google/play/requirements/target-sdk))
- creates a new entry for next 0.0.31 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs