### PR TITLE
feat: add connector timeout

### DIFF
--- a/src/libs/functions/convertMinutesToMs.ts
+++ b/src/libs/functions/convertMinutesToMs.ts
@@ -1,0 +1,2 @@
+export const minutesToMilliseconds = (minutes: number | string): number =>
+  Number(minutes) * 60 * 1000

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -11,6 +11,10 @@ import { getDimensions } from '/libs/dimensions'
 import ReactNativeLauncher from '/libs/ReactNativeLauncher'
 import { getColors } from '/ui/colors'
 import strings from '/constants/strings.json'
+import {
+  startTimeout,
+  stopTimeout
+} from '/screens/connectors/core/handleTimeout'
 
 const log = Minilog('LauncherView')
 
@@ -70,6 +74,7 @@ class LauncherView extends Component {
   async componentDidMount() {
     this.launcher = new ReactNativeLauncher()
     this.launcher.setLogger(this.props.onKonnectorLog)
+
     this.launcher.setStartContext({
       ...this.props.launcherContext,
       client: this.props.client,
@@ -98,7 +103,16 @@ class LauncherView extends Component {
         contentScript: get(this, 'state.connector.content')
       })
     }
+
+    startTimeout(() => {
+      this.launcher.stop({ message: 'context deadline exceeded' })
+      this.props.setLauncherContext({ state: 'default' })
+    })
+
     await this.launcher.start({ initConnectorError })
+
+    stopTimeout()
+
     this.props.setLauncherContext({ state: 'default' })
   }
 

--- a/src/screens/connectors/constants/connectors-constants.ts
+++ b/src/screens/connectors/constants/connectors-constants.ts
@@ -1,0 +1,5 @@
+import { minutesToMilliseconds } from '/libs/functions/convertMinutesToMs'
+
+export const constants = {
+  timeoutDuration: minutesToMilliseconds(15)
+}

--- a/src/screens/connectors/core/handleTimeout.spec.ts
+++ b/src/screens/connectors/core/handleTimeout.spec.ts
@@ -1,0 +1,26 @@
+import { constants } from '../constants/connectors-constants'
+import { startTimeout, stopTimeout } from './handleTimeout'
+
+test('startTimeout fires callback and deletes itself on completion', () => {
+  jest.useFakeTimers()
+  const onTimeout = jest.fn()
+
+  startTimeout(onTimeout)
+
+  jest.advanceTimersByTime(constants.timeoutDuration)
+
+  expect(onTimeout).toHaveBeenCalled()
+  expect(jest.getTimerCount()).toBe(0)
+})
+
+test('startTimeout deletes itself on demand without firing callback', () => {
+  jest.useFakeTimers()
+  const onTimeout = jest.fn()
+
+  startTimeout(onTimeout)
+
+  stopTimeout()
+
+  expect(onTimeout).not.toHaveBeenCalled()
+  expect(jest.getTimerCount()).toBe(0)
+})

--- a/src/screens/connectors/core/handleTimeout.ts
+++ b/src/screens/connectors/core/handleTimeout.ts
@@ -1,0 +1,18 @@
+import { constants } from '../constants/connectors-constants'
+
+let timerId: NodeJS.Timeout
+
+const _clearTimeout = (): void => {
+  clearTimeout(timerId)
+}
+
+export const stopTimeout = (): void => {
+  _clearTimeout()
+}
+
+export const startTimeout = (onTimeout: () => void): void => {
+  timerId = setTimeout(() => {
+    onTimeout()
+    _clearTimeout()
+  }, constants.timeoutDuration)
+}


### PR DESCRIPTION
## What does this do?

- When LauncherView is instantiated, it starts a 15 minutes timer. It will kill itself after this time has passed if it didn't stop the timer beforehand.

## Why did you do this?

- We're doing this to cleanup broken states in connectors

## Who/what does this impact?

- People working on connectors might experience less bugs

## How did you test this?

- Unit test for the timeout function
- Manually for the actual integration test