### PR TITLE
feat: Bump app version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.1
+# 1.0.2
 
 ## ✨ Features
 
@@ -8,6 +8,27 @@
 
 ## 🔧 Tech
 
+
+# 1.0.1
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+* File-viewer is now correctly hidden by Lock screen on iOS ([PR #501](https://github.com/cozy/cozy-react-native/pull/501) and [PR #523](https://github.com/cozy/cozy-react-native/pull/523))
+* Correctly display file name in file-viewer ([PR #502](https://github.com/cozy/cozy-react-native/pull/502))
+* The "in page" Back button on password reset page is now hidden when displayed on Flagship app ([PR #512](https://github.com/cozy/cozy-react-native/pull/512))
+* The app is now compatible with Android 5.1+ as we fixed the GZip library implementation ([PR #511](https://github.com/cozy/cozy-react-native/pull/511))
+* Fix cookie management for `Alan` Client Side Connector ([PR #510](https://github.com/cozy/cozy-react-native/pull/510))
+* The Lock screen password input now uses the correct caret color ([PR #524](https://github.com/cozy/cozy-react-native/pull/524))
+* Margins for handling navigation bar and status bar sizes should now be computed correctly on a wider device range ([PR #514](https://github.com/cozy/cozy-react-native/pull/514))
+
+## 🔧 Tech
+
+* Navigation bar and status bar Color API now allow to set different text colors on each bars ([PR #513](https://github.com/cozy/cozy-react-native/pull/513))
+* `handleOffline()` now explicitly includes a callbackRoute ([PR #515](https://github.com/cozy/cozy-react-native/pull/515))
+* Migrate `HomeScreen` code to TypeScript ([PR #531](https://github.com/cozy/cozy-react-native/pull/531))
 
 # 1.0.0
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100001
-        versionName "1.0.0"
+        versionCode 100011
+        versionName "1.0.1"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100001</string>
+	<string>0100011</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -382,7 +382,7 @@ PODS:
     - React-Core
   - RNCAsyncStorage (1.17.11):
     - React-Core
-  - RNDeviceInfo (10.0.2):
+  - RNDeviceInfo (10.3.0):
     - React-Core
   - RNFileViewer (2.1.5):
     - React-Core
@@ -668,7 +668,7 @@ SPEC CHECKSUMS:
   ReactCommon: 57b69f6383eafcbd7da625bfa6003810332313c4
   RNBootSplash: 8ef5ffa03dadd35f66510b42960ce40f397c98bf
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
-  RNDeviceInfo: 0a7c1d2532aa7691f9b9925a27e43af006db4dae
+  RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
   RNFileViewer: ce7ca3ac370e18554d35d6355cffd7c30437c592
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.0.1
- creates a new entry for next 1.0.2 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs