### PR TITLE
Fix/ios httpserver onlyoffice

### DIFF
--- a/src/libs/httpserver/indexGenerator.js
+++ b/src/libs/httpserver/indexGenerator.js
@@ -26,7 +26,10 @@ const slugBlocklist = [
 
   // settings cannot be injected until we modernize it by doing all queries through
   // cozy-client and correctly handle `https` override with `isSecureProtocol` parameter
-  { platform: 'ios', slug: 'settings' }
+  { platform: 'ios', slug: 'settings' },
+
+  // drive cannot be injected until we fix window.history bug on iOS (bug in OnlyOffice)
+  { platform: 'ios', slug: 'drive' }
 ]
 
 const initLocalBundleIfNotExist = async (fqdn, slug) => {

--- a/src/libs/httpserver/indexGenerator.spec.js
+++ b/src/libs/httpserver/indexGenerator.spec.js
@@ -343,6 +343,46 @@ ifTestEnabled('indexGenerator', () => {
 
         expect(result).toBe('SOME_FILE_CONTENT')
       })
+
+      it(`should not try to generate index.html if slug is 'settings' and platform is 'iOS'`, async () => {
+        const fqdn = 'cozy.tools'
+        const slug = 'settings'
+        RN.Platform.OS = 'ios'
+
+        const result = await getIndexForFqdnAndSlug(fqdn, slug)
+
+        expect(result).toBe(false)
+      })
+
+      it(`should generate index.html if slug is 'settings' and platform is 'android'`, async () => {
+        const fqdn = 'cozy.tools'
+        const slug = 'settings'
+        RN.Platform.OS = 'android'
+
+        const result = await getIndexForFqdnAndSlug(fqdn, slug)
+
+        expect(result).toBe('SOME_FILE_CONTENT')
+      })
+
+      it(`should not try to generate index.html if slug is 'drive' and platform is 'iOS'`, async () => {
+        const fqdn = 'cozy.tools'
+        const slug = 'drive'
+        RN.Platform.OS = 'ios'
+
+        const result = await getIndexForFqdnAndSlug(fqdn, slug)
+
+        expect(result).toBe(false)
+      })
+
+      it(`should generate index.html if slug is 'drive' and platform is 'android'`, async () => {
+        const fqdn = 'cozy.tools'
+        const slug = 'drive'
+        RN.Platform.OS = 'android'
+
+        const result = await getIndexForFqdnAndSlug(fqdn, slug)
+
+        expect(result).toBe('SOME_FILE_CONTENT')
+      })
     })
   })
 })


### PR DESCRIPTION
Current HttpServer implementation set `source={html, baseUrl}` on the
iOS' WebView

By doing so, the WebView's history does not work anymore due to a bug
on `WKWebview` component

This makes some iOS apps work incorrectly

In previous commits we set a blockList to prevent some slugs to be
served through HttpServer on iOS

But we found that there are still a lot of unknown features that may
not work

So we prefer to reverse the logic an only approve slugs that have been
test and proved to be working

Related issue: react-native-webview/react-native-webview#2608