### PR TITLE
fix: Set correct project info for Android deploy workflow and trigger it on dispatch

### DIFF
--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -82,4 +82,3 @@ jobs:
           releaseFiles: android/app/build/outputs/bundle/release/*.aab
           track: internal
           status: completed
-          inAppUpdatePriority: 2

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -78,8 +78,8 @@ jobs:
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON_TEXT }}
-          packageName: com.test.test
+          packageName: io.cozy.flagship.mobile
           releaseFiles: android/app/build/outputs/bundle/release/*.aab
-          track: alpha
+          track: internal
           status: completed
           inAppUpdatePriority: 2

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -1,4 +1,4 @@
-name: Android Build
+name: Android Deploy
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   android-build:
-    name: Android Build
+    name: Android Deploy
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -1,8 +1,7 @@
 name: Android Deploy
 
-on:
-  release:
-    types: [published]
+on: 
+  workflow_dispatch:
 
 jobs:
   android-build:


### PR DESCRIPTION
This PR fixes the Android deploy workflow by setting correct package name and targeted track

It also remove unused props and edit the workflow's name as it should be unique for better readability in the Github Actions page

Finally, until we validate the CI behaviour we want this workflow to be manually triggered instead of being paired with a Github release