### PR TITLE
feat: disconnect connectors on end and on reboot

### DIFF
--- a/src/libs/connectors/cleanConnectorsOnBoot.ts
+++ b/src/libs/connectors/cleanConnectorsOnBoot.ts
@@ -8,6 +8,8 @@ import {
   setCurrentRunningConnector
 } from '/redux/ConnectorState/CurrentConnectorSlice'
 import { store } from '/redux/store'
+import { cleanAllConnectorCookies } from '/libs/connectors/manageCookies'
+import { selectConnectorUrls } from '/redux/ConnectorState/ConnectorUrlsSlice'
 
 const log = Minilog('cleanConnectorsOnBoot')
 
@@ -21,12 +23,14 @@ const getRunningConnector = (state: {
 
 /**
  * Check for still-running connectors, clean them and
- * send remaining connectors' logs on cozy-stack
+ * send remaining connectors' logs on cozy-stack.
+ * Also remove all cookies related to connectors
  */
 export const cleanConnectorsOnBoot = async (
   client: CozyClient
 ): Promise<void> => {
   const state = store.getState()
+  const { urls } = selectConnectorUrls(state)
 
   const runningConnector = getRunningConnector(state)
   if (runningConnector !== undefined) {
@@ -38,6 +42,8 @@ export const cleanConnectorsOnBoot = async (
   }
 
   await sendConnectorsLogs(client)
+
+  if (urls.length > 0) await cleanAllConnectorCookies()
 }
 
 /**

--- a/src/libs/connectors/manageCookies.spec.ts
+++ b/src/libs/connectors/manageCookies.spec.ts
@@ -1,0 +1,112 @@
+import CookieManager, { Cookie } from '@react-native-cookies/cookies'
+import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
+
+import {
+  _stateManager,
+  cleanAllConnectorCookies,
+  cleanConnectorCookies,
+  handleWorkerStartRequest
+} from '/libs/connectors/manageCookies'
+
+const mockCookieState = {
+  ['https://microsoft.com']: {
+    cookie1: {
+      name: 'cookie1',
+      value: 'value1',
+      expires: 'Thu, 01 Jan 2000 00:00:00 GMT'
+    },
+    cookie2: {
+      name: 'cookie2',
+      value: 'value2',
+      expires: 'Thu, 01 Jan 2000 00:00:00 GMT'
+    }
+  },
+  ['https://google.com']: {
+    cookie3: {
+      name: 'cookie3',
+      value: 'value3',
+      expires: 'Thu, 01 Jan 2000 00:00:00 GMT'
+    },
+    cookie4: {
+      name: 'cookie4',
+      value: 'value4',
+      expires: 'Thu, 01 Jan 2000 00:00:00 GMT'
+    }
+  }
+} as Record<string, Record<string, Cookie>>
+
+jest.mock('@react-native-cookies/cookies', () => ({
+  get: jest.fn().mockImplementation((url: string) => mockCookieState[url]),
+  set: jest.fn().mockImplementation((url: string, cookie: Cookie) => {
+    const existing = mockCookieState[url]
+    if (existing) existing[cookie.name] = cookie
+    else mockCookieState[url] = { [cookie.name]: cookie }
+  })
+}))
+
+afterEach(() => {
+  _stateManager.cleanStore()
+})
+
+it('should push to store', () => {
+  const url = 'https://google.com'
+  const expected = [url]
+
+  handleWorkerStartRequest({ url } as ShouldStartLoadRequest)
+
+  expect(_stateManager.getFromStore()).toEqual(expected)
+})
+
+it('should clean cookies from specified url', async () => {
+  _stateManager.pushToStore('https://google.com')
+  _stateManager.pushToStore('https://microsoft.com')
+
+  await cleanConnectorCookies('https://microsoft.com')
+
+  expect(_stateManager.getFromStore()).toStrictEqual(['https://google.com'])
+  expect(CookieManager.get('https://microsoft.com')).toStrictEqual({
+    cookie1: {
+      expires: 'Thu, 01 Jan 1970 00:00:00 GMT',
+      name: 'cookie1',
+      value: 'value1'
+    },
+    cookie2: {
+      expires: 'Thu, 01 Jan 1970 00:00:00 GMT',
+      name: 'cookie2',
+      value: 'value2'
+    }
+  })
+})
+
+it('should clean cookies from all urls', async () => {
+  _stateManager.pushToStore('https://google.com')
+  _stateManager.pushToStore('https://microsoft.com')
+
+  await cleanAllConnectorCookies()
+
+  expect(_stateManager.getFromStore()).toStrictEqual([])
+  expect(CookieManager.get('https://microsoft.com')).toStrictEqual({
+    cookie1: {
+      expires: 'Thu, 01 Jan 1970 00:00:00 GMT',
+      name: 'cookie1',
+      value: 'value1'
+    },
+    cookie2: {
+      expires: 'Thu, 01 Jan 1970 00:00:00 GMT',
+      name: 'cookie2',
+      value: 'value2'
+    }
+  })
+  expect(CookieManager.get('https://google.com')).toStrictEqual({
+    cookie3: {
+      expires: 'Thu, 01 Jan 1970 00:00:00 GMT',
+      name: 'cookie3',
+      value: 'value3'
+    },
+    cookie4: {
+      expires: 'Thu, 01 Jan 1970 00:00:00 GMT',
+      name: 'cookie4',
+      value: 'value4'
+    }
+  })
+})

--- a/src/libs/connectors/manageCookies.ts
+++ b/src/libs/connectors/manageCookies.ts
@@ -1,0 +1,73 @@
+import CookieManager from '@react-native-cookies/cookies'
+import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
+import { store } from '/redux/store'
+
+import {
+  clearList,
+  removeUrlFromStore,
+  selectConnectorUrls,
+  updateList
+} from '/redux/ConnectorState/ConnectorUrlsSlice'
+import { logger } from '/libs/functions/logger'
+
+export const _stateManager = {
+  pushToStore: (url: string): void => {
+    store.dispatch(updateList(url))
+  },
+  getFromStore: (): string[] => {
+    const { urls } = selectConnectorUrls(store.getState())
+
+    return urls
+  },
+  cleanStore: (): void => {
+    store.dispatch(clearList())
+  },
+  removeUrlFromStore: (url: string): void => {
+    store.dispatch(removeUrlFromStore(url))
+  }
+}
+
+export const handleWorkerStartRequest = (
+  event: ShouldStartLoadRequest
+): boolean => {
+  const { url } = event
+
+  _stateManager.pushToStore(url)
+
+  return true
+}
+
+export const cleanConnectorCookies = async (
+  connectorUrl: string
+): Promise<void> => {
+  const cookies = await CookieManager.get(connectorUrl)
+
+  for (const cookie of Object.values(cookies)) {
+    // Can't remove them directly, so we set them to expire in the past
+    await CookieManager.set(connectorUrl, {
+      ...cookie,
+      expires: 'Thu, 01 Jan 1970 00:00:00 GMT'
+    })
+  }
+
+  _stateManager.removeUrlFromStore(connectorUrl)
+}
+
+export const cleanAllConnectorCookies = async (): Promise<void> => {
+  const urls = _stateManager.getFromStore()
+
+  /**
+   * We don't want to stop the process if one of the cookies fails to be removed.
+   * As the CookieManager deals with native code, it's possible that the process
+   * fails for some reason.
+   */
+  try {
+    for (const url of urls) {
+      await cleanConnectorCookies(url)
+    }
+  } catch (error) {
+    logger('manageCookies').error(error)
+  }
+
+  _stateManager.cleanStore()
+}

--- a/src/redux/ConnectorState/ConnectorUrlsSlice.ts
+++ b/src/redux/ConnectorState/ConnectorUrlsSlice.ts
@@ -1,0 +1,35 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+import { RootState } from '/redux/store'
+
+export interface ConnectorUrlsState {
+  urls: string[]
+}
+
+const initialState: ConnectorUrlsState = {
+  urls: []
+}
+
+export const connectorUrlsSlice = createSlice({
+  name: 'connectorUrls',
+  initialState,
+  reducers: {
+    updateList: (state, action: PayloadAction<string>) => {
+      state.urls = Array.from(new Set([...state.urls, action.payload]))
+    },
+    clearList: state => {
+      state.urls = []
+    },
+    removeUrlFromStore: (state, action: PayloadAction<string>) => {
+      state.urls = state.urls.filter(url => url !== action.payload)
+    }
+  }
+})
+
+export const { updateList, clearList, removeUrlFromStore } =
+  connectorUrlsSlice.actions
+
+export const selectConnectorUrls = (state: RootState): ConnectorUrlsState =>
+  state.connectorUrls
+
+export default connectorUrlsSlice.reducer

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -13,6 +13,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import logger from 'redux-logger'
 
 import connectorLogsSlice from '/redux/ConnectorState/ConnectorLogsSlice'
+import connectorUrlsSlice from '/redux/ConnectorState/ConnectorUrlsSlice'
 import currentConnectorSlice from '/redux/ConnectorState/CurrentConnectorSlice'
 import { shouldEnableReduxLogger } from '/core/tools/env'
 
@@ -23,7 +24,8 @@ const persistConfig = {
 
 const rootReducter = combineReducers({
   currentConnector: currentConnectorSlice,
-  connectorLogs: connectorLogsSlice
+  connectorLogs: connectorLogsSlice,
+  connectorUrls: connectorUrlsSlice
 })
 
 const persistedReducer = persistReducer(persistConfig, rootReducter)

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -6,11 +6,15 @@ import React, { Component } from 'react'
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native'
 import { WebView } from 'react-native-webview'
 
-import { BackTo } from '/components/ui/icons/BackTo'
-import { getDimensions } from '/libs/dimensions'
 import ReactNativeLauncher from '/libs/ReactNativeLauncher'
-import { getColors } from '/ui/colors'
 import strings from '/constants/strings.json'
+import { BackTo } from '/components/ui/icons/BackTo'
+import { getColors } from '/ui/colors'
+import { getDimensions } from '/libs/dimensions'
+import {
+  cleanAllConnectorCookies,
+  handleWorkerStartRequest
+} from '/libs/connectors/manageCookies'
 
 const log = Minilog('LauncherView')
 
@@ -106,6 +110,7 @@ class LauncherView extends Component {
     if (this.launcher.removeAllListener) {
       this.launcher.removeAllListener()
     }
+    cleanAllConnectorCookies()
     this.launcher.close()
   }
 
@@ -169,6 +174,7 @@ class LauncherView extends Component {
                   this,
                   'state.connector.content'
                 )}
+                onShouldStartLoadWithRequest={handleWorkerStartRequest}
               />
             </View>
           </>


### PR DESCRIPTION
## What does this do?

- Add to url list on launch
- Delete linked cookies after completion
- Delete all cookies stored after crash reboot

## Why did you do this?

- This allows better handling of end of life in the connector lifecycle

## Who/what does this impact?

- At this time only developers working on connectors

## How did you test this?

- Unit tests