### PR TITLE
fix: Force LockScreen to be on top of the UI

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -398,8 +398,9 @@ PODS:
     - React
   - RNKeychain (8.0.0):
     - React-Core
-  - RNScreens (2.18.1):
+  - RNScreens (3.18.2):
     - React-Core
+    - React-RCTImage
   - RNSentry (3.4.3):
     - React-Core
     - Sentry (= 7.11.0)
@@ -680,7 +681,7 @@ SPEC CHECKSUMS:
   RNInAppBrowser: 48b95ba7a4eaff5cc223bca338d3e319561dbd1b
   RNIOS11DeviceCheck: 9b36378a945711eba558e5e0db3a15a9ccb83150
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
-  RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
+  RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
   RNSentry: 85f6525b5fe8d2ada065858026b338605b3c09da
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-native-keychain": "^8.0.0",
     "react-native-mask-input": "1.2.1",
     "react-native-safe-area-context": "^4.3.1",
-    "react-native-screens": "2.18.1",
+    "react-native-screens": "3.18.2",
     "react-native-status-bar-height": "^2.6.0",
     "react-native-svg": "12.3.0",
     "react-native-url-polyfill": "^1.3.0",

--- a/patches/react-native-file-viewer+2.1.5.patch
+++ b/patches/react-native-file-viewer+2.1.5.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/react-native-file-viewer/ios/RNFileViewerManager.m b/node_modules/react-native-file-viewer/ios/RNFileViewerManager.m
+index 8149cac..6ea97af 100644
+--- a/node_modules/react-native-file-viewer/ios/RNFileViewerManager.m
++++ b/node_modules/react-native-file-viewer/ios/RNFileViewerManager.m
+@@ -102,6 +102,12 @@ - (void)previewControllerDidDismiss:(CustomQLViewController *)controller {
+     [self sendEventWithName:DISMISS_EVENT body: @{@"id": controller.invocation}];
+ }
+ 
++- (void)dismissView:(id)sender {
++    UIViewController* controller = [RNFileViewer topViewController];
++    [self sendEventWithName:DISMISS_EVENT body: @{@"id": ((CustomQLViewController*)controller).invocation}];
++    [[RNFileViewer topViewController] dismissViewControllerAnimated:YES completion:nil];
++}
++
+ RCT_EXPORT_MODULE()
+ 
+ - (NSArray<NSString *> *)supportedEvents {
+@@ -117,8 +123,17 @@ - (void)previewControllerDidDismiss:(CustomQLViewController *)controller {
+     QLPreviewController *controller = [[CustomQLViewController alloc] initWithFile:file identifier:invocationId];
+     controller.delegate = self;
+ 
++    if (@available(iOS 13.0, *)) {
++        [controller setModalInPresentation: true];
++    }
++
++    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:controller];
++    controller.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissView:)];
++    controller.navigationController.navigationBar.translucent = NO;
++    controller.edgesForExtendedLayout = UIRectEdgeNone;
++
+     typeof(self) __weak weakSelf = self;
+-    [[RNFileViewer topViewController] presentViewController:controller animated:YES completion:^{
++    [[RNFileViewer topViewController] presentViewController:navigationController animated:YES completion:^{
+         [weakSelf sendEventWithName:OPEN_EVENT body: @{@"id": invocationId}];
+     }];
+ }

--- a/src/screens/lock/LockScreen.tsx
+++ b/src/screens/lock/LockScreen.tsx
@@ -6,6 +6,7 @@ import {
   Platform,
   TouchableWithoutFeedback
 } from 'react-native'
+import { FullWindowOverlay } from 'react-native-screens'
 
 import { Button } from '/ui/Button'
 import { ConfirmDialog } from '/ui/CozyDialogs/ConfirmDialog'
@@ -162,17 +163,19 @@ const LockView = ({
 
 export const LockScreen = (props: LockScreenProps): JSX.Element => (
   <>
-    <LockScreenBars />
+    <FullWindowOverlay>
+      <LockScreenBars />
 
-    <TouchableWithoutFeedback
-      onPress={Keyboard.dismiss}
-      style={{ backgroundColor: palette.Primary[600], height: '100%' }}
-    >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      <TouchableWithoutFeedback
+        onPress={Keyboard.dismiss}
+        style={{ backgroundColor: palette.Primary[600], height: '100%' }}
       >
-        <LockView {...useLockScreenProps(props.route?.params)} />
-      </KeyboardAvoidingView>
-    </TouchableWithoutFeedback>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
+          <LockView {...useLockScreenProps(props.route?.params)} />
+        </KeyboardAvoidingView>
+      </TouchableWithoutFeedback>
+    </FullWindowOverlay>
   </>
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -14709,6 +14709,11 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-freeze@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.3.tgz#5e3ca90e682fed1d73a7cb50c2c7402b3e85618d"
+  integrity sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g==
+
 react-input-autosize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
@@ -14847,10 +14852,13 @@ react-native-safe-area-context@^4.3.1:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.1.tgz#5cf97b25b395e0d09bc1f828920cd7da0d792ade"
   integrity sha512-cEr7fknJCToTrSyDCVNg0GRdRMhyLeQa2NZwVCuzEQcWedOw/59ExomjmzCE4rxrKXs6OJbyfNtFRNyewDaHuA==
 
-react-native-screens@2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.18.1.tgz#47b9991c6f762d00d0ed3233e5283d523e859885"
-  integrity sha512-r5WZLpmx2hHjC1RgMdPq5YpSU9tEhBpUaZ5M1SUtNIONyiLqQVxabhRCINdebIk4depJiIl7yw2Q85zJyeX6fw==
+react-native-screens@3.18.2:
+  version "3.18.2"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.18.2.tgz#d7ab2d145258d3db9fa630fa5379dc4474117866"
+  integrity sha512-ANUEuvMUlsYJ1QKukEhzhfrvOUO9BVH9Nzg+6eWxpn3cfD/O83yPBOF8Mx6x5H/2+sMy+VS5x/chWOOo/U7QJw==
+  dependencies:
+    react-freeze "^1.0.0"
+    warn-once "^0.1.0"
 
 react-native-securerandom@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
On iOS when the users opens a file (PDF, Image, etc), then a QuickLook
controller is displayed on top of the app with the file content

This conflicts with the Lock feature that should show the Lock UI on
top of everything

With current implementation, the QuickLook controller would still be
displayed on top of the Lock screen (this happens if the users send the
apps into the background while viewing a file)

By wrapping the Lock screen into a `FullWindowOverlay` we ensure that
it will be displayed on top of every other elements
