### PR TITLE
fix: Set correct caret color on LockScreen on iOS

### DIFF
--- a/src/ui/TextField/index.tsx
+++ b/src/ui/TextField/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { TextInput, TextInputProps, View } from 'react-native'
+import { Platform, TextInput, TextInputProps, View } from 'react-native'
 import { MaskInputProps } from 'react-native-mask-input'
 
 import { Typography } from '/ui/Typography'
@@ -34,6 +34,7 @@ export const TextField = ({
     {InputComponent ? (
       <InputComponent
         cursorColor={styles.input.color}
+        selectionColor={Platform.OS === 'ios' ? styles.input.color : undefined}
         style={[styles.input, { letterSpacing: 10 }]}
         value={value}
         placeholderTextColor={styles.input.color}
@@ -43,6 +44,7 @@ export const TextField = ({
     ) : (
       <TextInput
         cursorColor={styles.input.color}
+        selectionColor={Platform.OS === 'ios' ? styles.input.color : undefined}
         style={styles.input}
         value={value}
         {...props}


### PR DESCRIPTION
The `cursorColor` prop only works on Android so we want to use `selectionColor` on iOS instead

The drawback of `selectionColor` is that the caret AND the selection highlight are impacted. This is not a problem on iOS as an opacity is applied on the highlight color. However on Android we get white text on white highlight, which is not usable. So we want to apply `selectionColor` only on iOS

More info:
- https://reactnative.dev/docs/textinput#cursorcolor-android
- https://reactnative.dev/docs/textinput#selectioncolor


### Result on iOS
<img width="304" alt="image" src="https://user-images.githubusercontent.com/1884255/209570764-86880080-e698-408f-930b-d7f94400db7c.png">
<img width="308" alt="image" src="https://user-images.githubusercontent.com/1884255/209570727-f68cc8c2-f2c4-4ef9-a852-4ff62e8b04f2.png">

### Result on Android
<img width="405" alt="image" src="https://user-images.githubusercontent.com/1884255/209570743-5daa02a6-50f9-4348-b2b0-604bf96b4984.png">
<img width="407" alt="image" src="https://user-images.githubusercontent.com/1884255/209570789-bbf8a7e9-7d13-4a81-9bc1-1488dbd7e622.png">



### What would happen on Android if we applied the `selectionColor` prop
<img width="406" alt="image" src="https://user-images.githubusercontent.com/1884255/209570812-075c904e-d360-4125-8786-812dccc81be3.png">

> **Note**
> We may want to use Secondary color on Android for the selection color. This is what we do in CozyPass Mobile (cf cozy/cozy-pass-mobile@d9b7dbc145ab0622ccc4bc357c228cd4758ad2fb). But the react-native API only changes the highlight color and not the selection handle. So we will have to investigate a better solution.
<img width="413" alt="image" src="https://user-images.githubusercontent.com/1884255/209570948-9666c7ca-fca2-466d-81b8-4d90e613784a.png">
