### PR TITLE
feat: Use react-native-safe-area-context to compute bar dimensions

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -294,8 +294,6 @@ PODS:
   - React-jsinspector (0.66.4)
   - React-logger (0.66.4):
     - glog
-  - react-native-android-navbar-height (0.1.0):
-    - React-Core
   - react-native-biometrics (3.0.1):
     - React-Core
   - react-native-cookies (6.0.7):
@@ -458,7 +456,6 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
-  - react-native-android-navbar-height (from `../node_modules/react-native-android-navbar-height`)
   - react-native-biometrics (from `../node_modules/react-native-biometrics`)
   - "react-native-cookies (from `../node_modules/@react-native-cookies/cookies`)"
   - react-native-flipper (from `../node_modules/react-native-flipper`)
@@ -550,8 +547,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
-  react-native-android-navbar-height:
-    :path: "../node_modules/react-native-android-navbar-height"
   react-native-biometrics:
     :path: "../node_modules/react-native-biometrics"
   react-native-cookies:
@@ -652,7 +647,6 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 94ce921e1d8ce7023366873ec371f3441383b396
   React-jsinspector: d0374f7509d407d2264168b6d0fad0b54e300b85
   React-logger: 933f80c97c633ee8965d609876848148e3fef438
-  react-native-android-navbar-height: bff52dac6312be20b4b90f1ff14b0444f3bbbbc4
   react-native-biometrics: 352e5a794bfffc46a0c86725ea7dc62deb085bdc
   react-native-cookies: 6004d512ffc6f2c498c5b70cda0bc040350c0585
   react-native-flipper: 4bfe0a324e663f1ae2f76ad0da75673de6895efe

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-native": "0.66.4",
-    "react-native-android-navbar-height": "git+https://github.com/ConnectyCube/react-native-android-navbar-height.git#main",
     "react-native-biometrics": "3.0.1",
     "react-native-bootsplash": "3.2.3",
     "react-native-device-info": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react-native-mask-input": "1.2.1",
     "react-native-safe-area-context": "^4.3.1",
     "react-native-screens": "3.18.2",
-    "react-native-status-bar-height": "^2.6.0",
     "react-native-svg": "12.3.0",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-web": "0.17.7",

--- a/src/components/makeErrorPage.js
+++ b/src/components/makeErrorPage.js
@@ -1,7 +1,7 @@
 import { cirrusCss } from '/screens/login/components/assets/common/css/cssCirrus'
 import { cozyBsCss } from '/screens/login/components/assets/common/css/cssCozyBs'
 import { fontsCss } from '/screens/login/components/assets/common/css/cssFonts'
-import { getNavbarHeight, statusBarHeight } from '/libs/dimensions'
+import { getDimensions } from '/libs/dimensions'
 import { themeCss } from '/screens/login/components/assets/common/css/cssTheme'
 import { translation } from '/locales'
 
@@ -17,7 +17,12 @@ const footerTemplate = `
   </p>
 `
 
-export const makeErrorPage = ({ icon, title, body, footer, header }) => `
+export const makeErrorPage = ({ icon, title, body, footer, header }) => {
+  const dimensions = getDimensions()
+  const navbarHeight = dimensions.navbarHeight
+  const statusBarHeight = dimensions.statusBarHeight
+
+  return `
   <!DOCTYPE html>
   <html>
     <head>
