### PR TITLE
fix: Update doc and `.gitignore` to reflect the move of `api-keys.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 coverage/
 src/api-keys.json
+src/constants/api-keys.json
 storage/
 token.json
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This verification requires the `cozy-stack` to be configured with the app inform
 To enable Flagship certification:
 - Retrieve the project's Safetynet Api Key on the pass manager
   - Or generate a new one following Google documentation: https://developer.android.com/training/safetynet/attestation#add-api-key
-- Create a file `src/api-keys.json` and fill it with the following content:
+- Create a file `src/constants/api-keys.json` and fill it with the following content:
 ```json
 {
   "androidSafetyNetApiKey": "YOUR_GOOGLE_SAFETYNET_API_KEY"


### PR DESCRIPTION
This PR updates doc and `.gitignore` file to reflect the new folder structure

Related commit: e749b85272a00e4743dc1880f0b3ff1488c0dc67

BREAKING CHANGE: `api-keys.json` should now be placed in `src/constants/` folder. See README.md file for more info

> **Note**
> I didn't removed the old `src/api-keys.json` to prevent unexpected commit of the old file.