### PR TITLE
feat: add more context to connectors errors

### DIFF
--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -195,7 +195,7 @@ class LauncherView extends Component {
    * @param {Object} event
    */
   onPilotError({ nativeEvent }) {
-    log.error('onWorkerError', { nativeEvent })
+    log.error('onPilotError', { nativeEvent })
     this.stop({ message: 'VENDOR_DOWN' })
   }
   /**

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -53,7 +53,8 @@ class LauncherView extends Component {
         })
       })
     } catch (err) {
-      return err
+      log.error({ err })
+      return 'UNKNOWN_ERROR'
     }
   }
 
@@ -184,16 +185,18 @@ class LauncherView extends Component {
    *
    * @param {Object} event
    */
-  onWorkerError(event) {
-    log.error('worker error event', event)
+  onWorkerError({ nativeEvent }) {
+    log.error('onWorkerError', { nativeEvent })
+    this.stop({ message: 'VENDOR_DOWN' })
   }
   /**
    * When an error is detected in the pilot webview
    *
    * @param {Object} event
    */
-  onPilotError(event) {
-    log.error('error event', event)
+  onPilotError({ nativeEvent }) {
+    log.error('onWorkerError', { nativeEvent })
+    this.stop({ message: 'VENDOR_DOWN' })
   }
   /**
    * Postmessage relay from the pilot to  the launcher


### PR DESCRIPTION
## What does this do?

- Add "UNKNOWN_ERROR" if LauncherView crashes on init
- Add "VENDOR_ERROR" if LauncherView crashes because of a WebView error (browser-like error, like error_disconnected, not http request errors)

## Why did you do this?

- The goal is to send more information to the stack when something goes wrong

## Who/what does this impact?

- It should impact people trying to debug connectors. It has no impact on the implementation of the connectors.
- Please note I could NOT add an online check before the user launches the connector, because it is handled Harvest side before being redirected to the Native side. So whatever I do, I will always be too late when doing an online check at connector start, unless I do it way too early on harvest open.

## How did you test this?

- Tested manually, but didn't test on the stack end to check the received result