### PR TITLE
fix: Correctly display file name in file-viewer

### DIFF
--- a/src/libs/functions/filePreviewHelper.spec.ts
+++ b/src/libs/functions/filePreviewHelper.spec.ts
@@ -139,6 +139,73 @@ describe('filePreviewHelper', () => {
       })
       expect(FileViewer.open).toHaveBeenCalledWith('/app/SOME_FILE.pdf')
     })
+
+    it(`should decode URLs for '/files/downloads/:secret/:name' links so the file name does not contains any %20 and is user friendly`, async () => {
+      const client = {
+        getStackClient: jest.fn(() => ({
+          uri: 'https://claude.mycozy.cloud',
+          getAuthorizationHeader: jest
+            .fn()
+            .mockReturnValue('SOME_AUTHORIZATION_TOKEN')
+        }))
+      } as unknown as CozyClient
+
+      mockSuccessFileDownload()
+
+      await previewFileFromDownloadUrl({
+        downloadUrl:
+          'https://claude.mycozy.cloud/files/downloads/SOME_SECRET/SOME%20FILE%20WITH%20SPACES.pdf?Dl=1',
+        client,
+        setDownloadProgress: () => undefined
+      })
+
+      expect(mockDownloadFile).toHaveBeenCalledWith({
+        fromUrl:
+          'https://claude.mycozy.cloud/files/downloads/SOME_SECRET/SOME%20FILE%20WITH%20SPACES.pdf?Dl=1',
+        toFile: '/app/SOME FILE WITH SPACES.pdf',
+        begin: expect.anything(),
+        progress: expect.anything(),
+        progressInterval: 100
+      })
+      expect(FileViewer.open).toHaveBeenCalledWith(
+        '/app/SOME FILE WITH SPACES.pdf'
+      )
+    })
+
+    it(`should decode URLs for '/files/download?Path=' links so the file name does not contains any %20 and is user friendly`, async () => {
+      const client = {
+        getStackClient: jest.fn(() => ({
+          uri: 'https://claude.mycozy.cloud',
+          getAuthorizationHeader: jest
+            .fn()
+            .mockReturnValue('SOME_AUTHORIZATION_TOKEN')
+        }))
+      } as unknown as CozyClient
+
+      mockSuccessFileDownload()
+
+      await previewFileFromDownloadUrl({
+        downloadUrl:
+          'https://claude.mycozy.cloud/files/download?Path=/Documents/SOME%20FILE%20WITH%20SPACES.pdf&Dl=1',
+        client,
+        setDownloadProgress: () => undefined
+      })
+
+      expect(mockDownloadFile).toHaveBeenCalledWith({
+        fromUrl:
+          'https://claude.mycozy.cloud/files/download?Path=/Documents/SOME%20FILE%20WITH%20SPACES.pdf&Dl=1',
+        headers: {
+          Authorization: 'SOME_AUTHORIZATION_TOKEN'
+        },
+        toFile: '/app/SOME FILE WITH SPACES.pdf',
+        begin: expect.anything(),
+        progress: expect.anything(),
+        progressInterval: 100
+      })
+      expect(FileViewer.open).toHaveBeenCalledWith(
+        '/app/SOME FILE WITH SPACES.pdf'
+      )
+    })
   })
 
   describe('getFileExtentionFromCozyDownloadUrl', () => {

--- a/src/libs/functions/filePreviewHelper.tsx
+++ b/src/libs/functions/filePreviewHelper.tsx
@@ -112,7 +112,7 @@ const getFileNameFromPrivateByPathDownloadLink = (
     )
   }
 
-  return url.searchParams.get('Path')?.split('/').pop() ?? ''
+  return decodeURI(url.searchParams.get('Path')?.split('/').pop() ?? '')
 }
 
 const getFileNameFromPublicBySecretDownloadLink = (
@@ -120,7 +120,7 @@ const getFileNameFromPublicBySecretDownloadLink = (
 ): string => {
   const url = new URL(downloadUrl)
 
-  return url.pathname.split('/').pop() ?? ''
+  return decodeURI(url.pathname.split('/').pop() ?? '')
 }
 
 const getFileNameFromCozyDownloadUrl = (


### PR DESCRIPTION
With previous implementation we created a local file extracted from the raw URL

If the file's name contains spaces, then those will be in the `%20` form (as for any other special characters)

The result is an encoded file name visible in the file-viewer

To prevent this we apply `decodeURI` on the file name


___

### Before:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/1884255/208082218-4635db9a-8727-4310-aaf2-79333fd79307.png">

### After:
<img width="336" alt="image" src="https://user-images.githubusercontent.com/1884255/208082272-c1af0eb9-c89e-4fe6-9d36-c1264dc6cfe7.png">
