### PR TITLE
ci: manage stale issues and pull requests

### DIFF
--- a/.github/workflows/actions_stale.yml
+++ b/.github/workflows/actions_stale.yml
@@ -1,0 +1,41 @@
+name: 'Close stale issues and PRs' 
+on:
+  schedule:
+    - cron: '30 1 * * *' # Run at 01:30 UTC (9:30 PM EST) every day
+
+jobs:
+  actions-stale:
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write # Required to close issues
+      pull-requests: write # Required to close PRs
+
+    steps:
+      - uses: actions/stale@v7
+        with:
+          ascending: false # Order to get issues/PRs: false = descending, true = ascending.
+          close-issue-message: 'This issue was closed because it has been inactive for 7 days since being marked as stale.' # Comment on the staled issues while closed.
+          close-issue-reason: 'not_planned' # Reason to use when closing issues.
+          close-pr-message: 'This PR was closed because it has been inactive for 7 days since being marked as stale.' # Comment on the staled PRs while closed.
+          days-before-close: 7 # Idle number of days before closing stale issues/PRs.
+          days-before-issue-stale: 30 # Override days-before-stale for issues only.
+          days-before-pr-stale: 15 # Override days-before-stale for PRs only.
+          days-before-stale: 60 # Idle number of days before marking issues/PRs stale
+          debug-only: false # Dry-run.
+          delete-branch: false # Delete branch after closing a stale PR.
+          enable-statistics: true # Display statistics in the logs.
+          exempt-all-assignees: false # Exempt all issues/PRs with assignees from stale.
+          exempt-all-milestones: false # Exempt all issues/PRs with milestones from stale.
+          exempt-draft-pr: false # Skip the stale action for draft PRs.
+          exempt-issue-labels: 'pinned' # Labels on issues exempted from stale.
+          exempt-pr-labels: 'pinned' # Labels on PRs exempted from stale.
+          ignore-updates: false # Any update (update/comment) can reset the stale idle time on the issues/PRs.
+          include-only-assigned: false # Process only assigned issues.
+          operations-per-run: 30 # Max number of operations per run.
+          remove-stale-when-updated: true # Remove stale label from issues/PRs on updates.
+          repo-token: ${{ github.token }} # PAT for GitHub API authentication.
+          stale-issue-label: 'Stale' # Label to apply to stale issues.
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity.' # Comment to post when marking an issue as stale.
+          stale-pr-label: 'Stale' # Label to apply to stale PRs.
+          stale-pr-message: 'This PR is stale because it has been open for 14 days with no activity.' # Comment to post when marking a PR as stale.


### PR DESCRIPTION
## What does this do?

- Uses the latest official GitHub Action `stale@v7`
- It will check once a day if there are any issues or PR to label as stale or to close if deeply stalled.
- Issues will go stale after 30 days of inactivity
- PRs will go stale after 15 days of inactivity
- Both will close after 7 days of inactivity AFTER being labelled/commented as `Stale`
- Branches are not deleted when a PR is closed
- Any activity on those stalled issues/PRs will reset the counter
- Branches/Issues using the label `pinned` will not be affected (more labels can be added)
- The whole config is included, so you can see some of the default values of the Github Action (like `delete_branch` to `false`)
- More info here: https://github.com/marketplace/actions/close-stale-issues

## Why did you do this?

- I noticed we have some issues/PRs that stay open forever and probably won't ever be closed or fulfilled. This adds noise to the project, and we can automate a part of that noise removal. Let's use a simple tool to automate the process, letting us remember an issue or decide it's not worth it anymore. Most likely, it will make us finish the stalled work, or consider it's not worth finishing. If it's still worth it but there is no time, we can always pin the pr/issue so it's never auto-closed.

## Who/what does this impact?

- Everyone working on the repo who has and will create an issue/pr that is not managed should be impacted as those issues/PRs will have to be handled or discarded.

## How did you test this?

- Tested a dry run (only stats, no action) on push: https://github.com/cozy/cozy-flagship-app/actions/runs/4270461872/jobs/7434272368
- Results: 
![image](https://user-images.githubusercontent.com/12577784/221362843-0d246789-5c05-4adc-980b-ac81169cb7a8.png)
