### PR TITLE
fix: downgrade commons-io in gzip lib to support Android 7+

### DIFF
--- a/patches/@fengweichong+react-native-gzip+2.0.0.patch
+++ b/patches/@fengweichong+react-native-gzip+2.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@fengweichong/react-native-gzip/android/build.gradle b/node_modules/@fengweichong/react-native-gzip/android/build.gradle
+index c2e330f..f28740e 100644
+--- a/node_modules/@fengweichong/react-native-gzip/android/build.gradle
++++ b/node_modules/@fengweichong/react-native-gzip/android/build.gradle
+@@ -73,7 +73,7 @@ repositories {
+ dependencies {
+     //noinspection GradleDynamicVersion
+     implementation 'com.facebook.react:react-native:+'  // From node_modules
+-    implementation 'commons-io:commons-io:2.6'
++    implementation 'commons-io:commons-io:2.5'
+     implementation 'org.apache.commons:commons-compress:1.1'
+ }
+ 


### PR DESCRIPTION
Sentry reported a bug caused by `react-native-gzip`,
created by `commons-io@2.6`.

We decide to patch the library with `patch-package`
to use a commons-io version
compatible with Android 7+

The application was tested on AVD with v7.1 and was not able to reproduce the error
