### PR TITLE
fix: remove warning from CI check

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -6,7 +6,7 @@ import {
   RouteProp
 } from '@react-navigation/native'
 
-import CozyClient, { CozyProvider } from 'cozy-client'
+import CozyClient from 'cozy-client'
 
 import HomeView from '/screens/home/components/HomeView'
 import LauncherView from '/screens/connectors/LauncherView'


### PR DESCRIPTION
'CozyProvider' is defined but never used

Will fix the only quality_checks warning