### PR TITLE
feat: setConnector to undefined on boot

### DIFF
--- a/src/libs/connectors/cleanConnectorsOnBoot.ts
+++ b/src/libs/connectors/cleanConnectorsOnBoot.ts
@@ -3,7 +3,10 @@ import CozyClient from 'cozy-client'
 
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
 import { sendConnectorsLogs } from '/libs/connectors/sendConnectorsLogs'
-import { CurrentConnectorState } from '/redux/ConnectorState/CurrentConnectorSlice'
+import {
+  CurrentConnectorState,
+  setCurrentRunningConnector
+} from '/redux/ConnectorState/CurrentConnectorSlice'
 import { store } from '/redux/store'
 
 const log = Minilog('cleanConnectorsOnBoot')
@@ -30,6 +33,8 @@ export const cleanConnectorsOnBoot = async (
     log.error(
       `A running connector is tagged as running. This means that the app may have previously crashed. Related connector: ${runningConnector}`
     )
+
+    store.dispatch(setCurrentRunningConnector())
   }
 
   await sendConnectorsLogs(client, 4)

--- a/src/redux/ConnectorState/CurrentConnectorSlice.ts
+++ b/src/redux/ConnectorState/CurrentConnectorSlice.ts
@@ -14,7 +14,10 @@ export const currentConnectorSlice = createSlice({
   name: 'currentConnector',
   initialState,
   reducers: {
-    setCurrentRunningConnector: (state, action: PayloadAction<string>) => {
+    setCurrentRunningConnector: (
+      state,
+      action: PayloadAction<string | undefined>
+    ) => {
       state.currentRunningConnector = action.payload
     }
   }


### PR DESCRIPTION
## What does this do?

- Delete the running connector when we boot the app after recovery

## Why did you do this?

- We need a clean state when app starts and recovered logs. No connector should be running at this point.

## Who/what does this impact?

- This impact all features that rely on the currentConnector state. Overall, it solidifies the feature.

## How did you test this?

- Manual test as it's fairly straightforward