### PR TITLE
fix: Ignore api-keys.json in new directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode
 coverage/
-src/api-keys.json
+src/constants/api-keys.json
 storage/
 token.json
 


### PR DESCRIPTION
api-keys.json file position was changed to src/constants/ directory

Updated .gitignore accordingly
