### PR TITLE
fix: update connector launcher

### DIFF
--- a/src/hooks/useLauncherClient.ts
+++ b/src/hooks/useLauncherClient.ts
@@ -9,17 +9,17 @@ interface useLauncherClientReturn {
   launcherClient?: CozyClient
 }
 export const useLauncherClient = (
-  launcherContext: LauncherContext
+  launcherContext?: LauncherContext
 ): useLauncherClientReturn => {
   const [launcherClient, setLauncherClient] = useState<CozyClient>()
   const client = useClient()
 
   useEffect(() => {
-    const slug = launcherContext.job?.message?.konnector
+    const slug = launcherContext?.job?.message?.konnector
 
     if (slug) void getLauncherClient(client, slug, setLauncherClient)
     else setLauncherClient(undefined)
-  }, [client, launcherContext.job?.message?.konnector])
+  }, [client, launcherContext?.job?.message?.konnector])
 
   return { launcherClient }
 }

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -195,7 +195,7 @@ export default class Launcher {
    */
   async saveBills(entries, options) {
     log.debug(entries, 'saveBills entries')
-    const { client, job, manifest } = this.getStartContext()
+    const { launcherClient: client, job, manifest } = this.getStartContext()
     const { sourceAccountIdentifier } = this.getUserData()
     const result = await saveBills(entries, {
       ...options,
@@ -222,7 +222,7 @@ export default class Launcher {
    * @param {Object} contact : contact object
    */
   async saveIdentity(contact) {
-    const { client } = this.getStartContext()
+    const { launcherClient: client } = this.getStartContext()
     log.debug(contact, 'saveIdentity contact')
     const { sourceAccountIdentifier } = this.getUserData()
     await saveIdentity(contact, sourceAccountIdentifier, { client })
@@ -235,7 +235,12 @@ export default class Launcher {
    * @returns {Array} list of saved files
    */
   async saveFiles(entries, options) {
-    const { client, trigger, job, manifest } = this.getStartContext()
+    const {
+      launcherClient: client,
+      trigger,
+      job,
+      manifest
+    } = this.getStartContext()
     const { sourceAccountIdentifier } = this.getUserData()
     for (const entry of entries) {
       if (entry.dataUri) {
@@ -276,7 +281,7 @@ export default class Launcher {
    * @returns {Object}
    */
   async getPilotContext({ sourceAccountIdentifier, slug }) {
-    const { client } = this.getStartContext()
+    const { launcherClient: client } = this.getStartContext()
     const result = await client.queryAll(
       Q('io.cozy.files')
         .where({

--- a/src/libs/connectors/getLauncherClient.ts
+++ b/src/libs/connectors/getLauncherClient.ts
@@ -18,17 +18,17 @@ export const getLauncherClient = async (
   slug: string,
   callback?: (client: CozyClient) => void
 ): Promise<CozyClient> => {
-  const { fetchKonnectorToken, uri } = client.getStackClient()
+  const { uri } = client.getStackClient()
 
   try {
-    const client = new CozyClient({
-      token: await fetchKonnectorToken(slug),
+    const newClient = new CozyClient({
+      token: await client.getStackClient().fetchKonnectorToken(slug),
       uri
     })
 
-    callback?.(client)
+    callback?.(newClient)
 
-    return client
+    return newClient
   } catch (error) {
     throw new Error(
       `Failed to create launcher client for ${slug}.\n,

--- a/src/libs/connectors/models.ts
+++ b/src/libs/connectors/models.ts
@@ -1,5 +1,5 @@
 export interface LauncherContext {
   job?: { message?: { konnector?: string } }
-  state: 'default' | 'launch'
+  state?: 'default' | 'launch'
   value?: Record<string, unknown>
 }

--- a/src/libs/cozyAppBundle/cozyAppBundle.functions.ts
+++ b/src/libs/cozyAppBundle/cozyAppBundle.functions.ts
@@ -30,7 +30,7 @@ export const getConnectorBundle = async ({
     const manifest = JSON.parse(
       await RNFS.readFile(path + '/manifest.konnector')
     ) as Record<string, unknown>
-    const content = await RNFS.readFile(path + '/index.js')
+    const content = await RNFS.readFile(path + '/main.js')
 
     return {
       manifest,

--- a/src/libs/cozyAppBundle/cozyAppBundle.ts
+++ b/src/libs/cozyAppBundle/cozyAppBundle.ts
@@ -77,7 +77,7 @@ export const updateCozyAppBundle = async ({
   const stackVersion = await fetchCozyAppVersion(slug, client, type)
 
   log.debug(
-    `Current local version is '${
+    `Current local version for ${slug} is '${
       currentVersion ?? 'unknown'
     }', stack version is '${stackVersion}'`
   )

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -61,6 +61,7 @@ class LauncherView extends Component {
     this.launcher.setStartContext({
       ...this.props.launcherContext,
       client: this.props.client,
+      launcherClient: this.props.launcherClient,
       manifest: get(this, 'state.connector.manifest')
     })
   }
@@ -70,6 +71,7 @@ class LauncherView extends Component {
     this.launcher.setStartContext({
       ...this.props.launcherContext,
       client: this.props.client,
+      launcherClient: this.props.launcherClient,
       manifest: get(this, 'state.connector.manifest')
     })
     const initConnectorError = await this.initConnector()

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -35,7 +35,7 @@ export const HomeScreen = ({
   const [launcherContext, setLauncherContext] = useState<LauncherContext>({
     state: 'default'
   })
-  const { launcherClient } = useLauncherClient(launcherContext)
+  const { launcherClient } = useLauncherClient(launcherContext.value)
 
   return (
     <View style={styles.container}>
@@ -49,13 +49,12 @@ export const HomeScreen = ({
       />
 
       {isLauncherReady(launcherContext) && isClientReady(launcherClient) && (
-        <CozyProvider client={launcherClient}>
-          <LauncherView
-            launcherContext={launcherContext.value}
-            retry={(): void => setLauncherContext({ state: 'default' })}
-            setLauncherContext={setLauncherContext}
-          />
-        </CozyProvider>
+        <LauncherView
+          launcherClient={launcherClient}
+          launcherContext={launcherContext.value}
+          retry={(): void => setLauncherContext({ state: 'default' })}
+          setLauncherContext={setLauncherContext}
+        />
       )}
     </View>
   )


### PR DESCRIPTION
## What does this do?

- Handle stack-only connectors (no registry publication)
- Provide the correct clients to both Launcher and LauncherView
- Read main.js instead of index.js in the cache

## Why did you do this?

Connectors weren't launching properly, especially if not published in the registry

## Who/what does this impact?

- Everyone working on connectors should perceive better workflow and less bugs

## How did you test this?

- Manually, installing `git://github.com/konnectors/template_ccc.git#build` on my staging environment (not local dev stack)