### PR TITLE
fix: Fallback screen width and height were undefined in navigateToApp

### DIFF
--- a/src/libs/functions/openApp.js
+++ b/src/libs/functions/openApp.js
@@ -1,6 +1,5 @@
 import { Alert, Linking, Platform } from 'react-native'
-import { screenHeight, screenWidth } from '../dimensions'
-
+import { getDimensions } from '/libs/dimensions'
 /**
  * App's mobile information. Used to describe the app scheme and its store urls
  * @typedef {object} AppManifestMobileInfo
@@ -132,6 +131,7 @@ export const openApp = (navigation, href, app, iconParams) => {
 }
 
 export const navigateToApp = ({ navigation, href, slug, iconParams }) => {
+  const { screenWidth, screenHeight } = getDimensions()
   return navigation.navigate('cozyapp', {
     href,
     iconParams: (iconParams && JSON.parse(iconParams)) || {

--- a/src/libs/functions/openApp.spec.js
+++ b/src/libs/functions/openApp.spec.js
@@ -2,9 +2,11 @@ import RN from 'react-native'
 
 import { openApp } from './openApp'
 
-jest.mock('../dimensions', () => ({
-  screenHeight: 732,
-  screenWidth: 412
+jest.mock('/libs/dimensions', () => ({
+  getDimensions: jest.fn().mockReturnValue({
+    screenHeight: 732,
+    screenWidth: 412
+  })
 }))
 
 jest.mock('react-native', () => ({


### PR DESCRIPTION
This issue was causing an error when clicking on "New note" in the FAB Button in Home.