### PR TITLE
fix: Force SDK version to 31 for react-native-android-navbar-height

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,8 @@ buildscript {
         targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
         androidXBrowser = "1.4.0"
+        AndroidNavbarHeight_targetSdkVersion = 31
+        AndroidNavbarHeight_compileSdkVersion = 31
     }
     repositories {
         google()


### PR DESCRIPTION
This would fix the `AAPT: error: resource android:attr/lStar not found` error when building APK

___

TODO:

- [ ] Upgrade `cozy-react-native-google-safetynet` after cozy/cozy-react-native-google-safetynet#4 is merged

