### PR TITLE
feat: handleOffline() now explicitely includes a callbackRoute 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ const config = {
   preset: 'react-native',
   setupFiles: ['<rootDir>/__tests__/jestSetupFile.js'],
   transform: {
-    '^.+\\.(ts|tsx)?$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': ['ts-jest', { diagnostics: { exclude: ['**'] } }],
     '^.+\\.(js|jsx)$': 'babel-jest'
   },
   transformIgnorePatterns: [

--- a/src/libs/services/NetService.spec.ts
+++ b/src/libs/services/NetService.spec.ts
@@ -1,13 +1,19 @@
-import NetInfo from '@react-native-community/netinfo'
+import NetInfo, { NetInfoState } from '@react-native-community/netinfo'
 
 import strings from '/strings.json'
-import { NetService, _netInfoChangeHandler } from './NetService'
+import { NetService } from './NetService'
 import { routes } from '/constants/routes'
 
 const mockReset = jest.fn<jest.Mock, unknown[]>()
 const callbackRoute = 'foo'
+const mockedNetInfo = NetInfo as jest.Mocked<typeof NetInfo>
 
-const fetch = NetInfo.fetch as jest.Mock
+const mockedListener = mockedNetInfo.addEventListener as unknown as jest.Mock<
+  void,
+  never[]
+>
+
+const mockedFetch = NetInfo.fetch as jest.Mock
 
 jest.mock('../RootNavigation', () => ({
   reset: (...args: unknown[]): jest.Mock => mockReset(...args)
@@ -18,113 +24,53 @@ afterEach(() => {
 })
 
 it('handles isConnected', async () => {
-  fetch.mockReturnValue({ isConnected: true })
+  mockedFetch.mockReturnValue({ isConnected: true })
 
   expect(await NetService.isConnected()).toBe(true)
 })
 
 it('handles isConnected false', async () => {
-  fetch.mockReturnValue({ isConnected: false })
+  mockedFetch.mockReturnValue({ isConnected: false })
 
   expect(await NetService.isConnected()).toBe(false)
 })
 
 it('handles isOffline', async () => {
-  fetch.mockReturnValue({ isConnected: false })
+  mockedFetch.mockReturnValue({ isConnected: false })
 
   expect(await NetService.isOffline()).toBe(true)
 })
 
 it('handles isOffline false', async () => {
-  fetch.mockReturnValue({ isConnected: true })
+  mockedFetch.mockReturnValue({ isConnected: true })
 
   expect(await NetService.isOffline()).toBe(false)
 })
 
-it('handles offline redirection', () => {
-  fetch.mockReturnValue({ isConnected: false })
+it('handles imperative offline fallback', async () => {
+  const timeBeforeReconnect = 500
+  const mockUnsubscribe = jest.fn()
 
-  NetService.handleOffline()
+  mockedListener.mockImplementation(
+    (callback: (state: NetInfoState) => void) => {
+      setTimeout(
+        () => callback({ isConnected: true } as NetInfoState),
+        timeBeforeReconnect
+      )
+
+      return mockUnsubscribe
+    }
+  )
+
+  NetService.handleOffline(callbackRoute)
+
+  await new Promise(resolve => setTimeout(resolve, timeBeforeReconnect))
 
   expect(mockReset).toHaveBeenNthCalledWith(1, routes.error, {
     type: strings.errorScreens.offline
   })
-})
 
-it('handle toggleNetWatcher', () => {
-  const cleanup = NetInfo.addEventListener
+  expect(mockReset).toHaveBeenNthCalledWith(2, callbackRoute)
 
-  NetService.toggleNetWatcher()
-  NetService.toggleNetWatcher()
-  NetService.toggleNetWatcher()
-  NetService.toggleNetWatcher({ shouldUnsub: true })
-  NetService.toggleNetWatcher()
-  NetService.toggleNetWatcher()
-  NetService.toggleNetWatcher()
-  NetService.toggleNetWatcher()
-  NetService.toggleNetWatcher({ shouldUnsub: true })
-
-  expect(NetInfo.addEventListener).toHaveBeenNthCalledWith(
-    2,
-    expect.any(Function)
-  )
-  expect(cleanup).toHaveBeenNthCalledWith(2, expect.any(Function))
-})
-
-it('handle toggleNetWatcher with route', () => {
-  const cleanup = NetInfo.addEventListener
-
-  NetService.toggleNetWatcher({ callbackRoute })
-  NetService.toggleNetWatcher({ callbackRoute })
-  NetService.toggleNetWatcher({ callbackRoute })
-  NetService.toggleNetWatcher({ shouldUnsub: true, callbackRoute })
-  NetService.toggleNetWatcher({ callbackRoute })
-  NetService.toggleNetWatcher({ callbackRoute })
-  NetService.toggleNetWatcher({ callbackRoute })
-  NetService.toggleNetWatcher({ callbackRoute })
-  NetService.toggleNetWatcher({ shouldUnsub: true, callbackRoute })
-
-  expect(NetInfo.addEventListener).toHaveBeenNthCalledWith(
-    2,
-    expect.any(Function)
-  )
-  expect(cleanup).toHaveBeenNthCalledWith(2, expect.any(Function))
-})
-
-it('handles state callback', () => {
-  _netInfoChangeHandler({ isConnected: true })
-
-  expect(mockReset).toHaveBeenNthCalledWith(1, routes.stack)
-})
-
-it('handles state callback on offline', () => {
-  _netInfoChangeHandler({ isConnected: false })
-
-  expect(mockReset).not.toHaveBeenCalled()
-})
-
-it('handles state callback on error', () => {
-  const brokenState = undefined
-  _netInfoChangeHandler(brokenState)
-
-  expect(mockReset).not.toHaveBeenCalled()
-})
-
-it('handles state callback with route', () => {
-  _netInfoChangeHandler({ isConnected: true }, callbackRoute)
-
-  expect(mockReset).toHaveBeenNthCalledWith(1, callbackRoute)
-})
-
-it('handles state callback on offline with route', () => {
-  _netInfoChangeHandler({ isConnected: false }, callbackRoute)
-
-  expect(mockReset).not.toHaveBeenCalled()
-})
-
-it('handles state callback on error with route', () => {
-  const brokenState = undefined
-  _netInfoChangeHandler(brokenState, callbackRoute)
-
-  expect(mockReset).not.toHaveBeenCalled()
+  expect(mockUnsubscribe).toHaveBeenCalledTimes(1)
 })

--- a/src/screens/cozy-app/CozyAppScreen.js
+++ b/src/screens/cozy-app/CozyAppScreen.js
@@ -1,14 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { StatusBar, View, Platform } from 'react-native'
-
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { CozyProxyWebView } from '../../components/webviews/CozyProxyWebView'
 import { Animation } from './CozyAppScreen.Animation'
+import { CozyProxyWebView } from '../../components/webviews/CozyProxyWebView'
+import { NetService } from '/libs/services/NetService'
 import { flagshipUI } from '../../libs/intents/setFlagshipUI'
 import { getNavbarHeight, statusBarHeight } from '../../libs/dimensions'
-import { styles } from './CozyAppScreen.styles'
 import { internalMethods } from '../../libs/intents/localMethods'
+import { routes } from '/constants/routes'
+import { styles } from './CozyAppScreen.styles'
 
 const firstHalfUI = () =>
   internalMethods.setFlagshipUI({
@@ -19,6 +20,13 @@ const firstHalfUI = () =>
     topTheme: 'dark',
     topOverlay: 'transparent'
   })
+
+const handleError = ({ nativeEvent }) => {
+  const { code, description } = nativeEvent
+
+  if (code === -2 && description === 'net::ERR_INTERNET_DISCONNECTED')
+    NetService.handleOffline(routes.stack)
+}
 
 export const CozyAppScreen = ({ route, navigation }) => {
   const [UIState, setUIState] = useState({})
@@ -98,6 +106,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
           route={route}
           logId="AppScreen"
           onLoadEnd={onLoadEnd}
+          onError={handleError}
         />
       </View>
 

--- a/src/screens/error/ErrorScreen.tsx
+++ b/src/screens/error/ErrorScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Linking } from 'react-native'
 import { WebViewMessageEvent } from 'react-native-webview/lib/WebViewTypes'
 
@@ -8,6 +8,7 @@ import { CozyNotFoundPage } from '/components/webviews/CozyNotFoundPage'
 import { OfflinePage } from '/components/webviews/OfflinePage'
 import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
 import { goBack } from '/libs/RootNavigation'
+import { changeBarColors } from 'react-native-immersive-bars'
 
 const log = Minilog('ErrorScreen')
 
@@ -76,9 +77,19 @@ const makeSource = (route: ErrorScreenProps['route']): Source => {
   return { html: htmlGenerator() }
 }
 
-export const ErrorScreen = (props: ErrorScreenProps): JSX.Element => (
-  <SupervisedWebView
-    onMessage={handleMessage}
-    source={makeSource(props.route)}
-  />
-)
+export const ErrorScreen = (props: ErrorScreenProps): JSX.Element => {
+  /*
+   * All error pages are in immersive mode with blue background, so we need light icons every time.
+   * To err on the side of caution, we set the icon colors to white everytime this page is rendered.
+   */
+  useEffect(() => {
+    changeBarColors(true)
+  }, [])
+
+  return (
+    <SupervisedWebView
+      onMessage={handleMessage}
+      source={makeSource(props.route)}
+    />
+  )
+}

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -28,6 +28,7 @@ import { useSplashScreen } from '/hooks/useSplashScreen'
 import strings from '../../strings.json'
 import { getColors } from '/theme/colors'
 import { NetService } from '/libs/services/NetService'
+import { routes } from '/constants/routes'
 
 const log = Minilog('LoginScreen')
 
@@ -115,7 +116,8 @@ const LoginSteps = ({
 
   const setInstanceData = useCallback(
     async ({ instance, fqdn }) => {
-      if (await NetService.isOffline()) NetService.handleOffline()
+      if (await NetService.isOffline())
+        NetService.handleOffline(routes.authenticate)
 
       try {
         const client = await createClient(instance)
@@ -172,7 +174,8 @@ const LoginSteps = ({
   }
 
   const startOAuth = useCallback(async () => {
-    if (await NetService.isOffline()) NetService.handleOffline()
+    if (await NetService.isOffline())
+      NetService.handleOffline(routes.authenticate)
 
     try {
       const { loginData, instance, client } = state
@@ -220,7 +223,8 @@ const LoginSteps = ({
 
   const continueOAuth = useCallback(
     async twoFactorCode => {
-      if (await NetService.isOffline()) NetService.handleOffline()
+      if (await NetService.isOffline())
+        NetService.handleOffline(routes.authenticate)
 
       try {
         const { loginData, client, twoFactorToken } = state
@@ -264,7 +268,8 @@ const LoginSteps = ({
   )
 
   const authorize = useCallback(async () => {
-    if (await NetService.isOffline()) NetService.handleOffline()
+    if (await NetService.isOffline())
+      NetService.handleOffline(routes.authenticate)
 
     try {
       const { client, loginData, sessionCode } = state

--- a/src/screens/login/components/ClouderyCreateInstanceView.js
+++ b/src/screens/login/components/ClouderyCreateInstanceView.js
@@ -12,6 +12,7 @@ import { jsLogInterception } from '/components/webviews/jsInteractions/jsLogInte
 import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
 
 import { getColors } from '/theme/colors'
+import { routes } from '/constants/routes'
 
 const log = Minilog('ClouderyCreateInstanceView')
 
@@ -45,7 +46,9 @@ export const ClouderyCreateInstanceView = ({
     const { fqdn, registerToken } = getOnboardingDataFromRequest(request)
 
     NetService.isOffline()
-      .then(isOffline => isOffline && NetService.handleOffline())
+      .then(
+        isOffline => isOffline && NetService.handleOffline(routes.onboarding)
+      )
       .catch(error => log.error(error))
 
     if (request.loading) {

--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -36,7 +36,7 @@ const run = `
 const handleError = async webviewErrorEvent => {
   try {
     const isOffline = await NetService.isOffline()
-    isOffline && NetService.handleOffline()
+    isOffline && NetService.handleOffline(routes.onboarding)
   } catch (error) {
     log.error(error)
   } finally {


### PR DESCRIPTION
The callbackRoute is mandatory. There is no guard if it's not provided.
handleOffline calls must respect the TS signature