### PR TITLE
fix: Rework `useAppBootsrap` and fix deeplinks implementations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -64,16 +64,35 @@ const App = ({ setClient }) => {
     return null
   }
 
+  const MainAppNavigator = () => (
+    <Root.Navigator
+      initialRouteName="default"
+      screenOptions={{ headerShown: false }}
+    >
+      <Stack.Screen
+        name="default"
+        component={HomeScreen}
+        initialParams={initialRoute.params}
+      />
+    </Root.Navigator>
+  )
+
   const RootNavigator = () => (
     <Root.Navigator
       initialRouteName={initialRoute.route}
       screenOptions={{ headerShown: false }}
     >
-      <Stack.Screen
-        name={routes.home}
-        component={HomeScreen}
-        initialParams={initialRoute.params}
-      />
+      {/*
+      We embed routes.home into its own Navigator so we prevent initialParams
+      to be re-applied when calling goBack() from the CozyApp route
+      i.e:
+       - We open the app with a deeplink https://links.mycozy.cloud/flagship/drive/?fallback=http://drive.cozy.tools:8080/
+       - routes.home is called with {initialParams:{cozyAppFallbackURL: 'http://drive.cozy.tools:8080/'}}
+       - routes.home reads initialParams and redirects to routes.cozyapp
+       - user press the back button so the app redirects to routes.home
+       - routes.home SHOULD NOT read initialParams and SHOULD NOT redirect to routes.cozyapp
+      */}
+      <Root.Screen name={routes.home} component={MainAppNavigator} />
 
       <Stack.Screen
         name={routes.authenticate}

--- a/src/App.js
+++ b/src/App.js
@@ -55,7 +55,7 @@ const App = ({ setClient }) => {
 
   useNetService(client)
 
-  const { initialScreen, initialRoute, isLoading } = useAppBootstrap(client)
+  const { initialRoute, isLoading } = useAppBootstrap(client)
 
   useGlobalAppState()
   useCookieResyncOnResume()
@@ -64,34 +64,34 @@ const App = ({ setClient }) => {
     return null
   }
 
-  const StackNavigator = () => (
-    <Stack.Navigator
-      initialRouteName={client ? routes.home : initialScreen.stack}
+  const RootNavigator = () => (
+    <Root.Navigator
+      initialRouteName={initialRoute.route}
       screenOptions={{ headerShown: false }}
     >
       <Stack.Screen
         name={routes.home}
         component={HomeScreen}
-        {...(initialRoute.stack ? { initialParams: initialRoute.stack } : {})}
+        initialParams={initialRoute.params}
       />
 
       <Stack.Screen
         name={routes.authenticate}
-        initialParams={initialScreen.params}
+        initialParams={initialRoute.params}
       >
         {params => <LoginScreen setClient={setClient} {...params} />}
       </Stack.Screen>
 
       <Stack.Screen
         name={routes.onboarding}
-        initialParams={initialScreen.params}
+        initialParams={initialRoute.params}
       >
         {params => <OnboardingScreen setClient={setClient} {...params} />}
       </Stack.Screen>
 
       <Stack.Screen
         name={routes.instanceCreation}
-        initialParams={initialScreen.params}
+        initialParams={initialRoute.params}
       >
         {params => <CreateInstanceScreen {...params} />}
       </Stack.Screen>
@@ -99,15 +99,6 @@ const App = ({ setClient }) => {
       <Stack.Screen name={routes.welcome}>
         {params => <WelcomeScreen setClient={setClient} {...params} />}
       </Stack.Screen>
-    </Stack.Navigator>
-  )
-
-  const RootNavigator = () => (
-    <Root.Navigator
-      initialRouteName={initialScreen.root}
-      screenOptions={{ headerShown: false }}
-    >
-      <Root.Screen name={routes.stack} component={StackNavigator} />
 
       <Root.Screen
         name={routes.error}
@@ -122,7 +113,6 @@ const App = ({ setClient }) => {
           presentation: 'transparentModal',
           animationEnabled: false
         }}
-        {...(initialRoute.root ? { initialParams: initialRoute.root } : {})}
       />
 
       <Root.Screen

--- a/src/App.js
+++ b/src/App.js
@@ -55,10 +55,7 @@ const App = ({ setClient }) => {
 
   useNetService(client)
 
-  const { initialScreen, initialRoute, isLoading } = useAppBootstrap(
-    client,
-    setClient
-  )
+  const { initialScreen, initialRoute, isLoading } = useAppBootstrap(client)
 
   useGlobalAppState()
   useCookieResyncOnResume()

--- a/src/hooks/useAppBootstrap.functions.ts
+++ b/src/hooks/useAppBootstrap.functions.ts
@@ -9,6 +9,10 @@ interface OnboardingParams {
   fqdn: string | null
 }
 
+const MAIN_APP = 'home'
+const FALLBACK_PARAM = 'fallback'
+const UNIVERSAL_LINK_BASE_PATH = 'flagship'
+
 export const parseOnboardingURL = (
   url: string | null
 ): OnboardingParams | undefined => {
@@ -55,12 +59,15 @@ export const parseFallbackURL = (url: string | null): FallbackUrl => {
 
   try {
     const makeURL = new URL(url)
-    const fallback = makeURL.searchParams.get('fallback') ?? undefined
-    const isHome = makeURL.pathname.split('/')[1] === 'home'
+    const fallback = makeURL.searchParams.get(FALLBACK_PARAM) ?? undefined
+    const isMainApp =
+      makeURL.pathname.startsWith(`/${MAIN_APP}`) ||
+      makeURL.pathname.startsWith(`/${UNIVERSAL_LINK_BASE_PATH}/${MAIN_APP}`) ||
+      makeURL.host === `${MAIN_APP}`
 
     return {
-      mainAppFallbackURL: isHome ? fallback : undefined,
-      cozyAppFallbackURL: !isHome ? fallback : undefined
+      mainAppFallbackURL: isMainApp ? fallback : undefined,
+      cozyAppFallbackURL: !isMainApp ? fallback : undefined
     }
   } catch (error) {
     const errorMessage = getErrorMessage(error)

--- a/src/hooks/useAppBootstrap.functions.ts
+++ b/src/hooks/useAppBootstrap.functions.ts
@@ -1,6 +1,5 @@
 import Minilog from '@cozy/minilog'
 
-import { routes } from '/constants/routes'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
 
 const log = Minilog('useAppBootstrap.functions')
@@ -41,14 +40,12 @@ export const parseOnboardingURL = (
 
 interface FallbackUrl {
   fallback: string | null | undefined
-  root: string
   isHome: boolean
 }
 
 export const parseFallbackURL = (url: string | null): FallbackUrl => {
   const defaultParse = {
     fallback: undefined,
-    root: routes.stack,
     isHome: false
   }
 
@@ -63,7 +60,6 @@ export const parseFallbackURL = (url: string | null): FallbackUrl => {
 
     return {
       fallback: fallback ? fallback : undefined,
-      root: isHome || !fallback ? routes.stack : routes.cozyapp,
       isHome
     }
   } catch (error) {

--- a/src/hooks/useAppBootstrap.functions.ts
+++ b/src/hooks/useAppBootstrap.functions.ts
@@ -1,0 +1,39 @@
+import Minilog from '@cozy/minilog'
+
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+const log = Minilog('useAppBootstrap.functions')
+
+interface OnboardingParams {
+  onboardUrl: string | null
+  fqdn: string | null
+}
+
+export const parseOnboardingURL = (
+  url: string | null
+): OnboardingParams | undefined => {
+  try {
+    if (!url?.includes('onboarding')) {
+      return undefined
+    }
+
+    const onboardingUrl = new URL(url)
+    const onboardUrl = onboardingUrl.searchParams.get('onboard_url')
+    const fqdn = onboardingUrl.searchParams.get('fqdn')
+
+    if (!onboardUrl && !fqdn) {
+      return undefined
+    }
+
+    return {
+      onboardUrl,
+      fqdn
+    }
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error(
+      `Something went wrong while trying to parse onboarding URL data: ${errorMessage}`
+    )
+    return undefined
+  }
+}

--- a/src/hooks/useAppBootstrap.functions.ts
+++ b/src/hooks/useAppBootstrap.functions.ts
@@ -39,14 +39,14 @@ export const parseOnboardingURL = (
 }
 
 interface FallbackUrl {
-  fallback: string | null | undefined
-  isHome: boolean
+  mainAppFallbackURL: string | undefined
+  cozyAppFallbackURL: string | undefined
 }
 
 export const parseFallbackURL = (url: string | null): FallbackUrl => {
   const defaultParse = {
-    fallback: undefined,
-    isHome: false
+    mainAppFallbackURL: undefined,
+    cozyAppFallbackURL: undefined
   }
 
   if (url === null) {
@@ -55,12 +55,12 @@ export const parseFallbackURL = (url: string | null): FallbackUrl => {
 
   try {
     const makeURL = new URL(url)
-    const fallback = makeURL.searchParams.get('fallback')
+    const fallback = makeURL.searchParams.get('fallback') ?? undefined
     const isHome = makeURL.pathname.split('/')[1] === 'home'
 
     return {
-      fallback: fallback ? fallback : undefined,
-      isHome
+      mainAppFallbackURL: isHome ? fallback : undefined,
+      cozyAppFallbackURL: !isHome ? fallback : undefined
     }
   } catch (error) {
     const errorMessage = getErrorMessage(error)

--- a/src/hooks/useAppBootstrap.functions.ts
+++ b/src/hooks/useAppBootstrap.functions.ts
@@ -1,5 +1,6 @@
 import Minilog from '@cozy/minilog'
 
+import { routes } from '/constants/routes'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
 
 const log = Minilog('useAppBootstrap.functions')
@@ -35,5 +36,37 @@ export const parseOnboardingURL = (
       `Something went wrong while trying to parse onboarding URL data: ${errorMessage}`
     )
     return undefined
+  }
+}
+
+interface FallbackUrl {
+  fallback: string | null | undefined
+  root: string
+  isHome?: boolean
+}
+
+export const parseFallbackURL = (url: string | null): FallbackUrl => {
+  const defaultParse = { fallback: undefined, root: routes.stack }
+
+  if (url === null) {
+    return defaultParse
+  }
+
+  try {
+    const makeURL = new URL(url)
+    const fallback = makeURL.searchParams.get('fallback')
+    const isHome = makeURL.pathname.split('/')[1] === 'home'
+
+    return {
+      fallback: fallback ? fallback : undefined,
+      root: isHome || !fallback ? routes.stack : routes.cozyapp,
+      isHome
+    }
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error(
+      `Something went wrong while trying to parse fallback URL data: ${errorMessage}`
+    )
+    return defaultParse
   }
 }

--- a/src/hooks/useAppBootstrap.functions.ts
+++ b/src/hooks/useAppBootstrap.functions.ts
@@ -42,11 +42,15 @@ export const parseOnboardingURL = (
 interface FallbackUrl {
   fallback: string | null | undefined
   root: string
-  isHome?: boolean
+  isHome: boolean
 }
 
 export const parseFallbackURL = (url: string | null): FallbackUrl => {
-  const defaultParse = { fallback: undefined, root: routes.stack }
+  const defaultParse = {
+    fallback: undefined,
+    root: routes.stack,
+    isHome: false
+  }
 
   if (url === null) {
     return defaultParse

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -128,7 +128,7 @@ export const useAppBootstrap = client => {
 
   // Handling app readiness
   useEffect(() => {
-    if (client !== 'fetching' && initialRoute !== 'fetching' && isLoading) {
+    if (initialRoute !== 'fetching' && isLoading) {
       setIsLoading(false)
       if (initialScreen.stack !== routes.home) {
         hideSplashScreen()

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -50,13 +50,14 @@ export const useAppBootstrap = client => {
         }
       } else {
         const payload = await Linking.getInitialURL()
-        const { fallback, isHome } = parseFallbackURL(payload)
+        const { mainAppFallbackURL, cozyAppFallbackURL } =
+          parseFallbackURL(payload)
 
         return setInitialRoute({
           route: routes.home,
           params: {
-            mainAppFallbackURL: isHome ? fallback : undefined,
-            cozyAppFallbackURL: !isHome ? fallback : undefined
+            mainAppFallbackURL,
+            cozyAppFallbackURL
           }
         })
       }

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -8,33 +8,9 @@ import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
 import { useSplashScreen } from '/hooks/useSplashScreen'
 
+import { parseOnboardingURL } from './useAppBootstrap.functions'
+
 const log = Minilog('useAppBootstrap')
-
-const parseOnboardingURL = url => {
-  try {
-    if (!url || !url.includes('onboarding')) {
-      return undefined
-    }
-
-    const onboardingUrl = new URL(url)
-    const onboardUrl = onboardingUrl.searchParams.get('onboard_url')
-    const fqdn = onboardingUrl.searchParams.get('fqdn')
-
-    if (!onboardUrl && !fqdn) {
-      return undefined
-    }
-
-    return {
-      onboardUrl,
-      fqdn
-    }
-  } catch (error) {
-    log.error(
-      `Something went wrong while trying to parse onboarding URL data: ${error.message}`
-    )
-    return undefined
-  }
-}
 
 const parseFallbackURL = url => {
   const defaultParse = { fallback: undefined, root: routes.stack }

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -14,7 +14,6 @@ import {
 
 export const useAppBootstrap = client => {
   const [initialRoute, setInitialRoute] = useState('fetching')
-  const [initialScreen, setInitialScreen] = useState('fetching')
   const [isLoading, setIsLoading] = useState(true)
   const { hideSplashScreen } = useSplashScreen()
 
@@ -30,62 +29,51 @@ export const useAppBootstrap = client => {
           const { onboardUrl, fqdn } = onboardingParams
 
           if (onboardUrl) {
-            setInitialRoute({ stack: undefined, root: undefined })
-
-            return setInitialScreen({
-              stack: routes.instanceCreation,
-              root: routes.stack,
+            return setInitialRoute({
+              route: routes.instanceCreation,
               params: {
                 onboardUrl
               }
             })
           } else {
-            setInitialRoute({ stack: undefined, root: undefined })
-
-            return setInitialScreen({
-              stack: routes.authenticate,
-              root: routes.stack,
+            return setInitialRoute({
+              route: routes.authenticate,
               params: {
                 fqdn
               }
             })
           }
         } else {
-          setInitialRoute({ stack: undefined, root: undefined })
-
-          return setInitialScreen({
-            stack: routes.welcome,
-            root: routes.stack
+          return setInitialRoute({
+            route: routes.welcome
           })
         }
       } else {
         const payload = await Linking.getInitialURL()
-        const { fallback, root, isHome } = parseFallbackURL(payload)
+        const { fallback, isHome } = parseFallbackURL(payload)
 
-        setInitialScreen({
-          stack: routes.home,
-          root
-        })
-
-        setInitialRoute({
-          stack: isHome ? fallback : undefined,
-          root: !isHome ? fallback : undefined
+        return setInitialRoute({
+          route: routes.home,
+          params: {
+            mainAppFallbackURL: isHome ? fallback : undefined,
+            cozyAppFallbackURL: !isHome ? fallback : undefined
+          }
         })
       }
     }
 
-    initialRoute === 'fetching' && initialScreen === 'fetching' && doAsync()
-  }, [client, initialRoute, initialScreen, hideSplashScreen])
+    initialRoute === 'fetching' && doAsync()
+  }, [client, initialRoute, hideSplashScreen])
 
   // Handling app readiness
   useEffect(() => {
     if (initialRoute !== 'fetching' && isLoading) {
       setIsLoading(false)
-      if (initialScreen.stack !== routes.home) {
+      if (initialRoute.route !== routes.home) {
         hideSplashScreen()
       }
     }
-  }, [isLoading, initialRoute, client, hideSplashScreen, initialScreen.stack])
+  }, [isLoading, initialRoute, client, hideSplashScreen, initialRoute.route])
 
   // Handling post load side effects
   useEffect(() => {
@@ -127,7 +115,6 @@ export const useAppBootstrap = client => {
   return {
     client,
     initialRoute,
-    initialScreen,
     isLoading
   }
 }

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -1,4 +1,3 @@
-import Minilog from '@cozy/minilog'
 import { Linking } from 'react-native'
 import { useEffect, useState } from 'react'
 
@@ -8,34 +7,10 @@ import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
 import { useSplashScreen } from '/hooks/useSplashScreen'
 
-import { parseOnboardingURL } from './useAppBootstrap.functions'
-
-const log = Minilog('useAppBootstrap')
-
-const parseFallbackURL = url => {
-  const defaultParse = { fallback: undefined, root: routes.stack }
-
-  if (url === null) {
-    return defaultParse
-  }
-
-  try {
-    const makeURL = new URL(url)
-    const fallback = makeURL.searchParams.get('fallback')
-    const isHome = makeURL.pathname.split('/')[1] === 'home'
-
-    return {
-      fallback: fallback ? fallback : undefined,
-      root: isHome || !fallback ? routes.stack : routes.cozyapp,
-      isHome
-    }
-  } catch (error) {
-    log.error(
-      `Something went wrong while trying to parse fallback URL data: ${error.message}`
-    )
-    return defaultParse
-  }
-}
+import {
+  parseFallbackURL,
+  parseOnboardingURL
+} from './useAppBootstrap.functions'
 
 export const useAppBootstrap = client => {
   const [initialRoute, setInitialRoute] = useState('fetching')

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -1,8 +1,10 @@
 import { Linking } from 'react-native'
 import { useEffect, useState } from 'react'
+import { deconstructCozyWebLinkWithSlug } from 'cozy-client'
 
 import { SentryCustomTags, setSentryTag } from '/libs/monitoring/Sentry'
 import { manageIconCache } from '/libs/functions/iconTable'
+import { getDefaultIconParams } from '/libs/functions/openApp'
 import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
 import { useSplashScreen } from '/hooks/useSplashScreen'
@@ -100,10 +102,23 @@ export const useAppBootstrap = client => {
         }
       }
 
-      const { fallback: href, isHome } = parseFallbackURL(url)
+      const { mainAppFallbackURL, cozyAppFallbackURL } = parseFallbackURL(url)
 
-      if (href) {
-        navigate(isHome ? routes.home : routes.cozyapp, { href })
+      if (mainAppFallbackURL || cozyAppFallbackURL) {
+        const href = mainAppFallbackURL || cozyAppFallbackURL
+
+        const subdomainType = client.capabilities?.flat_subdomains
+          ? 'flat'
+          : 'nested'
+        const { slug } = deconstructCozyWebLinkWithSlug(href, subdomainType)
+
+        const iconParams = getDefaultIconParams()
+
+        navigate(mainAppFallbackURL ? routes.home : routes.cozyapp, {
+          href,
+          slug,
+          iconParams
+        })
         return
       }
     })

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -7,12 +7,11 @@ import { manageIconCache } from '/libs/functions/iconTable'
 import { getDefaultIconParams } from '/libs/functions/openApp'
 import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
-import { useSplashScreen } from '/hooks/useSplashScreen'
-
 import {
   parseFallbackURL,
   parseOnboardingURL
-} from './useAppBootstrap.functions'
+} from '/hooks/useAppBootstrap.functions'
+import { useSplashScreen } from '/hooks/useSplashScreen'
 
 export const useAppBootstrap = client => {
   const [initialRoute, setInitialRoute] = useState('fetching')

--- a/src/hooks/useAppBootstrap.spec.js
+++ b/src/hooks/useAppBootstrap.spec.js
@@ -45,6 +45,22 @@ jest.mock('./useSplashScreen', () => ({
   useSplashScreen: () => ({ hideSplashScreen: mockHideSplashScreen })
 }))
 
+jest.mock('/libs/functions/openApp', () => ({
+  getDefaultIconParams: jest.fn().mockReturnValue({})
+}))
+
+jest.mock('cozy-client', () => ({
+  deconstructCozyWebLinkWithSlug: jest.fn().mockImplementation(url => {
+    if (url === HOME_FALLBACK_URL) {
+      return { slug: 'home' }
+    } else if (url === APP_FALLBACK_URL) {
+      return { slug: 'drive' }
+    } else {
+      throw new Error('Should not happen')
+    }
+  })
+}))
+
 const listeners = []
 const mockRemove = jest.fn().mockImplementation(listener => {
   return () => {
@@ -362,7 +378,9 @@ it('Should handle WITH lifecycle URL as HOME', async () => {
   })
 
   expect(navigate).toHaveBeenNthCalledWith(1, routes.home, {
-    href: HOME_FALLBACK_URL
+    href: HOME_FALLBACK_URL,
+    slug: 'home',
+    iconParams: expect.anything()
   })
 })
 
@@ -392,7 +410,9 @@ it('Should handle WITH lifecycle URL as APP LINK', async () => {
   })
 
   expect(navigate).toHaveBeenNthCalledWith(1, routes.cozyapp, {
-    href: APP_FALLBACK_URL
+    href: APP_FALLBACK_URL,
+    slug: 'drive',
+    iconParams: expect.anything()
   })
 })
 

--- a/src/hooks/useAppBootstrap.spec.js
+++ b/src/hooks/useAppBootstrap.spec.js
@@ -16,10 +16,12 @@ const HOME_FALLBACK_URL =
   'https://claude-drive.mycozy.cloud/#/connected/connector_slug/new'
 const HOME_FALLBACK_URL_ENCODED =
   'https%3A%2F%2Fclaude-drive.mycozy.cloud%2F%23%2Fconnected%2Fconnector_slug%2Fnew'
-const HOME_UNIVERSAL_LINK = `https://links.mycozy.cloud/home?fallback=${HOME_FALLBACK_URL_ENCODED}`
+const HOME_UNIVERSAL_LINK = `https://links.mycozy.cloud/flagship/home?fallback=${HOME_FALLBACK_URL_ENCODED}`
+const HOME_ANDROID_SCHEME = `cozy://home?fallback=${HOME_FALLBACK_URL_ENCODED}`
 const APP_FALLBACK_URL = `https://claude-drive.mycozy.cloud/#/folder/SOME_FOLDER_ID`
 const APP_FALLBACK_URL_ENCODED = `https%3A%2F%2Fclaude-drive.mycozy.cloud%2F%23%2Ffolder%2FSOME_FOLDER_ID`
-const APP_UNIVERSAL_LINK = `https://links.mycozy.cloud/drive/folder/SOME_FOLDER_ID?fallback=${APP_FALLBACK_URL_ENCODED}`
+const APP_UNIVERSAL_LINK = `https://links.mycozy.cloud/flagship/drive/folder/SOME_FOLDER_ID?fallback=${APP_FALLBACK_URL_ENCODED}`
+const APP_ANDROID_SCHEME = `cozy://drive/folder/SOME_FOLDER_ID?fallback=${APP_FALLBACK_URL_ENCODED}`
 const INVALID_LINK = 'https://foo.com'
 
 jest.mock('../libs/client', () => ({
@@ -226,7 +228,7 @@ it('Should handle WITH client NO initial URL', async () => {
   })
 })
 
-it('Should handle WITH client WITH initial URL as HOME', async () => {
+it('Should handle WITH client WITH initial URL as HOME (Universal Link)', async () => {
   Linking.getInitialURL.mockResolvedValueOnce(HOME_UNIVERSAL_LINK)
 
   const { result, waitForValueToChange } = renderHook(() =>
@@ -248,8 +250,52 @@ it('Should handle WITH client WITH initial URL as HOME', async () => {
   })
 })
 
-it('Should handle WITH client WITH initial URL as APP LINK', async () => {
+it('Should handle WITH client WITH initial URL as HOME (Android Scheme)', async () => {
+  Linking.getInitialURL.mockResolvedValueOnce(HOME_ANDROID_SCHEME)
+
+  const { result, waitForValueToChange } = renderHook(() =>
+    useAppBootstrap(mockClient)
+  )
+
+  await waitForValueToChange(() => result.current.isLoading)
+
+  expect(result.current).toStrictEqual({
+    client: mockClient,
+    initialRoute: {
+      route: routes.home,
+      params: {
+        mainAppFallbackURL: HOME_FALLBACK_URL,
+        cozyAppFallbackURL: undefined
+      }
+    },
+    isLoading: false
+  })
+})
+
+it('Should handle WITH client WITH initial URL as APP LINK (Universal Link)', async () => {
   Linking.getInitialURL.mockResolvedValueOnce(APP_UNIVERSAL_LINK)
+
+  const { result, waitForValueToChange } = renderHook(() =>
+    useAppBootstrap(mockClient)
+  )
+
+  await waitForValueToChange(() => result.current.isLoading)
+
+  expect(result.current).toStrictEqual({
+    client: mockClient,
+    initialRoute: {
+      route: routes.home,
+      params: {
+        mainAppFallbackURL: undefined,
+        cozyAppFallbackURL: APP_FALLBACK_URL
+      }
+    },
+    isLoading: false
+  })
+})
+
+it('Should handle WITH client WITH initial URL as APP LINK (Android Scheme)', async () => {
+  Linking.getInitialURL.mockResolvedValueOnce(APP_ANDROID_SCHEME)
 
   const { result, waitForValueToChange } = renderHook(() =>
     useAppBootstrap(mockClient)

--- a/src/libs/functions/openApp.js
+++ b/src/libs/functions/openApp.js
@@ -130,16 +130,22 @@ export const openApp = (navigation, href, app, iconParams) => {
   return navigateToApp({ navigation, href, slug: app?.slug, iconParams })
 }
 
-export const navigateToApp = ({ navigation, href, slug, iconParams }) => {
+export const getDefaultIconParams = () => {
   const { screenWidth, screenHeight } = getDimensions()
+
+  return {
+    x: screenWidth * 0.5 - 32 * 0.5,
+    y: screenHeight * 0.5 - 32 * 0.5,
+    width: 32,
+    height: 32
+  }
+}
+
+export const navigateToApp = ({ navigation, href, slug, iconParams }) => {
   return navigation.navigate('cozyapp', {
     href,
-    iconParams: (iconParams && JSON.parse(iconParams)) || {
-      x: screenWidth * 0.5 - 32 * 0.5,
-      y: screenHeight * 0.5 - 32 * 0.5,
-      width: 32,
-      height: 32
-    },
+    iconParams:
+      (iconParams && JSON.parse(iconParams)) || getDefaultIconParams(),
     slug
   })
 }

--- a/src/libs/intents/localMethods.spec.ts
+++ b/src/libs/intents/localMethods.spec.ts
@@ -40,7 +40,7 @@ describe('asyncLogout', () => {
   it('should handle Navigate to authenticate page and prevent go back', async () => {
     await asyncLogout(client)
 
-    expect(RootNavigation.reset).toHaveBeenCalledWith('stack', {
+    expect(RootNavigation.reset).toHaveBeenCalledWith('welcome', {
       screen: 'welcome'
     })
   })

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -33,7 +33,7 @@ export const asyncLogout = async (client?: CozyClient): Promise<null> => {
   await deleteKeychain()
   await clearCookies()
   await clearData()
-  RootNavigation.reset(routes.stack, { screen: 'welcome' })
+  RootNavigation.reset(routes.welcome, { screen: 'welcome' })
   return Promise.resolve(null)
 }
 


### PR DESCRIPTION
With previous implementation we had to use `setInitialRoute()` and `setInitialScreen()` to define the initial app state

This was problematic as it was difficult to understand which route should be defined as `initial route` and which one should be defined as `initial screen`

Also the usage of `initialRoute.stack = <some_route>` and `initialScreen.stack = <some_route>` with addition to the presence of `intialRoute.route = routes.stack` made it even more confusing about what is a `root` and what is a `stack`

This complexity was due to the fact that we split the routes declarations between `RootNavigator` and `StackNavigator`. Here again the rule defining where to put each route was unclear

To simplify this we chose to refactor the code to use one single `Navigator` for every routes

This simplifies the API as we only need to use `setInitialRoute()` now, and its parameters only consist of a `route` and a set of `params`

The only exception is the nested `MainAppNavigator` that has been introduced in the `fix: Handle deeplinks on cold start` commit. See the commit description to understand why it is needed
___

TODO:

- [x] Tests on iOS
- [x] Tests on Android
- [x] Document test scenario in a Paper document