### PR TITLE
fix: duplicate versions of jetified-kotlin-stdlib-1 when building android version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -228,6 +228,14 @@ dependencies {
     implementation project(':react-native-fs')
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
     implementation 'org.nanohttpd:nanohttpd-webserver:2.3.1'
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
+            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
 }
 
 // Run this once to be able to run the application with BUCK


### PR DESCRIPTION
This fix comes from https://github.com/facebook/react-native/issues/35979