### PR TITLE
feat: Sending konnectors logs to stack in batch

### DIFF
--- a/connectors/connectorLibs/ContentScript.js
+++ b/connectors/connectorLibs/ContentScript.js
@@ -362,11 +362,26 @@ export default class ContentScript {
   /**
    * Send log message to the launcher
    *
-   * @param {string} : the log message
-   * @todo Use cozy-logger to add logging level and other features
+   * @param {"debug"|"info"|"warn"|"error"} level: the log level
+   * @param {string} message: the log message
    */
-  log(message) {
-    this.bridge.emit('log', message)
+  log(level, message) {
+    const allowedLevels = ['debug', 'info', 'warn', 'error']
+    if (!message) {
+      log.warn(
+        `you are calling log without message, use log(level,message) instead`
+      )
+      return
+    }
+    if (!allowedLevels.includes(level)) {
+      level = 'debug'
+    }
+    const now = new Date()
+    this.bridge.emit('log', {
+      timestamp: now,
+      level,
+      msg: message
+    })
   }
 
   /**

--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -22,8 +22,9 @@ declare module 'cozy-client' {
   }
 
   interface StackClient {
-    fetchJSON: <T>(method: string, path: string) => Promise<T>
     fetchKonnectorToken: (slug: string) => Promise<string>
+    fetchJSON: <T>(method: string, path: string, body: unknown) => Promise<T>
+    uri: string
     fetchSessionCode: () => Promise<{ session_code: string }>
     getAuthorizationHeader: () => string
     uri: string

--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -23,7 +23,7 @@ declare module 'cozy-client' {
 
   interface StackClient {
     fetchKonnectorToken: (slug: string) => Promise<string>
-    fetchJSON: <T>(method: string, path: string, body: unknown) => Promise<T>
+    fetchJSON: <T>(method: string, path: string, body?: unknown) => Promise<T>
     uri: string
     fetchSessionCode: () => Promise<{ session_code: string }>
     getAuthorizationHeader: () => string

--- a/src/hooks/useConnectors.ts
+++ b/src/hooks/useConnectors.ts
@@ -1,7 +1,10 @@
 import { useClient } from 'cozy-client'
 
 import { useAppDispatch, useAppSelector } from '/hooks/reduxHooks'
-import { addLog as sliceAddLog } from '/redux/ConnectorState/ConnectorLogsSlice'
+import {
+  addLog as sliceAddLog,
+  LogObj
+} from '/redux/ConnectorState/ConnectorLogsSlice'
 import {
   selectCurrentConnector,
   setCurrentRunningConnector
@@ -9,7 +12,7 @@ import {
 import { sendConnectorsLogs } from '/libs/connectors/sendConnectorsLogs'
 
 export interface UseAddLogHook {
-  addLog: () => void
+  addLog: (logObj: LogObj) => void
   currentRunningConnector?: string
   processLogs: () => void
   setCurrentRunningConnector: (slug: string) => void
@@ -20,9 +23,8 @@ export const useConnectors = (): UseAddLogHook => {
   const dispatch = useAppDispatch()
   const client = useClient()
 
-  const doAddLog = (): void => {
-    // TODO: Implement ADD logic
-    dispatch(sliceAddLog('SOME_LOG'))
+  const doAddLog = (logObj: LogObj): void => {
+    dispatch(sliceAddLog(logObj))
   }
 
   const doSetCurrentRunningConnector = (slug: string): void => {
@@ -30,7 +32,7 @@ export const useConnectors = (): UseAddLogHook => {
   }
 
   const doProcessLogs = (): void => {
-    void sendConnectorsLogs(client, 5)
+    void sendConnectorsLogs(client)
   }
 
   return {

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -104,7 +104,7 @@ class ReactNativeLauncher extends Launcher {
   async stop({ message } = {}) {
     const context = this.getStartContext()
     const client = context.client
-    sendConnectorsLogs(client)
+    await sendConnectorsLogs(client)
     if (message) {
       await this.updateJobResult({
         state: 'errored',

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -7,6 +7,7 @@ import Launcher from './Launcher'
 import { getConnectorBundle } from '/libs/cozyAppBundle/cozyAppBundle.functions'
 import { saveCookie, getCookie, removeCookie } from './keychain'
 import { updateCozyAppBundle } from '/libs/cozyAppBundle/cozyAppBundle'
+import { sendConnectorsLogs } from '/libs/connectors/sendConnectorsLogs'
 
 const log = Minilog('ReactNativeLauncher')
 
@@ -101,6 +102,9 @@ class ReactNativeLauncher extends Launcher {
   }
 
   async stop({ message } = {}) {
+    const context = this.getStartContext()
+    const client = context.client
+    sendConnectorsLogs(client)
     if (message) {
       await this.updateJobResult({
         state: 'errored',

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -27,6 +27,16 @@ class ReactNativeLauncher extends Launcher {
     this.workerListenedEventsNames = ['log', 'workerEvent', 'workerReady']
   }
 
+  setLogger(onKonnectorLog) {
+    this.logger = onKonnectorLog
+  }
+
+  log(logContent) {
+    const context = this.getStartContext()
+    const slug = context.manifest.slug
+    this.logger({ ...logContent, slug })
+  }
+
   async init({ bridgeOptions, contentScript }) {
     log.debug('bridges init start')
     const promises = [

--- a/src/libs/connectors/cleanConnectorsOnBoot.ts
+++ b/src/libs/connectors/cleanConnectorsOnBoot.ts
@@ -37,7 +37,7 @@ export const cleanConnectorsOnBoot = async (
     store.dispatch(setCurrentRunningConnector())
   }
 
-  await sendConnectorsLogs(client, 4)
+  await sendConnectorsLogs(client)
 }
 
 /**

--- a/src/libs/connectors/sendConnectorsLogs.spec.js
+++ b/src/libs/connectors/sendConnectorsLogs.spec.js
@@ -1,0 +1,177 @@
+import CozyClient from 'cozy-client'
+import { sendConnectorsLogs } from './sendConnectorsLogs'
+import { store } from '/redux/store'
+
+jest.genMockFromModule('cozy-client')
+jest.mock('cozy-client')
+
+const mockFetchJSON = jest.fn()
+
+const mockCozyClient = {
+  getStackClient: jest.fn().mockReturnValue({ fetchJSON: mockFetchJSON })
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+CozyClient.mockImplementation(() => mockCozyClient)
+
+jest.mock('/redux/store', () => ({
+  store: {
+    getState: jest.fn(),
+    dispatch: jest.fn()
+  }
+}))
+
+describe('Konnectors logs', () => {
+  it('Should send no log', async () => {
+    const client = new CozyClient()
+
+    store.getState.mockReturnValue({
+      connectorLogs: {
+        logs: {}
+      }
+    })
+
+    await sendConnectorsLogs(client)
+    expect(mockFetchJSON).not.toHaveBeenCalled()
+    expect(store.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('Should send one log', async () => {
+    const client = new CozyClient()
+
+    store.getState.mockReturnValue({
+      connectorLogs: {
+        logs: {
+          myslug: [
+            {
+              level: 'debug',
+              msg: 'Log Message',
+              timestamp: '2023-01-05T10:12:32Z'
+            }
+          ]
+        }
+      }
+    })
+
+    await sendConnectorsLogs(client)
+    expect(mockFetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/konnectors/myslug/logs',
+      [
+        {
+          level: 'debug',
+          msg: 'Log Message',
+          timestamp: '2023-01-05T10:12:32Z'
+        }
+      ]
+    )
+    expect(store.dispatch).toHaveBeenCalledWith({
+      payload: { number: 1, slug: 'myslug' },
+      type: 'connectorLogs/removeLogs'
+    })
+  })
+
+  it('Should send 2 logs', async () => {
+    const client = new CozyClient()
+
+    store.getState.mockReturnValue({
+      connectorLogs: {
+        logs: {
+          myslug: [
+            {
+              level: 'error',
+              msg: 'Log Message',
+              timestamp: '2023-01-05T10:12:32Z'
+            },
+            {
+              level: 'info',
+              msg: 'Log Message2',
+              timestamp: '2023-01-05T10:12:33Z'
+            }
+          ]
+        }
+      }
+    })
+
+    await sendConnectorsLogs(client)
+    expect(mockFetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/konnectors/myslug/logs',
+      [
+        {
+          level: 'error',
+          msg: 'Log Message',
+          timestamp: '2023-01-05T10:12:32Z'
+        },
+        {
+          level: 'info',
+          msg: 'Log Message2',
+          timestamp: '2023-01-05T10:12:33Z'
+        }
+      ]
+    )
+    expect(store.dispatch).toHaveBeenCalledWith({
+      payload: { number: 2, slug: 'myslug' },
+      type: 'connectorLogs/removeLogs'
+    })
+  })
+
+  it('Should send logs for 2 slugs', async () => {
+    const client = new CozyClient()
+
+    store.getState.mockReturnValue({
+      connectorLogs: {
+        logs: {
+          myslug: [
+            {
+              level: 'debug',
+              msg: 'Log Message',
+              timestamp: '2023-01-05T10:12:32Z'
+            }
+          ],
+          myslug2: [
+            {
+              level: 'debug',
+              msg: 'Log Message',
+              timestamp: '2023-01-05T10:12:32Z'
+            }
+          ]
+        }
+      }
+    })
+
+    await sendConnectorsLogs(client)
+    expect(mockFetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/konnectors/myslug/logs',
+      [
+        {
+          level: 'debug',
+          msg: 'Log Message',
+          timestamp: '2023-01-05T10:12:32Z'
+        }
+      ]
+    )
+    expect(mockFetchJSON).toHaveBeenNthCalledWith(
+      2,
+      'POST',
+      '/konnectors/myslug2/logs',
+      [
+        {
+          level: 'debug',
+          msg: 'Log Message',
+          timestamp: '2023-01-05T10:12:32Z'
+        }
+      ]
+    )
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      payload: { number: 1, slug: 'myslug' },
+      type: 'connectorLogs/removeLogs'
+    })
+    expect(store.dispatch).toHaveBeenCalledWith({
+      payload: { number: 1, slug: 'myslug2' },
+      type: 'connectorLogs/removeLogs'
+    })
+  })
+})

--- a/src/libs/connectors/sendConnectorsLogs.ts
+++ b/src/libs/connectors/sendConnectorsLogs.ts
@@ -1,44 +1,41 @@
 import Minilog from '@cozy/minilog'
 import CozyClient from 'cozy-client'
 
-import { clearLogs, spliceLogs } from '/redux/ConnectorState/ConnectorLogsSlice'
+import { removeLogs } from '/redux/ConnectorState/ConnectorLogsSlice'
 import { store } from '/redux/store'
 
 const log = Minilog('sendConnectorsLogs')
 
-const sleep = (ms: number): Promise<void> => {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
-export const sendConnectorsLogs = async (
-  client: CozyClient,
-  limit?: number
-): Promise<void> => {
+export const sendConnectorsLogs = async (client: CozyClient): Promise<void> => {
   try {
     const state = store.getState()
-    log.debug(
-      `🐙 Current number of logs to handle: `,
-      state.connectorLogs.logs.length
-    )
+    const logs = state.connectorLogs.logs
 
-    const logs = limit
-      ? state.connectorLogs.logs.slice(0, limit)
-      : state.connectorLogs.logs
+    // You can activate this line to get the log loop data
+    // log.debug(`🐟 ${this.loopId} - logs`, logs)
 
-    log.debug(`🐟 logs`, logs)
-
-    store.dispatch(limit ? spliceLogs(limit) : clearLogs())
-    const state2 = store.getState()
-
-    await sleep(500)
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
-    log.debug(`🐙 ${client.getStackClient().uri}`)
-
-    log.debug(
-      `🐙 New number of logs to handle: `,
-      state2.connectorLogs.logs.length
-    )
+    const slugs = Object.keys(logs)
+    for (const slug of slugs) {
+      log.debug(`Sending ${slug} logs batch`)
+      // Clean slug property in LogObj
+      const cleanedLogs = logs[slug]?.map(({ slug, ...el }) => el)
+      if (!cleanedLogs) {
+        continue
+      }
+      try {
+        // Sending
+        await client
+          .getStackClient()
+          .fetchJSON('POST', `/konnectors/${slug}/logs`, cleanedLogs)
+        // Deleting
+        store.dispatch(removeLogs({ slug, number: cleanedLogs.length }))
+      } catch (e) {
+        log.error(`Error while sending ${slug} logs`)
+        log.error(e)
+      }
+    }
   } catch (e) {
+    log.error('Error in loop while sending konnectors logs to stack')
     log.error(e)
   }
 }

--- a/src/redux/ConnectorState/ConnectorLogsSlice.ts
+++ b/src/redux/ConnectorState/ConnectorLogsSlice.ts
@@ -2,31 +2,55 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import type { RootState } from '/redux/store'
 
+export interface LogObj {
+  msg: string
+  timestamp: string
+  level: string
+  slug: string
+}
+
+type LogDict = Record<string, LogObj[] | undefined>
+
 export interface ConnectorLogsState {
-  logs: string[]
+  logs: LogDict
+}
+
+export interface removeLogInfo {
+  slug: string
+  number: number
 }
 
 const initialState: ConnectorLogsState = {
-  logs: []
+  logs: {}
 }
 
 export const connectorLogsSlice = createSlice({
   name: 'connectorLogs',
   initialState,
   reducers: {
-    addLog: (state, action: PayloadAction<string>) => {
-      state.logs = [...state.logs, action.payload]
+    addLog: (state, action: PayloadAction<LogObj>) => {
+      if (state.logs[action.payload.slug] === undefined) {
+        state.logs[action.payload.slug] = []
+      }
+      state.logs[action.payload.slug]?.push(action.payload)
     },
-    spliceLogs: (state, action: PayloadAction<number>) => {
-      state.logs = state.logs.slice(action.payload)
+    removeLogs: (state, action: PayloadAction<removeLogInfo>) => {
+      const result = state.logs[action.payload.slug]?.slice(
+        action.payload.number
+      )
+      if (result?.length) {
+        state.logs[action.payload.slug] = result
+      } else {
+        delete state.logs[action.payload.slug]
+      }
     },
     clearLogs: state => {
-      state.logs = []
+      state.logs = {}
     }
   }
 })
 
-export const { addLog, clearLogs, spliceLogs } = connectorLogsSlice.actions
+export const { addLog, clearLogs, removeLogs } = connectorLogsSlice.actions
 
 export const selectConnectorLogs = (state: RootState): ConnectorLogsState =>
   state.connectorLogs

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -58,6 +58,7 @@ class LauncherView extends Component {
   }
 
   async componentDidUpdate() {
+    this.launcher.setLogger(this.props.onKonnectorLog)
     this.launcher.setStartContext({
       ...this.props.launcherContext,
       client: this.props.client,
@@ -68,6 +69,7 @@ class LauncherView extends Component {
 
   async componentDidMount() {
     this.launcher = new ReactNativeLauncher()
+    this.launcher.setLogger(this.props.onKonnectorLog)
     this.launcher.setStartContext({
       ...this.props.launcherContext,
       client: this.props.client,

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,16 +1,10 @@
 import React, { useState } from 'react'
 import { StatusBar, View } from 'react-native'
-
-import Minilog from '@cozy/minilog'
-const konnLog = Minilog('Konnector')
-
 import {
   NavigationProp,
   ParamListBase,
   RouteProp
 } from '@react-navigation/native'
-import { useConnectors } from '/hooks/useConnectors'
-import { LogObj } from '/redux/ConnectorState/ConnectorLogsSlice'
 
 import HomeView from '/screens/home/components/HomeView'
 import LauncherView from '/screens/connectors/LauncherView'
@@ -33,6 +27,7 @@ export const HomeScreen = ({
     canDisplayLauncher,
     launcherClient,
     launcherContext,
+    onKonnectorLog,
     resetLauncherContext,
     setLauncherContext,
     trySetLauncherContext
@@ -55,6 +50,7 @@ export const HomeScreen = ({
           launcherContext={launcherContext.value}
           retry={resetLauncherContext}
           setLauncherContext={setLauncherContext}
+          onKonnectorLog={onKonnectorLog}
         />
       )}
 

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,10 +1,16 @@
 import React, { useState } from 'react'
 import { StatusBar, View } from 'react-native'
+
+import Minilog from '@cozy/minilog'
+const konnLog = Minilog('Konnector')
+
 import {
   NavigationProp,
   ParamListBase,
   RouteProp
 } from '@react-navigation/native'
+import { useConnectors } from '/hooks/useConnectors'
+import { LogObj } from '/redux/ConnectorState/ConnectorLogsSlice'
 
 import HomeView from '/screens/home/components/HomeView'
 import LauncherView from '/screens/connectors/LauncherView'

--- a/src/screens/home/hooks/useLauncherContext.tsx
+++ b/src/screens/home/hooks/useLauncherContext.tsx
@@ -2,10 +2,14 @@ import React from 'react'
 import { useState } from 'react'
 
 import CozyClient from 'cozy-client'
+import Minilog from '@cozy/minilog'
+const konnLog = Minilog('Konnector')
 
 import { LauncherContext } from '/libs/connectors/models'
 import { useLauncherWrapper } from '/screens/home/hooks/useLauncherWrapper'
 import { ErrorParallelConnectors } from '/screens/home/components/ErrorParallelConnectors'
+import { useConnectors } from '/hooks/useConnectors'
+import { LogObj } from '/redux/ConnectorState/ConnectorLogsSlice'
 
 interface useLauncherContextReturn {
   LauncherDialog: JSX.Element | null
@@ -13,6 +17,7 @@ interface useLauncherContextReturn {
   concurrentConnector?: string
   launcherClient?: CozyClient
   launcherContext: LauncherContext
+  onKonnectorLog: (logObj: LogObj) => void
   resetLauncherContext: () => void
   setConcurrentConnector: (connectorSlug?: string) => void
   setLauncherContext: (candidateContext: LauncherContext) => void
@@ -26,6 +31,16 @@ export const useLauncherContext = (): useLauncherContextReturn => {
   const { canDisplayLauncher, launcherClient } =
     useLauncherWrapper(launcherContext)
   const [concurrentConnector, setConcurrentConnector] = useState<string>()
+  const { addLog } = useConnectors()
+
+  const onKonnectorLog = (logObj: LogObj): void => {
+    const level = logObj.level
+    if (level in konnLog) {
+      const key = level as keyof MiniLogger
+      konnLog[key](`${logObj.slug}: ${logObj.msg}`)
+    }
+    addLog(logObj)
+  }
 
   const trySetLauncherContext = (candidateContext: LauncherContext): void => {
     if (launcherContext.value && candidateContext.value)
@@ -54,6 +69,7 @@ export const useLauncherContext = (): useLauncherContextReturn => {
     resetLauncherContext,
     setConcurrentConnector,
     setLauncherContext,
-    trySetLauncherContext
+    trySetLauncherContext,
+    onKonnectorLog
   }
 }


### PR DESCRIPTION
This PR send konnectors logs in batch to the stack.

They respect the format of stack.
They are filtered on possible level (or debug is the default level) : debug, info, warn, error
They are log into the flagship app too corresponding to their level.
