### PR TITLE
feat: Bump app version to 0.0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.31
+# 0.0.32
 
 ## ✨ Features
 
@@ -8,6 +8,32 @@
 
 ## 🔧 Tech
 
+
+# 0.0.31
+
+## ✨ Features
+
+* The connectivity checks are now targeting the Cozy server instead of Google's ones ([PR #470](https://github.com/cozy/cozy-react-native/pull/470) and [PR #479](https://github.com/cozy/cozy-react-native/pull/479))
+* Improve Client Side Connectors API by allowing connectors to manipulate related Cookies ([PR #460](https://github.com/cozy/cozy-react-native/pull/460))
+* Lock screen UI is now using the Cozy's system font ([PR #485](https://github.com/cozy/cozy-react-native/pull/485))
+
+## 🐛 Bug Fixes
+
+* Prevent the app to crash when trying to open an email link but no email client is set on the Android phone ([PR #473](https://github.com/cozy/cozy-react-native/pull/473))
+* Re-apply user's session when App resumes ([PR #468](https://github.com/cozy/cozy-react-native/pull/468))
+* Only serve approved cozy-apps through HttpServer ([PR #486](https://github.com/cozy/cozy-react-native/pull/486))
+* Fix a bug that prevented to open PDF on latest Android versions ([PR #477](https://github.com/cozy/cozy-react-native/pull/477))
+* Fix a bug that could crash the App when opening an in-app browser ([PR #477](https://github.com/cozy/cozy-react-native/pull/477))
+* Fix a bug that could crash the App when accessing `caller.name` JS API ([PR #489](https://github.com/cozy/cozy-react-native/pull/489))
+* Correctly handle Offline detection when opening the App ([PR #488](https://github.com/cozy/cozy-react-native/pull/488))
+
+## 🔧 Tech
+
+* Upgrade testing environment ([PR #471](https://github.com/cozy/cozy-react-native/pull/471))
+* Fix build that was breaking due to incorrect import ([PR #476](https://github.com/cozy/cozy-react-native/pull/476))
+* Add documentation about `PhaseScriptExecution failed` build error in Troubleshooting section ([PR #450](https://github.com/cozy/cozy-react-native/pull/450))
+* Improve release process by generating the Home embedded bundle using the Cozy's Registry ([PR #478](https://github.com/cozy/cozy-react-native/pull/478))
+* Homogenise AsyncStorage keys ([PR #487](https://github.com/cozy/cozy-react-native/pull/487))
 
 # 0.0.30
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3002
-        versionName "0.0.30"
+        versionCode 3101
+        versionName "0.0.31"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.30</string>
+	<string>0.0.31</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0003001</string>
+	<string>0003101</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -305,7 +305,7 @@ PODS:
   - react-native-gzip (2.0.0):
     - NVHTarGzip
     - React
-  - react-native-netinfo (8.3.0):
+  - react-native-netinfo (9.3.6):
     - React-Core
   - react-native-safe-area-context (4.3.1):
     - RCT-Folly
@@ -382,7 +382,7 @@ PODS:
     - React-perflogger (= 0.66.4)
   - RNBootSplash (3.2.3):
     - React-Core
-  - RNCAsyncStorage (1.17.7):
+  - RNCAsyncStorage (1.17.11):
     - React-Core
   - RNDeviceInfo (10.0.2):
     - React-Core
@@ -400,7 +400,7 @@ PODS:
     - React-Core
   - RNScreens (2.18.1):
     - React-Core
-  - RNSentry (3.4.1):
+  - RNSentry (3.4.3):
     - React-Core
     - Sentry (= 7.11.0)
   - RNSVG (12.3.0):
@@ -656,7 +656,7 @@ SPEC CHECKSUMS:
   react-native-cookies: 6004d512ffc6f2c498c5b70cda0bc040350c0585
   react-native-flipper: 4bfe0a324e663f1ae2f76ad0da75673de6895efe
   react-native-gzip: 5ffb84bf191c7cd135338eca748317bc466d41a1
-  react-native-netinfo: 3671b091c4843fda5e153612866ef4024b8f5d62
+  react-native-netinfo: f80db8cac2151405633324cb645c60af098ee461
   react-native-safe-area-context: 6c12e3859b6f27b25de4fee8201cfb858432d8de
   react-native-webview: 8ec7ddf9eb4ddcd92b32cee7907efec19a9ec7cb
   React-perflogger: 93075d8931c32cd1fce8a98c15d2d5ccc4d891bd
@@ -672,7 +672,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: dec32ee6f2e2a26e13e58152271535fadff5455a
   ReactCommon: 57b69f6383eafcbd7da625bfa6003810332313c4
   RNBootSplash: 8ef5ffa03dadd35f66510b42960ce40f397c98bf
-  RNCAsyncStorage: d81ee5c3db1060afd49ea7045ad460eff82d2b7d
+  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNDeviceInfo: 0a7c1d2532aa7691f9b9925a27e43af006db4dae
   RNFileViewer: ce7ca3ac370e18554d35d6355cffd7c30437c592
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
@@ -681,7 +681,7 @@ SPEC CHECKSUMS:
   RNIOS11DeviceCheck: 9b36378a945711eba558e5e0db3a15a9ccb83150
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
-  RNSentry: fbbdcd7213058e3de5fbaa452b25a06a16b4b382
+  RNSentry: 85f6525b5fe8d2ada065858026b338605b3c09da
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.31
- creates a new entry for next 0.0.32 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs