### PR TITLE
Feat  forbid parallel connectors   rework

### DIFF
--- a/src/core/tools/interpolate.ts
+++ b/src/core/tools/interpolate.ts
@@ -1,0 +1,18 @@
+/*
+ * Looks for {{variable}} in a string and replaces it with the value of the variable.
+ * If the variable is not found in the arguments, it will be replaced with the variable name.
+ */
+const regex = new RegExp('{{([^{]+)}}', 'g')
+
+export const t = (
+  template: string,
+  variables: Record<string, string | undefined>
+): string =>
+  template.replace(regex, (_match, varName) => {
+    if (typeof varName !== 'string') return ''
+
+    const variable = variables[varName]
+
+    if (typeof variable === 'undefined') return varName
+    else return variable
+  })

--- a/src/libs/connectors/models.ts
+++ b/src/libs/connectors/models.ts
@@ -1,5 +1,268 @@
+export interface LauncherContextValue {
+  connector: Connector
+  account: Account
+  trigger: Trigger
+  job: Job
+}
+
+interface Account {
+  id: string
+  _id: string
+  _type: string
+  _rev: string
+  account_type: string
+  auth: Auth
+  cozyMetadata: CozyMetadata
+  state: null
+}
+
+type Auth = Record<string, unknown>
+
+interface CozyMetadata {
+  createdAt: Date
+  createdByApp: string
+  doctypeVersion: string
+  metadataVersion: number
+  updatedAt: Date
+  updatedByApps?: UpdatedByApp[]
+}
+
+interface UpdatedByApp {
+  date: Date
+  slug?: string
+}
+
+interface Connector {
+  type: string
+  id?: string
+  attributes?: Connector
+  meta?: Meta
+  links?: ConnectorLinks
+  categories: string[]
+  checksum: string
+  clientSide: boolean
+  created_at: Date
+  editor: string
+  fields: Auth
+  folders: Folder[]
+  icon: string
+  langs: string[]
+  language: string
+  locales: Locales
+  name: string
+  permissions: ConnectorPermissions
+  slug: string
+  source: string
+  state: string
+  updated_at: Date
+  vendor_link: string
+  version: string
+  _type?: string
+  triggers?: Triggers
+}
+
+interface Folder {
+  defaultDir: string
+}
+
+interface ConnectorLinks {
+  self: string
+  icon: string
+  permissions: string
+}
+
+interface Locales {
+  fr: Fr
+}
+
+interface Fr {
+  long_description: string
+  permissions: FrPermissions
+  short_description: string
+}
+
+interface FrPermissions {
+  bills: PurpleBills
+  files: PurpleBills
+}
+
+interface PurpleBills {
+  description: string
+}
+
+interface Meta {
+  rev: string
+}
+
+interface ConnectorPermissions {
+  bills: FluffyBills
+  files: FluffyBills
+}
+
+interface FluffyBills {
+  type: string
+}
+
+interface Triggers {
+  data: Datum[]
+}
+
+interface Datum {
+  type: TypeEnum
+  id: string
+  attributes: DatumAttributes
+  meta: Auth
+  links: DatumLinks
+  _id: string
+  _rev: string
+  domain: string
+  prefix: string
+  worker: Worker
+  arguments: string
+  debounce: string
+  options: null
+  message: DatumMessage
+  current_state: CurrentState
+  cozyMetadata: CozyMetadata
+  _type: Type
+}
+
+enum Type {
+  IoCozyTriggers = 'io.cozy.triggers'
+}
+
+interface DatumAttributes {
+  _id: string
+  _rev: string
+  domain: string
+  prefix: string
+  type: TypeEnum
+  worker: Worker
+  arguments: string
+  debounce: string
+  options: null
+  message: DatumMessage
+  current_state: CurrentState
+  cozyMetadata: CozyMetadata
+}
+
+interface CurrentState {
+  trigger_id: string
+  status: Stat
+  last_execution: Date
+  last_executed_job_id: string
+  last_failure?: Date
+  last_failed_job_id?: string
+  last_error?: string
+  last_manual_execution: Date
+  last_manual_job_id: string
+  last_success?: Date
+  last_successful_job_id?: string
+}
+
+enum Stat {
+  Done = 'done',
+  Errored = 'errored',
+  Running = 'running'
+}
+
+interface DatumMessage {
+  account: string
+  konnector: string
+  folder_to_save?: string
+}
+
+enum TypeEnum {
+  Client = '@client'
+}
+
+enum Worker {
+  Client = 'client'
+}
+
+interface DatumLinks {
+  self: string
+}
+
+interface Job {
+  type: string
+  id: string
+  attributes: JobAttributes
+  meta: Meta
+  links: DatumLinks
+  _id: string
+  _type: string
+  _rev: string
+  domain: string
+  prefix: string
+  worker: Worker
+  trigger_id: string
+  message: JobMessage
+  event: null
+  manual_execution: boolean
+  state: Stat
+  queued_at: Date
+  started_at: Date
+  finished_at: Date
+}
+
+interface JobAttributes {
+  _id: string
+  _rev: string
+  domain: string
+  prefix: string
+  worker: Worker
+  trigger_id: string
+  message: JobMessage
+  event: null
+  manual_execution: boolean
+  state: Stat
+  queued_at: Date
+  started_at: Date
+  finished_at: Date
+}
+
+interface JobMessage {
+  account: string
+  konnector: string
+}
+
+interface Trigger {
+  type: TypeEnum
+  id: string
+  attributes: TriggerAttributes
+  meta: Auth
+  links: DatumLinks
+  _id: string
+  _rev: string
+  domain: string
+  prefix: string
+  worker: Worker
+  arguments: string
+  debounce: string
+  options: null
+  message: JobMessage
+  current_state: CurrentState
+  cozyMetadata: CozyMetadata
+  _type: Type
+}
+
+interface TriggerAttributes {
+  _id: string
+  _rev: string
+  domain: string
+  prefix: string
+  type: TypeEnum
+  worker: Worker
+  arguments: string
+  debounce: string
+  options: null
+  message: JobMessage
+  current_state: CurrentState
+  cozyMetadata: CozyMetadata
+}
+
 export interface LauncherContext {
-  job?: { message?: { konnector?: string } }
-  state?: 'default' | 'launch'
-  value?: Record<string, unknown>
+  state: 'default' | 'launch'
+  value?: LauncherContextValue
 }

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -1,4 +1,11 @@
 {
+  "connectors": {
+    "errorDoubleRun": {
+      "title": "Déjà un compte en cours d'exécution",
+      "body": "Un compte {{running_connector}} est déjà en cours d'éxecution. Vous ne pouvez pas lancer deux comptes simultanément. Veuillez donc attendre la fin de l'exécution du compte {{running_connector}} avant de lancer votre compte {{concurrent_connector}}",
+      "button": "J'ai compris"
+    }
+  },
   "errors": {
     "badUnlockPassword": "Les identifiants que vous avez saisis sont incorrects, veuillez ré-essayer.",
     "badUnlockPin": "Le code PIN que vous avez saisi est incorrect, veuillez ré-essayer",

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -6,36 +6,31 @@ import {
   RouteProp
 } from '@react-navigation/native'
 
-import CozyClient from 'cozy-client'
-
 import HomeView from '/screens/home/components/HomeView'
 import LauncherView from '/screens/connectors/LauncherView'
 import { StatusBarStyle } from '/libs/intents/setFlagshipUI'
 import { styles } from '/screens/home/HomeScreen.styles'
-import { useLauncherClient } from '/hooks/useLauncherClient'
-import { LauncherContext } from '/libs/connectors/models'
+import { useLauncherContext } from '/screens/home/hooks/useLauncherContext'
 
 interface HomeScreenProps {
   navigation: NavigationProp<ParamListBase>
   route: RouteProp<ParamListBase>
 }
 
-const isLauncherReady = (
-  context: LauncherContext
-): context is LauncherContext => context.state !== 'default'
-
-const isClientReady = (client: CozyClient | undefined): client is CozyClient =>
-  Boolean(client)
-
 export const HomeScreen = ({
   navigation,
   route
 }: HomeScreenProps): JSX.Element => {
   const [barStyle, setBarStyle] = useState(StatusBarStyle.Light)
-  const [launcherContext, setLauncherContext] = useState<LauncherContext>({
-    state: 'default'
-  })
-  const { launcherClient } = useLauncherClient(launcherContext.value)
+  const {
+    LauncherDialog,
+    canDisplayLauncher,
+    launcherClient,
+    launcherContext,
+    resetLauncherContext,
+    setLauncherContext,
+    trySetLauncherContext
+  } = useLauncherContext()
 
   return (
     <View style={styles.container}>
@@ -45,17 +40,19 @@ export const HomeScreen = ({
         navigation={navigation}
         route={route}
         setBarStyle={setBarStyle}
-        setLauncherContext={setLauncherContext}
+        setLauncherContext={trySetLauncherContext}
       />
 
-      {isLauncherReady(launcherContext) && isClientReady(launcherClient) && (
+      {canDisplayLauncher() && (
         <LauncherView
           launcherClient={launcherClient}
           launcherContext={launcherContext.value}
-          retry={(): void => setLauncherContext({ state: 'default' })}
+          retry={resetLauncherContext}
           setLauncherContext={setLauncherContext}
         />
       )}
+
+      {LauncherDialog}
     </View>
   )
 }

--- a/src/screens/home/components/ErrorParallelConnectors.tsx
+++ b/src/screens/home/components/ErrorParallelConnectors.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import { Button } from '/ui/Button'
+import { ConfirmDialog } from '/ui/CozyDialogs/ConfirmDialog'
+import { Typography } from '/ui/Typography'
+import { t } from '/core/tools/interpolate'
+import { translation } from '/locales'
+
+interface ErrorParallelConnectorsProps {
+  concurrentConnector: string
+  currentRunningConnector: string
+  onClose: () => void
+}
+
+export const ErrorParallelConnectors = ({
+  concurrentConnector,
+  currentRunningConnector,
+  onClose
+}: ErrorParallelConnectorsProps): JSX.Element | null => (
+  <ConfirmDialog
+    actions={
+      <Button onPress={onClose} variant="secondary">
+        <Typography color="textSecondary" variant="button">
+          {translation.connectors.errorDoubleRun.button}
+        </Typography>
+      </Button>
+    }
+    content={t(translation.connectors.errorDoubleRun.body, {
+      running_connector: currentRunningConnector,
+      concurrent_connector: concurrentConnector
+    })}
+    onClose={onClose}
+    title={translation.connectors.errorDoubleRun.title}
+  />
+)

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -22,6 +22,17 @@ const unzoomHomeView = webviewRef => {
 
 let hasRenderedOnce = false
 
+/**
+ * @typedef Props
+ * @prop {(arg: import('/libs/connectors/models').LauncherContext) => void} setLauncherContext
+ * @prop {unknown} navigation
+ * @prop {unknown} route
+ * @prop {(arg: import('/libs/intents/setFlagshipUI').BarStyle) => void} setBarStyle
+ */
+
+/**
+ * @param {Props} props
+ */
 const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
   const client = useClient()
   const [uri, setUri] = useState('')

--- a/src/screens/home/hooks/useLauncherClient.ts
+++ b/src/screens/home/hooks/useLauncherClient.ts
@@ -2,24 +2,25 @@ import { useState, useEffect } from 'react'
 
 import CozyClient, { useClient } from 'cozy-client'
 
-import { LauncherContext } from '/libs/connectors/models'
+import { LauncherContextValue } from '/libs/connectors/models'
 import { getLauncherClient } from '/libs/connectors/getLauncherClient'
 
 interface useLauncherClientReturn {
   launcherClient?: CozyClient
 }
+
 export const useLauncherClient = (
-  launcherContext?: LauncherContext
+  launcherContextValue?: LauncherContextValue
 ): useLauncherClientReturn => {
   const [launcherClient, setLauncherClient] = useState<CozyClient>()
   const client = useClient()
 
   useEffect(() => {
-    const slug = launcherContext?.job?.message?.konnector
+    const slug = launcherContextValue?.job.message.konnector
 
     if (slug) void getLauncherClient(client, slug, setLauncherClient)
     else setLauncherClient(undefined)
-  }, [client, launcherContext?.job?.message?.konnector])
+  }, [client, launcherContextValue?.job.message.konnector])
 
   return { launcherClient }
 }

--- a/src/screens/home/hooks/useLauncherContext.tsx
+++ b/src/screens/home/hooks/useLauncherContext.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { useState } from 'react'
+
+import CozyClient from 'cozy-client'
+
+import { LauncherContext } from '/libs/connectors/models'
+import { useLauncherWrapper } from '/screens/home/hooks/useLauncherWrapper'
+import { ErrorParallelConnectors } from '/screens/home/components/ErrorParallelConnectors'
+
+interface useLauncherContextReturn {
+  LauncherDialog: JSX.Element | null
+  canDisplayLauncher: () => boolean
+  concurrentConnector?: string
+  launcherClient?: CozyClient
+  launcherContext: LauncherContext
+  resetLauncherContext: () => void
+  setConcurrentConnector: (connectorSlug?: string) => void
+  setLauncherContext: (candidateContext: LauncherContext) => void
+  trySetLauncherContext: (candidateContext: LauncherContext) => void
+}
+
+export const useLauncherContext = (): useLauncherContextReturn => {
+  const [launcherContext, setLauncherContext] = useState<LauncherContext>({
+    state: 'default'
+  })
+  const { canDisplayLauncher, launcherClient } =
+    useLauncherWrapper(launcherContext)
+  const [concurrentConnector, setConcurrentConnector] = useState<string>()
+
+  const trySetLauncherContext = (candidateContext: LauncherContext): void => {
+    if (launcherContext.value && candidateContext.value)
+      return setConcurrentConnector(candidateContext.value.connector.slug)
+
+    setLauncherContext(candidateContext)
+  }
+
+  const resetLauncherContext = (): void => {
+    setLauncherContext({ state: 'default' })
+  }
+
+  return {
+    canDisplayLauncher,
+    concurrentConnector,
+    launcherClient,
+    launcherContext,
+    LauncherDialog:
+      launcherContext.value && concurrentConnector ? (
+        <ErrorParallelConnectors
+          currentRunningConnector={launcherContext.value.connector.slug}
+          concurrentConnector={concurrentConnector}
+          onClose={(): void => setConcurrentConnector(undefined)}
+        />
+      ) : null,
+    resetLauncherContext,
+    setConcurrentConnector,
+    setLauncherContext,
+    trySetLauncherContext
+  }
+}

--- a/src/screens/home/hooks/useLauncherWrapper.ts
+++ b/src/screens/home/hooks/useLauncherWrapper.ts
@@ -1,0 +1,37 @@
+import CozyClient from 'cozy-client'
+
+import { LauncherContext } from '/libs/connectors/models'
+import { useLauncherClient } from '/screens/home/hooks/useLauncherClient'
+
+const isLauncherReady = (
+  context: LauncherContext
+): context is LauncherContext => context.state !== 'default'
+
+const isClientReady = (client: CozyClient | undefined): client is CozyClient =>
+  Boolean(client)
+
+export const useLauncherWrapper = (
+  launcherContext: LauncherContext
+): {
+  canDisplayLauncher: () => boolean
+  launcherClient?: CozyClient
+} => {
+  const { launcherClient } = useLauncherClient(launcherContext.value)
+
+  const canDisplayLauncher = (): boolean => {
+    if (!isLauncherReady(launcherContext)) {
+      return false
+    }
+
+    if (!isClientReady(launcherClient)) {
+      return false
+    }
+
+    return true
+  }
+
+  return {
+    canDisplayLauncher,
+    launcherClient
+  }
+}

--- a/src/ui/CozyDialogs/ConfirmDialog.tsx
+++ b/src/ui/CozyDialogs/ConfirmDialog.tsx
@@ -8,12 +8,35 @@ import { Typography } from '/ui/Typography'
 import { styles } from '/ui/CozyDialogs/styles'
 
 interface ConfirmDialogProps {
-  actions: ReactElement<{
-    children: ReactElement<{ style: StyleProp<ViewStyle> }>[]
-  }>
+  actions:
+    | ReactElement<{
+        children: ReactElement<{ style: StyleProp<ViewStyle> }>[]
+      }>
+    | ReactElement<{ style: StyleProp<ViewStyle> }>
   content: string
   onClose: () => void
   title: string
+}
+
+const renderActions = (
+  actions: ConfirmDialogProps['actions']
+): ReactElement => {
+  if ('children' in actions.props && actions.props.children.length > 0) {
+    return (
+      <View style={styles.footer}>
+        {actions.props.children.map((child, index, array) =>
+          React.cloneElement(child, {
+            style: {
+              ...styles.actions,
+              ...(index + 1 === array.length ? styles.actionsLast : {})
+            }
+          })
+        )}
+      </View>
+    )
+  }
+
+  return actions
 }
 
 export const ConfirmDialog = ({
@@ -37,16 +60,7 @@ export const ConfirmDialog = ({
           <Typography>{content}</Typography>
         </View>
 
-        <View style={styles.footer}>
-          {actions.props.children.map((child, index, array) =>
-            React.cloneElement(child, {
-              style: {
-                ...styles.actions,
-                ...(index + 1 === array.length ? styles.actionsLast : {})
-              }
-            })
-          )}
-        </View>
+        <View style={styles.footer}>{renderActions(actions)}</View>
       </View>
     </Pressable>
   </Modal>


### PR DESCRIPTION
## What does this do?

- Forbid the launch of a new connector if one is already running
- Display a dialog with confirm so the user can understand what happened

## Why did you do this?

- This is needed because connectors can't run correctly in parallel at the moment so we have to avoid this situation in the first place

## Who/what does this impact?

- For the moment it should reduce the number of bugs for local development. Although if a connector never stops, you can never open another one so it can be a big problem. But it's easy to hack the feature to disable it.

## How did you test this?

- Test manually only. I wanted to add integration tests but it's too complex at the moment with the current architecture. I will work on having a LauncherView mock that can be useful and usable for more testing