### PR TITLE
feat: add .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Copy this file and rename it to .env and fill the missing values as needed.
+# Only the SENTRY_AUTH_TOKEN is mandatory when developing locally. 
+# You will need more credentials if you need to produce actual signed builds.
+
+# --- ANDROID BUILD ---
+
+# ANDROID_ALIAS="Alias of the signing key"
+# ANDROID_KEY_PASSWORD="Private key password for the signing Keystore"
+# ANDROID_KEY_STORE_PASSWORD="Password to the signing Keystore"
+# ANDROID_SAFETY_NET_API_KEY="SafetyNet Attestation API key"
+# ANDROID_SIGNING_KEY="Base64 encoded signing key used to sign the application"
+
+# --- ANDROID DEPLOY ---
+
+# ANDROID_SERVICE_ACCOUNT_JSON_TEXT="JSON file of the Google Play service account"
+
+# --- IOS BUILD ---
+
+# IOS_CERTIFICATE_PASSWORD="Password used to generate the .p12 certificate"
+# IOS_MOBILE_PROVISION_BASE64="Base64 encoded Provisioning profile file"
+# IOS_P12_BASE64="Base64 encoded .p12 file (key + cert)"
+# IOS_TEAM_ID="Cozy Cloud team ID"
+
+# --- IOS DEPLOY ---
+
+# APPSTORE_API_KEY_ID="Key ID of the App Store Connect API key"
+# APPSTORE_API_PRIVATE_KEY="PKCS8 format Private Key for AppStore Connect API"
+# APPSTORE_ISSUER_ID="UUID of the App Store Connect API key issuer"
+
+# --- OTHER SECRETS ---
+
+SENTRY_AUTH_TOKEN="Auth token for Sentry - MANDATORY"

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ scripts/dist/*
 
 # Sentry
 sentry.properties
+
+# Credentials
+.env

--- a/README.md
+++ b/README.md
@@ -127,12 +127,7 @@ This verification requires the `cozy-stack` to be configured with the app inform
 To enable Flagship certification:
 - Retrieve the project's Safetynet Api Key on the pass manager
   - Or generate a new one following Google documentation: https://developer.android.com/training/safetynet/attestation#add-api-key
-- Create a file `src/constants/api-keys.json` and fill it with the following content:
-```json
-{
-  "androidSafetyNetApiKey": "YOUR_GOOGLE_SAFETYNET_API_KEY"
-}
-```
+- Put the token in the `ANDROID_SAFETY_NET_API_KEY` variable in your local `.env` file
 - On `src/libs/client.js` set `shouldRequireFlagshipPermissions` to `true`
 - Read `cozy-client` instruction in [flagship-certification/README.md](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/flagship-certification/README.md)
 

--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -12,7 +12,7 @@ jest.mock('@sentry/react-native', () => ({
   setTag: jest.fn()
 }))
 jest.mock(
-  '../src/constants/api-keys.json',
+  '../src/constants/api-keys',
   () => ({
     androidSafetyNetApiKey: 'foo'
   }),

--- a/src/constants/api-keys.ts
+++ b/src/constants/api-keys.ts
@@ -1,0 +1,2 @@
+export const androidSafetyNetApiKey =
+  process.env.ANDROID_SAFETY_NET_API_KEY ?? 'testEnvFallback'

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -8,7 +8,7 @@ import { loginFlagship } from './clientHelpers/loginFlagship'
 import { normalizeFqdn } from './functions/stringHelpers'
 import { SOFTWARE_ID, SOFTWARE_NAME } from './constants'
 
-import apiKeys from '/constants/api-keys.json'
+import { androidSafetyNetApiKey } from '/constants/api-keys'
 import strings from '/constants/strings.json'
 
 const log = Minilog('LoginScreen')
@@ -191,9 +191,7 @@ export const createClient = async instance => {
       clientKind: 'mobile',
       clientName: `${SOFTWARE_NAME} (${await getDeviceName()})`,
       shouldRequireFlagshipPermissions: true,
-      certificationConfig: {
-        androidSafetyNetApiKey: apiKeys.androidSafetyNetApiKey
-      }
+      certificationConfig: { androidSafetyNetApiKey }
     }
   }
 


### PR DESCRIPTION
## What does this do?

This will be how we manage build variables now.


## Why did you do this?

Rationalization of the app secrets and structure that match Github secrets. This change was kindled by the implementation of the CI/CD process.

## Who/what does this impact?

When developing locally, you definitely don't need all the variables.
Only the auth token for Sentry is mandatory.
You will need more credentials if you need
to produce actual builds locally.

## How did you test this?

Tested locally and in CI/CD environments.

## Handling breaking changes

- Write your Sentry auth key in local .env (SENTRY_AUTH_TOKEN)
- (optional) Write your Safetynet key in local .env (ANDROID_SAFETY_NET_API_KEY)