### PR TITLE
feat: Bump app version to 0.0.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.33
+# 0.0.34
 
 ## ✨ Features
 
@@ -8,6 +8,19 @@
 
 ## 🔧 Tech
 
+
+# 0.0.33
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+* Fix a bug that prevented the app to logout ([PR #498](https://github.com/cozy/cozy-react-native/pull/498))
+
+## 🔧 Tech
+
+* Improve dev documentation about debugging from an Android emulator ([PR #499](https://github.com/cozy/cozy-react-native/pull/499))
 
 # 0.0.32
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3201
-        versionName "0.0.32"
+        versionCode 3301
+        versionName "0.0.33"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.32</string>
+	<string>0.0.33</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0003201</string>
+	<string>0003301</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 0.0.33
- creates a new entry for next 0.0.34 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs