### PR TITLE
fix: improve autolock pairing with biometry/pinCode

### DIFF
--- a/src/libs/intents/setBiometryState.ts
+++ b/src/libs/intents/setBiometryState.ts
@@ -6,15 +6,19 @@ import { FlagshipMetadata } from 'cozy-device-helper/dist/flagship'
 import { getData, StorageKeys, storeData } from '/libs/localStore/storage'
 import { promptBiometry } from '/screens/lock/functions/lockScreenFunctions'
 import { getVaultInformation } from '../keychain'
+import { ensureAutoLockIsEnabled } from './toggleSetting'
 
 export const BiometryEmitter = new EventEmitter()
 
 const BIOMETRY_DENIED_BY_USER_IOS_ERROR = /.*User.*denied.*/
 
-const updateBiometrySetting = async (activated: boolean): Promise<boolean> => {
+export const updateBiometrySetting = async (
+  activated: boolean
+): Promise<boolean> => {
   await storeData(StorageKeys.BiometryActivated, activated)
-  if (!activated && !(await getData(StorageKeys.AutoLockEnabled)))
-    await storeData(StorageKeys.AutoLockEnabled, true)
+
+  if (activated) await ensureAutoLockIsEnabled()
+
   const newData = Boolean(await getData(StorageKeys.BiometryActivated))
 
   BiometryEmitter.emit('change', newData)

--- a/src/libs/intents/toggleSetting.spec.ts
+++ b/src/libs/intents/toggleSetting.spec.ts
@@ -1,0 +1,73 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { StorageKeys } from '../localStore/storage'
+
+import { ensureAutoLockIsEnabled } from '/libs/intents/toggleSetting'
+
+jest.mock('@react-native-cookies/cookies', () => ({
+  clearAll: jest.fn()
+}))
+
+describe('ensureAutoLockIsEnabled', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear()
+  })
+
+  it('should not tamper with autoLock value when already enabled', async () => {
+    const expected = 'true'
+
+    await AsyncStorage.setItem(StorageKeys.AutoLockEnabled, expected)
+
+    await ensureAutoLockIsEnabled()
+
+    const result = await AsyncStorage.getItem(StorageKeys.AutoLockEnabled)
+
+    expect(result).toBe(expected)
+  })
+
+  it('should set autoLock value to true when the key does not exist', async () => {
+    const expected = 'true'
+
+    await ensureAutoLockIsEnabled()
+
+    const result = await AsyncStorage.getItem(StorageKeys.AutoLockEnabled)
+
+    expect(result).toBe(expected)
+  })
+
+  it('should set autoLock value to true when the key exists with a false string', async () => {
+    const expected = 'true'
+
+    await AsyncStorage.setItem(StorageKeys.AutoLockEnabled, 'false')
+
+    await ensureAutoLockIsEnabled()
+
+    const result = await AsyncStorage.getItem(StorageKeys.AutoLockEnabled)
+
+    expect(result).toBe(expected)
+  })
+
+  it('should set autoLock value to true when the key exists with a falsy value', async () => {
+    const expected = 'true'
+
+    await AsyncStorage.setItem(StorageKeys.AutoLockEnabled, '')
+
+    await ensureAutoLockIsEnabled()
+
+    const result = await AsyncStorage.getItem(StorageKeys.AutoLockEnabled)
+
+    expect(result).toBe(expected)
+  })
+
+  /* Improbable case, but still possible */
+  it('should not tamper with autoLock value when the key exists with a truthy value', async () => {
+    const expected = '"foobar"'
+
+    await AsyncStorage.setItem(StorageKeys.AutoLockEnabled, expected)
+
+    await ensureAutoLockIsEnabled()
+
+    const result = await AsyncStorage.getItem(StorageKeys.AutoLockEnabled)
+
+    expect(result).toBe(expected)
+  })
+})

--- a/src/libs/intents/toggleSetting.ts
+++ b/src/libs/intents/toggleSetting.ts
@@ -26,6 +26,14 @@ const toggleStorageSetting = async (
   return null
 }
 
+export const ensureAutoLockIsEnabled = async (): Promise<void> => {
+  const autoLockEnabled = await getData(StorageKeys.AutoLockEnabled)
+
+  if (!autoLockEnabled) {
+    await storeData(StorageKeys.AutoLockEnabled, true)
+  }
+}
+
 export const toggleSetting = async (
   settingName: 'biometryLock' | 'autoLock' | 'PINLock',
   params?: { pinCode: string }
@@ -42,9 +50,9 @@ export const toggleSetting = async (
     resolveTo = false
   }
 
-  if (params?.pinCode) {
-    typeof params.pinCode === 'string' &&
-      (await saveVaultInformation('pinCode', params.pinCode))
+  if (params?.pinCode && typeof params.pinCode === 'string') {
+    await saveVaultInformation('pinCode', params.pinCode)
+    await ensureAutoLockIsEnabled()
     resolveTo = true
   }
 


### PR DESCRIPTION
Autolock should always get stored as true if pinCode/biometry are also
set to true.