@@ -30,7 +35,7 @@ export const makeErrorPage = ({ icon, title, body, footer, header }) => `
       <style type="text/css">${cirrusCss}</style>
     </head>
 
-    <body class="theme-inverted" style="padding-top: ${statusBarHeight}px; padding-bottom: ${getNavbarHeight()}px;">
+    <body class="theme-inverted" style="padding-top: ${statusBarHeight}px; padding-bottom: ${navbarHeight}px;">
       <main class="wrapper">
         <header class="wrapper-top d-flex flex-row align-items-center">${
           header ? headerTemplate : ''
@@ -65,3 +70,4 @@ export const makeErrorPage = ({ icon, title, body, footer, header }) => `
     </body>
   </html>
 `
+}

--- a/src/components/makeHTML.js
+++ b/src/components/makeHTML.js
@@ -1,10 +1,13 @@
 import { cirrusCss } from '/screens/login/components/assets/common/css/cssCirrus'
 import { cozyBsCss } from '/screens/login/components/assets/common/css/cssCozyBs'
 import { fontsCss } from '/screens/login/components/assets/common/css/cssFonts'
-import { getNavbarHeight, statusBarHeight } from '/libs/dimensions'
+import { getDimensions } from '/libs/dimensions'
 import { themeCss } from '/screens/login/components/assets/common/css/cssTheme'
 
-export const makeHTML = body => `
+export const makeHTML = body => {
+  const { navbarHeight, statusBarHeight } = getDimensions()
+
+  return `
   <!DOCTYPE html>
   <html>
     <head>
@@ -17,10 +20,11 @@ export const makeHTML = body => `
       <style type="text/css">${cirrusCss}</style>
     </head>
 
-    <body class="theme-inverted" style="padding-top: ${statusBarHeight}px; padding-bottom: ${getNavbarHeight()}px;">
+    <body class="theme-inverted" style="padding-top: ${statusBarHeight}px; padding-bottom: ${navbarHeight}px;">
       <main class="wrapper">
         ${body}
       </main>
     </body>
   </html>
 `
+}

--- a/src/components/webviews/jsInteractions/jsCozyInjection.js
+++ b/src/components/webviews/jsInteractions/jsCozyInjection.js
@@ -1,19 +1,22 @@
 import { Platform } from 'react-native'
 
 import { version } from '../../../../package.json'
-import { statusBarHeight, getNavbarHeight } from '../../../libs/dimensions'
+import { getDimensions } from '/libs/dimensions'
 
 const immersiveRoutes = ['home']
 
-const makeMetadata = routeName =>
-  JSON.stringify({
+const makeMetadata = routeName => {
+  const { navbarHeight, statusBarHeight } = getDimensions()
+
+  return JSON.stringify({
     immersive: immersiveRoutes.includes(routeName),
-    navbarHeight: getNavbarHeight(),
+    navbarHeight,
     platform: Platform,
     routeName,
     statusBarHeight,
     version
   })
+}
 
 export const jsCozyGlobal = (routeName, isSecureProtocol) => `
   if (!window.cozy) window.cozy = {}

--- a/src/libs/dimensions.ts
+++ b/src/libs/dimensions.ts
@@ -5,7 +5,7 @@ import Minilog from '@cozy/minilog'
 
 let navbarHeight = 0
 
-const getNavbarHeight = () => navbarHeight
+const getNavbarHeight = (): number => navbarHeight
 const statusBarHeight = getStatusBarHeight()
 const {
   scale,
@@ -13,7 +13,7 @@ const {
   width: screenWidth
 } = Dimensions.get('screen')
 
-const init = async () => {
+const init = async (): Promise<void> => {
   try {
     if (Platform.OS !== 'android') return
     navbarHeight = (await getNavigationBarHeight()) / scale
@@ -25,6 +25,6 @@ const init = async () => {
   }
 }
 
-init()
+void init()
 
 export { getNavbarHeight, screenHeight, screenWidth, statusBarHeight }

--- a/src/libs/dimensions.ts
+++ b/src/libs/dimensions.ts
@@ -1,30 +1,46 @@
-import { Dimensions, Platform } from 'react-native'
-import { getStatusBarHeight } from 'react-native-status-bar-height'
-import { getNavigationBarHeight } from 'react-native-android-navbar-height'
-import Minilog from '@cozy/minilog'
+import { Dimensions } from 'react-native'
+import {
+  initialWindowMetrics,
+  useSafeAreaFrame,
+  useSafeAreaInsets
+} from 'react-native-safe-area-context'
 
-let navbarHeight = 0
+interface DeviceDimensions {
+  navbarHeight: number
+  screenHeight: number
+  screenWidth: number
+  statusBarHeight: number
+}
 
-const getNavbarHeight = (): number => navbarHeight
-const statusBarHeight = getStatusBarHeight()
-const {
-  scale,
-  height: screenHeight,
-  width: screenWidth
-} = Dimensions.get('screen')
+const { height: screenHeight, width: screenWidth } = Dimensions.get('screen')
 
-const init = async (): Promise<void> => {
-  try {
-    if (Platform.OS !== 'android') return
-    navbarHeight = (await getNavigationBarHeight()) / scale
-  } catch (error) {
-    Minilog('libs/dimensions').warn(
-      `Failed to compute NavbarHeight, keeping default value: ${navbarHeight}. Please refer to the error below.\n`,
-      error
-    )
+/**
+ * React Hook that returns device's dimensions (screen, navigationBar and statusBar sizes)
+ * @returns device's dimensions
+ */
+const useDimensions = (): DeviceDimensions => {
+  const insets = useSafeAreaInsets()
+  const frame = useSafeAreaFrame()
+
+  return {
+    navbarHeight: insets.bottom,
+    screenHeight: frame.height,
+    screenWidth: frame.width,
+    statusBarHeight: insets.top
   }
 }
 
-void init()
+/**
+ * Get device's dimensions (screen, navigationBar and statusBar sizes)
+ * @returns device's dimensions
+ */
+const getDimensions = (): DeviceDimensions => {
+  return {
+    navbarHeight: initialWindowMetrics?.insets.bottom ?? 0,
+    screenHeight: screenHeight,
+    screenWidth: screenWidth,
+    statusBarHeight: initialWindowMetrics?.insets.top ?? 0
+  }
+}
 
-export { getNavbarHeight, screenHeight, screenWidth, statusBarHeight }
+export { useDimensions, getDimensions }

--- a/src/libs/httpserver/server-helpers.spec.ts
+++ b/src/libs/httpserver/server-helpers.spec.ts
@@ -1,9 +1,17 @@
-import { statusBarHeight, getNavbarHeight } from '/libs/dimensions'
 import {
   addBodyClasses,
   addBarStyles,
   addMetaAttributes
 } from '/libs/httpserver/server-helpers'
+
+jest.mock('react-native-safe-area-context', () => ({
+  initialWindowMetrics: {
+    insets: {
+      bottom: 25,
+      top: 33
+    }
+  }
+}))
 
 jest.mock('/libs/RootNavigation.js', () => ({
   navigationRef: {
@@ -13,7 +21,7 @@ jest.mock('/libs/RootNavigation.js', () => ({
 
 it('should return a stringified HTML with added CSS', () => {
   const html = `<html><head></head><body></body></html>`
-  const expected = `<html><head><style>body {--flagship-top-height: ${statusBarHeight}px; --flagship-bottom-height: ${getNavbarHeight()}px;}</style></head><body></body></html>`
+  const expected = `<html><head><style>body {--flagship-top-height: 33px; --flagship-bottom-height: 25px;}</style></head><body></body></html>`
 
   expect(addBarStyles(html)).toEqual(expected)
 })

--- a/src/libs/httpserver/server-helpers.ts
+++ b/src/libs/httpserver/server-helpers.ts
@@ -1,10 +1,12 @@
 import { Platform } from 'react-native'
 
-import { statusBarHeight, getNavbarHeight } from '/libs/dimensions'
+import { getDimensions } from '/libs/dimensions'
 import { navigationRef } from '/libs/RootNavigation'
 
 export const addBarStyles = (HTMLstring: string): string => {
-  const style = `<style>body {--flagship-top-height: ${statusBarHeight}px; --flagship-bottom-height: ${getNavbarHeight()}px;}</style>`
+  const { navbarHeight, statusBarHeight } = getDimensions()
+
+  const style = `<style>body {--flagship-top-height: ${statusBarHeight}px; --flagship-bottom-height: ${navbarHeight}px;}</style>`
 
   return HTMLstring.replace('</head>', style + '</head>')
 }

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -22,7 +22,7 @@ import { WebView } from 'react-native-webview'
 // import veoliaeauConnector from '../../../connectors/veoliaeau/dist/webviewScript'
 // import gaztarifreglementeConnector from '../../../connectors/gaztarifreglemente/dist/webviewScript'
 import { BackTo } from '/components/ui/icons/BackTo'
-import { statusBarHeight } from '/libs/dimensions'
+import { getDimensions } from '/libs/dimensions'
 import ReactNativeLauncher from '/libs/ReactNativeLauncher'
 import { getColors } from '/theme/colors'
 import strings from '/strings.json'
@@ -30,6 +30,7 @@ import strings from '/strings.json'
 const log = Minilog('LauncherView')
 
 const colors = getColors()
+const { statusBarHeight } = getDimensions()
 
 const DEBUG = false
 

--- a/src/screens/cozy-app/CozyAppScreen.Animation.js
+++ b/src/screens/cozy-app/CozyAppScreen.Animation.js
@@ -4,9 +4,11 @@ import { SvgXml } from 'react-native-svg'
 
 import ProgressBar from '/components/Bar'
 import { iconTable, iconFallback } from '/libs/functions/iconTable'
-import { screenHeight, screenWidth } from '/libs/dimensions'
+import { getDimensions } from '/libs/dimensions'
 import { palette } from '/ui/palette'
 import { styles } from './CozyAppScreen.styles'
+
+const { screenHeight, screenWidth } = getDimensions()
 
 const config = {
   duration: 300,

--- a/src/screens/cozy-app/CozyAppScreen.js
+++ b/src/screens/cozy-app/CozyAppScreen.js
@@ -1,12 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { StatusBar, View, Platform } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { StatusBar, View } from 'react-native'
 
 import { Animation } from './CozyAppScreen.Animation'
 import { CozyProxyWebView } from '../../components/webviews/CozyProxyWebView'
 import { NetService } from '/libs/services/NetService'
 import { flagshipUI } from '../../libs/intents/setFlagshipUI'
-import { getNavbarHeight, statusBarHeight } from '../../libs/dimensions'
+import { useDimensions } from '/libs/dimensions'
 import { internalMethods } from '../../libs/intents/localMethods'
 import { routes } from '/constants/routes'
 import { styles } from './CozyAppScreen.styles'
@@ -58,7 +57,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
 
     isFirstHalf && firstHalfUI()
   }, [isFirstHalf, isReady, route.params.iconParams])
-  const insets = useSafeAreaInsets()
+  const dimensions = useDimensions()
 
   const onLoadEnd = useCallback(() => {
     setShouldExitAnimation(true)
@@ -75,7 +74,9 @@ export const CozyAppScreen = ({ route, navigation }) => {
 
       <View
         style={{
-          height: isFirstHalf ? statusBarHeight : styles.immersiveHeight,
+          height: isFirstHalf
+            ? dimensions.statusBarHeight
+            : styles.immersiveHeight,
           backgroundColor: topBackground
         }}
       >
@@ -113,9 +114,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
       <View
         style={{
           height: isFirstHalf
-            ? Platform.OS === 'ios'
-              ? insets.bottom
-              : getNavbarHeight()
+            ? dimensions.navbarHeight
             : styles.immersiveHeight,
           backgroundColor: bottomBackground
         }}

--- a/src/screens/lock/view/LockScreenBars.tsx
+++ b/src/screens/lock/view/LockScreenBars.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { View, StatusBar } from 'react-native'
 
 import { lockScreenUi } from '/screens/lock/events/LockScreen.events'
-import { statusBarHeight, getNavbarHeight } from '/libs/dimensions'
+import { useDimensions } from '/libs/dimensions'
 import { styles } from '/screens/lock/view/LockScreenBars.styles'
 import {
   NormalisedFlagshipUI,
@@ -19,6 +19,7 @@ export const LockScreenBars = ({
   }
 }): JSX.Element => {
   const [UIState, setUIState] = useState<NormalisedFlagshipUI>(initialUi)
+  const dimensions = useDimensions()
   const {
     bottomBackground,
     bottomOverlay,
@@ -43,7 +44,7 @@ export const LockScreenBars = ({
 
       <View
         style={{
-          height: statusBarHeight,
+          height: dimensions.statusBarHeight,
           backgroundColor: topBackground,
           ...styles.top
         }}
@@ -51,7 +52,7 @@ export const LockScreenBars = ({
 
       <View
         style={{
-          height: statusBarHeight,
+          height: dimensions.statusBarHeight,
           backgroundColor: topOverlay,
           ...styles.top,
           ...styles.innerOverlay
@@ -60,7 +61,7 @@ export const LockScreenBars = ({
 
       <View
         style={{
-          height: getNavbarHeight(),
+          height: dimensions.navbarHeight,
           backgroundColor: bottomBackground,
           ...styles.bottom
         }}
@@ -68,7 +69,7 @@ export const LockScreenBars = ({
 
       <View
         style={{
-          height: getNavbarHeight(),
+          height: dimensions.navbarHeight,
           backgroundColor: bottomOverlay,
           ...styles.bottom,
           ...styles.innerOverlay

--- a/src/screens/login/CreateInstanceScreen.js
+++ b/src/screens/login/CreateInstanceScreen.js
@@ -1,13 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import { StyleSheet, View, Platform } from 'react-native'
-
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { StyleSheet, View } from 'react-native'
 
 import Minilog from '@cozy/minilog'
 
 import { routes } from '/constants/routes'
 
-import { getNavbarHeight, statusBarHeight } from '/libs/dimensions'
+import { useDimensions } from '/libs/dimensions'
 import { consumeRouteParameter } from '/libs/functions/routeHelpers'
 
 import { getColors } from '/theme/colors'
@@ -48,10 +46,10 @@ export const CreateInstanceScreen = ({ route, navigation }) => {
       setClouderyUrl(onboardUrl)
     }
   }, [navigation, route, setClouderyUrl])
-  const insets = useSafeAreaInsets()
+  const dimensions = useDimensions()
   return (
     <View style={styles.view}>
-      <View style={{ height: statusBarHeight }} />
+      <View style={{ height: dimensions.statusBarHeight }} />
       {clouderyUrl && (
         <ClouderyCreateInstanceView
           clouderyUrl={clouderyUrl}
@@ -60,7 +58,7 @@ export const CreateInstanceScreen = ({ route, navigation }) => {
       )}
       <View
         style={{
-          height: Platform.OS === 'ios' ? insets.bottom : getNavbarHeight()
+          height: dimensions.navbarHeight
         }}
       />
     </View>

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { BackHandler, Platform, StyleSheet, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { BackHandler, StyleSheet, View } from 'react-native'
 import Minilog from '@cozy/minilog'
 
 import { ClouderyView } from './components/ClouderyView'
@@ -20,7 +19,7 @@ import {
   STATE_AUTHORIZE_NEEDED,
   STATE_INVALID_PASSWORD
 } from '/libs/client'
-import { getNavbarHeight, statusBarHeight } from '/libs/dimensions'
+import { useDimensions } from '/libs/dimensions'
 import { resetKeychainAndSaveLoginData } from '/libs/functions/passwordHelpers'
 import { consumeRouteParameter } from '/libs/functions/routeHelpers'
 import { useSplashScreen } from '/hooks/useSplashScreen'
@@ -411,7 +410,7 @@ export const LoginScreen = ({
   setClient
 }) => {
   const colors = getColors()
-  const insets = useSafeAreaInsets()
+  const dimensions = useDimensions()
   return (
     <View
       style={[
@@ -421,7 +420,7 @@ export const LoginScreen = ({
         }
       ]}
     >
-      <View style={{ height: statusBarHeight }} />
+      <View style={{ height: dimensions.statusBarHeight }} />
       <LoginSteps
         navigation={navigation}
         route={route}
@@ -431,7 +430,7 @@ export const LoginScreen = ({
       />
       <View
         style={{
-          height: Platform.OS === 'ios' ? insets.bottom : getNavbarHeight()
+          height: dimensions.navbarHeight
         }}
       />
     </View>

--- a/src/screens/login/OnboardingScreen.js
+++ b/src/screens/login/OnboardingScreen.js
@@ -7,7 +7,7 @@ import { OnboardingPasswordView } from './components/OnboardingPasswordView'
 import Minilog from '@cozy/minilog'
 
 import { callOnboardingInitClient } from '/libs/client'
-import { getNavbarHeight, statusBarHeight } from '/libs/dimensions'
+import { useDimensions } from '/libs/dimensions'
 import { resetKeychainAndSaveLoginData } from '/libs/functions/passwordHelpers'
 import { consumeRouteParameter } from '/libs/functions/routeHelpers'
 
@@ -177,15 +177,17 @@ const OnboardingSteps = ({ setClient, route, navigation }) => {
 }
 
 export const OnboardingScreen = ({ setClient, route, navigation }) => {
+  const dimensions = useDimensions()
+
   return (
     <View style={styles.view}>
-      <View style={{ height: statusBarHeight }} />
+      <View style={{ height: dimensions.statusBarHeight }} />
       <OnboardingSteps
         setClient={setClient}
         route={route}
         navigation={navigation}
       />
-      <View style={{ height: getNavbarHeight() }} />
+      <View style={{ height: dimensions.navbarHeight }} />
     </View>
   )
 }

--- a/src/screens/login/components/transitions/TransitionToPasswordView.js
+++ b/src/screens/login/components/transitions/TransitionToPasswordView.js
@@ -3,12 +3,12 @@ import { Animated, Dimensions, Easing, StyleSheet, View } from 'react-native'
 
 import log from 'cozy-logger'
 
-import { statusBarHeight } from '../../../../libs/dimensions'
+import { getDimensions } from '/libs/dimensions'
 import { CozyIcon } from './transitions-icons/CozyIcon'
 
 import { getColors } from '../../../../theme/colors'
 
-const webViewTopToNativeTop = top => top + statusBarHeight
+const webViewTopToNativeTop = top => top + getDimensions().statusBarHeight
 
 /**
  * Display a transition that should come before displaying the PasswordView

--- a/src/screens/welcome/WelcomeScreen.jsx
+++ b/src/screens/welcome/WelcomeScreen.jsx
@@ -1,19 +1,17 @@
 import React, { useState } from 'react'
-import { BackHandler, StyleSheet, View, Platform } from 'react-native'
-
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { BackHandler, StyleSheet, View } from 'react-native'
 
 import { WelcomePage } from '/components/html/WelcomePage'
 import { makeHTML } from '/components/makeHTML'
 import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
 import { makeHandlers } from '/libs/functions/makeHandlers'
 import { getColors } from '/theme/colors'
-import { getNavbarHeight } from '/libs/dimensions'
+import { useDimensions } from '/libs/dimensions'
 import { LoginScreen } from '/screens/login/LoginScreen'
 
 const WelcomeView = ({ setIsWelcomeModalDisplayed }) => {
   const colors = getColors()
-  const insets = useSafeAreaInsets()
+  const dimensions = useDimensions()
   return (
     <View
       style={[
@@ -34,7 +32,7 @@ const WelcomeView = ({ setIsWelcomeModalDisplayed }) => {
       />
       <View
         style={{
-          height: Platform.OS === 'ios' ? insets.bottom : getNavbarHeight()
+          height: dimensions.navbarHeight
         }}
       />
     </View>

--- a/src/ui/Container/index.tsx
+++ b/src/ui/Container/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { SafeAreaView, View, ViewProps } from 'react-native'
-import { getNavbarHeight } from '/libs/dimensions'
+import { useDimensions } from '/libs/dimensions'
 
 import { styles } from '/ui/Container/styles'
 
@@ -10,11 +10,19 @@ export const Container = ({
   children,
   style,
   ...props
-}: ContainerProps): JSX.Element => (
-  <View
-    style={[styles.container, { paddingBottom: getNavbarHeight() + 16 }, style]}
-    {...props}
-  >
-    <SafeAreaView>{children}</SafeAreaView>
-  </View>
-)
+}: ContainerProps): JSX.Element => {
+  const dimensions = useDimensions()
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingBottom: dimensions.navbarHeight + 16 },
+        style
+      ]}
+      {...props}
+    >
+      <SafeAreaView>{children}</SafeAreaView>
+    </View>
+  )
+}

--- a/src/ui/Container/styles.ts
+++ b/src/ui/Container/styles.ts
@@ -1,7 +1,9 @@
 import { StyleSheet } from 'react-native'
 
-import { statusBarHeight } from '/libs/dimensions'
+import { getDimensions } from '/libs/dimensions'
 import { palette } from '/ui/palette'
+
+const { statusBarHeight } = getDimensions()
 
 export const styles = StyleSheet.create({
   container: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14594,11 +14594,6 @@ react-native-securerandom@^0.1.1:
   dependencies:
     base64-js "*"
 
-react-native-status-bar-height@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.6.0.tgz#b6afd25b6e3d533c43d0fcdcfd5cafd775592cea"
-  integrity sha512-z3SGLF0mHT+OlJDq7B7h/jXPjWcdBT3V14Le5L2PjntjjWM3+EJzq2BcXDwV+v67KFNJic5pgA26cCmseYek6w==
-
 react-native-svg-transformer@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-svg-transformer/-/react-native-svg-transformer-1.0.0.tgz#7a707e5e95d20321b5f3dcfd0c3c8762ebd0221b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14481,10 +14481,6 @@ react-markdown@^4.0.8:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
-"react-native-android-navbar-height@git+https://github.com/ConnectyCube/react-native-android-navbar-height.git#main":
-  version "0.1.0"
-  resolved "git+https://github.com/ConnectyCube/react-native-android-navbar-height.git#3b04b4b66ce1bcc1b316fd44b368575cf8b3432d"
-
 react-native-biometrics@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-native-biometrics/-/react-native-biometrics-3.0.1.tgz#23c5a0bdbae1fcb1e08b22936223fe0fc4af846e"


### PR DESCRIPTION
In previous implementation we used `react-native-status-bar-height` and `react-native-android-navbar-height` to compute safe areas for cozy-apps and immersive home

Those libraries did not behave correctly on iPhone 14 Pro and the new `Dynamic Island`

As this is not the first time that those libraries don't give the correct bar sizes, we want to replace them with `react-native-safe-area-context`

This commit does the conversion but also tries to homogenise the `dimensions` API

Note: this library already handles device's ratio so we don't have to convert the navbarHeight anymore