### PR TITLE
Fix/alan connector cookies

### DIFF
--- a/connectors/alan/manifest.konnector
+++ b/connectors/alan/manifest.konnector
@@ -6,6 +6,9 @@
   "clientSide": true,
   "icon": "icon.svg",
   "slug": "alan",
+  "cookie_domains": [
+    "https://api.alan.com"
+  ],
   "source": "git@github.com:konnectors/cozy-konnector-template.git",
   "editor": "Cozy",
   "vendor_link": "https://alan.com/about/life-at-alan",

--- a/connectors/alan/src/index.js
+++ b/connectors/alan/src/index.js
@@ -180,7 +180,7 @@ class TemplateContentScript extends ContentScript {
         userCredentials
       })
     }
-    if(document.location.href.includes(`${HOMEPAGE_URL}`) && document.querySelector('a[href="#"]') || document.querySelector('div[class="murray__NavListItem"]')){
+    if(document.location.href.includes(`${HOMEPAGE_URL}`) && document.querySelector('a[href="#"]') || document.querySelector('div[class="ListItem ListItem__Clickable ListCareEventItem"]')){
       this.log('Auth Check succeeded')
       return true
     }


### PR DESCRIPTION
Fixing Alan connector. Using cookieManager from the RNLauncher to be able to retrieve the token hidden in the httpOnly cookies to make the requests on Alan's API.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

