### PR TITLE
fix: Use `FullWindowOverlay` only on iOS

### DIFF
--- a/src/components/ConditionalWrapper.tsx
+++ b/src/components/ConditionalWrapper.tsx
@@ -1,0 +1,12 @@
+interface ConditionalWrapperProps {
+  condition?: boolean
+  wrapper: (children: JSX.Element) => JSX.Element
+  children: JSX.Element
+}
+
+export const ConditionalWrapper = ({
+  condition,
+  wrapper,
+  children
+}: ConditionalWrapperProps): JSX.Element =>
+  condition ? wrapper(children) : children

--- a/src/components/CondtionalWrapper.spec.tsx
+++ b/src/components/CondtionalWrapper.spec.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { ConditionalWrapper } from './ConditionalWrapper'
+
+const Component = (): JSX.Element => <div>Component</div>
+
+const Wrapper = ({ children }: { children: JSX.Element }): JSX.Element => (
+  <section>
+    <header>Wrapper</header>
+    {children}
+  </section>
+)
+
+it('should render without Wrapper by default', () => {
+  const { queryByText } = render(
+    <ConditionalWrapper
+      wrapper={(children): JSX.Element => <Wrapper>{children}</Wrapper>}
+    >
+      <Component />
+    </ConditionalWrapper>
+  )
+
+  expect(queryByText('Wrapper')).toBe(null)
+  expect(queryByText('Component')).toBeDefined()
+})
+
+it('should not render with Wrapper if provided but not needed', () => {
+  const { queryByText } = render(
+    <ConditionalWrapper
+      condition={false}
+      wrapper={(children): JSX.Element => <Wrapper>{children}</Wrapper>}
+    >
+      <Component />
+    </ConditionalWrapper>
+  )
+
+  expect(queryByText('Wrapper')).toBe(null)
+  expect(queryByText('Component')).toBeDefined()
+})
+
+it('should render with Wrapper if provided', () => {
+  const { queryByText } = render(
+    <ConditionalWrapper
+      condition={true}
+      wrapper={(children): JSX.Element => <Wrapper>{children}</Wrapper>}
+    >
+      <Component />
+    </ConditionalWrapper>
+  )
+
+  expect(queryByText('Wrapper')).toBeDefined()
+  expect(queryByText('Component')).toBeDefined()
+})

--- a/src/screens/lock/LockScreen.tsx
+++ b/src/screens/lock/LockScreen.tsx
@@ -28,6 +28,7 @@ import { getBiometryIcon } from '/screens/lock/functions/lockScreenFunctions'
 import { palette } from '/ui/palette'
 import { translation } from '/locales'
 import { useLockScreenProps } from '/screens/lock/hooks/useLockScreen'
+import { ConditionalWrapper } from '/components/ConditionalWrapper'
 
 const LockView = ({
   biometryEnabled,
@@ -161,9 +162,14 @@ const LockView = ({
   </Container>
 )
 
-export const LockScreen = (props: LockScreenProps): JSX.Element => (
-  <>
-    <FullWindowOverlay>
+export const LockScreen = (props: LockScreenProps): React.ReactNode => (
+  <ConditionalWrapper
+    condition={Platform.OS === 'ios'}
+    wrapper={(children): JSX.Element => (
+      <FullWindowOverlay>{children}</FullWindowOverlay>
+    )}
+  >
+    <>
       <LockScreenBars />
 
       <TouchableWithoutFeedback
@@ -176,6 +182,6 @@ export const LockScreen = (props: LockScreenProps): JSX.Element => (
           <LockView {...useLockScreenProps(props.route?.params)} />
         </KeyboardAvoidingView>
       </TouchableWithoutFeedback>
-    </FullWindowOverlay>
-  </>
+    </>
+  </ConditionalWrapper>
 )


### PR DESCRIPTION
In #501 we added `FullWindowOverlay` to enforce LockScreen on top of UI

If this would work on Android with no functional impact, a warning is displayed on the react-native console saying that `FullWindowOverlay` should not be used on Android (it has no impact)

So this commit add a condition to use it only on iOS

Note: `ConditionalWrapper` component is a copy from cozy/cozy-home@43b7661484b032166823b0489b1a77c39829ae92