### PR TITLE
fix: Template connector manifest url to https

### DIFF
--- a/connectors/template/manifest.konnector
+++ b/connectors/template/manifest.konnector
@@ -7,7 +7,7 @@
   "slug": "template",
   "source": "git@github.com:konnectors/template.git",
   "editor": "Cozy",
-  "vendor_link": "http://books.toscrape.com/",
+  "vendor_link": "https://books.toscrape.com/",
   "categories": [
     "transport"
   ],


### PR DESCRIPTION
Or else, the pilot webview will be init on http://books.toscrape.com and
will fail to fetch https files.


#### Checklist

Before merging this PR, the following things must have been done:

* [X] Tested on Android

