### PR TITLE
fix: Reconfigure NetService after logout

### DIFF
--- a/src/libs/services/NetService.ts
+++ b/src/libs/services/NetService.ts
@@ -17,7 +17,7 @@ const log = Minilog('NetService')
 
 const configureService = (client?: CozyClient): void => {
   NetInfo.configure({
-    reachabilityUrl: client
+    reachabilityUrl: client?.isLogged
       ? `${(client.getStackClient() as { uri: string }).uri}/${
           strings.reachability.stack
         }`
@@ -27,7 +27,17 @@ const configureService = (client?: CozyClient): void => {
 
 export const useNetService = (client?: CozyClient): void =>
   useEffect(() => {
-    configureService(client)
+    const configure = (): void => {
+      configureService(client)
+    }
+
+    client?.on('logout', configure)
+
+    configure()
+
+    return () => {
+      client?.removeListener('logout', configure)
+    }
   }, [client])
 
 export const _netInfoChangeHandler = (

--- a/src/libs/services/NetService.ts
+++ b/src/libs/services/NetService.ts
@@ -1,5 +1,6 @@
 import NetInfo, {
   NetInfoState,
+  NetInfoStateType,
   NetInfoSubscription
 } from '@react-native-community/netinfo'
 import { useEffect } from 'react'
@@ -14,6 +15,16 @@ import { routes } from '/constants/routes'
 import { showSplashScreen } from '/libs/services/SplashScreenService'
 
 const log = Minilog('NetService')
+
+if (devConfig.forceOffline) {
+  NetInfo.fetch = (): Promise<NetInfoState> =>
+    Promise.resolve({
+      details: null,
+      isConnected: false,
+      isInternetReachable: false,
+      type: NetInfoStateType.none
+    })
+}
 
 const configureService = (client?: CozyClient): void => {
   NetInfo.configure({
@@ -86,19 +97,13 @@ const isOffline = async (): Promise<NetInfoState['isConnected']> =>
 const handleOffline = (): void =>
   reset(routes.error, { type: strings.errorScreens.offline })
 
-const toggleNetWatcher = makeNetWatcher()
+const toggleNetWatcher = devConfig.forceOffline
+  ? (): void => undefined
+  : makeNetWatcher()
 
-const NetService = {
+export const NetService = {
   handleOffline,
-  isConnected: devConfig.forceOffline
-    ? (): Promise<false> => Promise.resolve(false)
-    : isConnected,
-  isOffline: devConfig.forceOffline
-    ? (): Promise<true> => Promise.resolve(true)
-    : isOffline,
-  toggleNetWatcher: devConfig.forceOffline
-    ? (): void => undefined
-    : toggleNetWatcher
+  isConnected,
+  isOffline,
+  toggleNetWatcher
 }
-
-export { NetService }

--- a/src/libs/services/NetService.ts
+++ b/src/libs/services/NetService.ts
@@ -81,7 +81,7 @@ const isConnected = async (): Promise<NetInfoState['isConnected']> =>
   (await NetInfo.fetch()).isConnected
 
 const isOffline = async (): Promise<NetInfoState['isConnected']> =>
-  !(await NetInfo.fetch()).isConnected
+  (await NetInfo.fetch()).isConnected === false
 
 const handleOffline = (): void =>
   reset(routes.error, { type: strings.errorScreens.offline })


### PR DESCRIPTION
In #468 we fixed logout method to correctly logs out cozy-client

This state change should be detected by NetService so it can reconfigure itself to ping the Cloudery instead of the previous cozy-stack

> **Note**
> This PR can be merged before #468 , it will just do nothing until this other PR is merged
