### PR TITLE
fix: Revert react-native-flipper from 0.176.1 to 0.146.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-native-bootsplash": "3.2.3",
     "react-native-device-info": "^10.3.0",
     "react-native-file-viewer": "^2.1.5",
-    "react-native-flipper": "^0.176.1",
+    "react-native-flipper": "^0.146.1",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "1.10.3",
     "react-native-google-safetynet": "npm:cozy-react-native-google-safetynet@^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14518,10 +14518,10 @@ react-native-file-viewer@^2.1.5:
   resolved "https://registry.yarnpkg.com/react-native-file-viewer/-/react-native-file-viewer-2.1.5.tgz#cd4544f573108e79002b5c7e1ebfce4371885250"
   integrity sha512-MGC6sx9jsqHdefhVQ6o0akdsPGpkXgiIbpygb2Sg4g4bh7v6K1cardLV1NwGB9A6u1yICOSDT/MOC//9Ez6EUg==
 
-react-native-flipper@^0.176.1:
-  version "0.176.1"
-  resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.176.1.tgz#fdf01e09160660d1c833d537909244965481275e"
-  integrity sha512-kioHzO9JzA2ReW9LfopIEUXeD6gDp3Mw6KjQbELvoLVIEMvCfGz59akezw4l/S8i6qkFVcnwh5c/7Z+L3nthQA==
+react-native-flipper@^0.146.1:
+  version "0.146.1"
+  resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.146.1.tgz#b6bbb23edc347597788bdca4c89b58bad425e1a1"
+  integrity sha512-M3pjqDigOPRpPN9lkT3o0yKDViqciGe5aUjPrtuKdxmaCbH4ofpMEZGxrcKjnEwXJWKC24IDZKtz7WitaWgRig==
 
 react-native-fs@^2.20.0:
   version "2.20.0"


### PR DESCRIPTION
This reverts commit 81995dc7bfd8023a3fc3c538591eccdb5c02614d

Since previous upgrade flipper does not work anymore on iOS as `pod install` command would remove all reference to the native module

This commit downgrades flipper until the issue is fixed

Related issue: facebook/flipper#4402