### PR TITLE
feat: Bump app version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.34
+# 1.0.1
 
 ## ✨ Features
 
@@ -8,6 +8,18 @@
 
 ## 🔧 Tech
 
+
+# 1.0.0
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+
+## 🔧 Tech
+
+* Bump app version to `1.0.0` for release publication ([PR #509](https://github.com/cozy/cozy-react-native/pull/509))
 
 # 0.0.33
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3301
-        versionName "0.0.33"
+        versionCode 100001
+        versionName "1.0.0"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.33</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0003301</string>
+	<string>0100001</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "0.0.33",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.0.0
- creates a new entry for next 1.0.1 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs

> **Warning**
> With this PR we updates the buildversion generation rules, now its must be in the form XXYYZZA where XX is the major, YY the minor, ZZ the patch and A the build number