### PR TITLE
docs: Add port and url to use when working on Android with locally ho…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ $ yarn ios
 ### Working with locally hosted webviews
 
 #### On Android
-* Create a cozy instance with the following format : `foobar.10-0-2-2.nip.io`, so the webview browser has access to cozy-stack instances thanks to the redirection done by https://nip.io (10.0.2.2 is the local IP address of your emulator)
+* Create a cozy instance with the following format : `foobar.10-0-2-2.nip.io:8080`, so the webview browser has access to cozy-stack instances thanks to the redirection done by https://nip.io (10.0.2.2 is the local IP address of your emulator)
 * Launch your cozy app with `DEV_HOST=(some accessible local IP)` preceding the actual start command, so the webview browser has access to webpack dev server assets. See some examples below:
     * `DEV_HOST="$(ip -4 address show eth0| grep -Po 'inet [^/]+' | cut -d' ' -f2)" yarn start`
     * `DEV_HOST="$(hostname -I | xargs)" yarn start`
 * Disable the local httpServer by setting to `true` disableGetIndex in `dev.js`
 * Your webview browser should now be able to use a locally hosted cozy-app in development/hot-reload mode
+
+You can then connect to your local stack using the following URL : `http://foobar.10-0-2-2.nip.io:8080`
 
 #### On iOS simulator 
 * Create a cozy instance with the *.cozy.tools:8080 format


### PR DESCRIPTION
…sted webviews

When blindly following these steps, I forgot to add a custom port like 8080. So app could not connect to the stack. I also did not write explicitly http which can lead to connection issues.

