### PR TITLE
feat: Remove cozy-client-js from saveFiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "base-64": "^1.0.0",
     "bluebird-retry": "^0.11.0",
     "cheerio": "^1.0.0-rc.9",
-    "cozy-client": "^34.7.1",
+    "cozy-client": "^34.11.0",
     "cozy-client-js": "^0.20.0",
     "cozy-device-helper": "^2.6.0",
     "cozy-flags": "^2.10.2",

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -257,11 +257,11 @@ export default class Launcher {
     }
     log.info(entries, 'saveFiles entries')
     const result = await saveFiles(
+      client,
       entries,
       await this.getFolderPath(trigger.message.folder_to_save),
       {
         ...options,
-        client,
         manifest,
         sourceAccount: job.message.account,
         sourceAccountIdentifier

--- a/src/libs/connectorLibs/saveFiles.js
+++ b/src/libs/connectorLibs/saveFiles.js
@@ -400,8 +400,9 @@ const shouldReplaceFile = async function (file, entry, options) {
 const removeFile = async function (client, file) {
   if (!client) {
     log.error('No client, impossible to delete file')
+  } else {
+    await client.collection('io.cozy.files').deleteFilePermanently(file._id)
   }
-  await client.collection('io.cozy.files').deleteFilePermanently(file._id)
 }
 
 module.exports = saveFiles

--- a/src/libs/connectorLibs/saveFiles.js
+++ b/src/libs/connectorLibs/saveFiles.js
@@ -4,8 +4,6 @@ import omit from 'lodash/omit'
 import { Q } from 'cozy-client'
 import retry from 'bluebird-retry'
 
-let client
-
 const log = Minilog('saveFiles')
 
 const saveFiles = async (entries, folderPath, options = {}) => {
@@ -22,7 +20,7 @@ const saveFiles = async (entries, folderPath, options = {}) => {
     throw new Error('No cozy-client instance given')
   }
 
-  client = options.client
+  const client = options.client
 
   const saveOptions = {
     folderPath,
@@ -194,6 +192,7 @@ async function getFileIfExists(client, entry, options) {
     fileIdAttributes && slug && sourceAccountIdentifier
   if (isReadyForFileMetadata) {
     const file = await getFileFromMetaData(
+      client,
       entry,
       fileIdAttributes,
       sourceAccountIdentifier,
@@ -212,6 +211,7 @@ async function getFileIfExists(client, entry, options) {
 }
 
 async function getFileFromMetaData(
+  client,
   entry,
   fileIdAttributes,
   sourceAccountIdentifier,

--- a/src/libs/connectorLibs/saveFiles.js
+++ b/src/libs/connectorLibs/saveFiles.js
@@ -202,12 +202,12 @@ async function getFileIfExists(client, entry, options) {
     if (!file) {
       // no file with correct metadata, maybe the corresponding file already exist in the default
       // path from a previous version of the connector
-      return await getFileFromPath(client, entry, options)
+      return getFileFromPath(client, entry, options)
     } else {
       return file
     }
   } else {
-    return await getFileFromPath(client, entry, options)
+    return getFileFromPath(client, entry, options)
   }
 }
 

--- a/src/libs/connectorLibs/saveFiles.js
+++ b/src/libs/connectorLibs/saveFiles.js
@@ -6,7 +6,7 @@ import retry from 'bluebird-retry'
 
 const log = Minilog('saveFiles')
 
-const saveFiles = async (entries, folderPath, options = {}) => {
+const saveFiles = async (client, entries, folderPath, options = {}) => {
   if (!entries || entries.length === 0) {
     log.warn('No file to download')
   }
@@ -16,11 +16,9 @@ const saveFiles = async (entries, folderPath, options = {}) => {
   if (!options.sourceAccountIdentifier) {
     log.warn('There is no sourceAccountIdentifier given to saveFiles')
   }
-  if (!options.client) {
+  if (!client) {
     throw new Error('No cozy-client instance given')
   }
-
-  const client = options.client
 
   const saveOptions = {
     folderPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6395,16 +6395,16 @@ cozy-client-js@^0.20.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@^34.7.1:
-  version "34.7.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.7.1.tgz#d0641b43dbf67ca33a4ccae2a9a62b24784c2e1f"
-  integrity sha512-3KDrVOCMVnsxLcuCggM/rL13cIh+jY2MKZmHDZVM0cF8HeGMDHOJSH7cGwyL6vEoEzo6K2bxqPafJaIRqgw9Mw==
+cozy-client@^34.11.0:
+  version "34.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.11.0.tgz#f6877b9eb9080fd1d509cdbcf59473560f282392"
+  integrity sha512-EENMenuECpCe1k8InnoSiI4lpJ20hbfcrBNh5KYTRhHnAzBmrxikzzxEGB5VMzX5bq48Rm94pjpqzNeD0heLEQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^34.7.1"
+    cozy-stack-client "^34.11.0"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -6454,10 +6454,10 @@ cozy-logger@^1.9.1:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-stack-client@^34.7.1:
-  version "34.7.1"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-34.7.1.tgz#f1b81cce2c88ba558a1b5995a91674462f3e629c"
-  integrity sha512-iarCc6y79HCcQKM7ITQX+y3Tvhi1SjtMGonKAkA98MOtB7qBBolU0CJd9CTLyRfzJAVT/VpXHpwBwTLQ5tyo4g==
+cozy-stack-client@^34.11.0:
+  version "34.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-34.11.0.tgz#2c6a6f33b0a935c4d491077d7a4f85e8d2a542b2"
+  integrity sha512-rl6FKFY6r8fhnihBnrsLOS0F0xdvx/2YG6Ok/Yk9OKIsm0GMAn4DIq15xv4XLpHkxSyJLHBX+pZBtdfAFq7wJg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
This PR should remove all 6 calls to cozy-client-js in the saveFiles.js file.

* [x] create file
* [x] update file
* [x] 2 statByPath
* [x] delete and destroy file
* [x] Remove cozy-client-js import and declaration 


