### PR TITLE
fix: Do not display the "in page" Back button on password reset page

### DIFF
--- a/src/libs/functions/openForgotPasswordLink.ts
+++ b/src/libs/functions/openForgotPasswordLink.ts
@@ -6,6 +6,7 @@ export const openForgotPasswordLink = async (
   const url = new URL(instance)
 
   url.pathname = '/auth/passphrase_reset'
+  url.searchParams.set('hideBackButton', 'true')
 
   await Linking.openURL(url.toString())
 }


### PR DESCRIPTION
When clicking the "I forgot my password" button from the Login screen or from the Lock screen, we redirect the user to a cozy-stack page using the OS web browser

By default this page displays a Back button that is intended to be used on a Web only scenario

On mobile we have choice between the Android's native Back button or the iOS "back to app" interaction on the browser's top left, so we don't need the cozy-stack provided button

Since cozy/cozy-stack#3590 we can now request this page to hide the Back button, which is done by this commit

Related PR: cozy/cozy-stack#3590