### PR TITLE
Fix/open app open iab

### DIFF
--- a/src/libs/functions/urlHelpers.js
+++ b/src/libs/functions/urlHelpers.js
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native'
 import { InAppBrowser } from 'react-native-inappbrowser-reborn'
 
-import { deconstructCozyWebLinkWithSlug } from 'cozy-client'
+import { deconstructCozyWebLinkWithSlug } from 'cozy-client/dist/helpers'
 
 import Minilog from '@cozy/minilog'
 

--- a/src/libs/functions/urlHelpers.js
+++ b/src/libs/functions/urlHelpers.js
@@ -40,7 +40,41 @@ export const checkIsRedirectOutside = ({ currentUrl, destinationUrl }) => {
 
   return false
 }
+/**
+ *
+ * @param {object} params
+ * @param {string} params.cozyUrl The URL of the cozy, from client.stackclient.uri
+ * @param {string} params.destinationUrl The URL we want to redirect the user
+ * @param {'flat' | 'nested'} params.subdomainType - the Cozy's subdomain type
+ * @returns {boolean} True is the destination is the same cozy
+ */
+export const isSameCozy = ({
+  cozyUrl,
+  destinationUrl,
+  subdomainType = 'flat'
+}) => {
+  try {
+    const currentUrlData = deconstructCozyWebLinkWithSlug(
+      cozyUrl,
+      subdomainType
+    )
+    const destinationUrlData = deconstructCozyWebLinkWithSlug(
+      destinationUrl,
+      subdomainType
+    )
+    if (
+      currentUrlData.cozyBaseDomain !== destinationUrlData.cozyBaseDomain ||
+      currentUrlData.cozyName !== destinationUrlData.cozyName
+    ) {
+      return false
+    }
 
+    return true
+  } catch (err) {
+    log.error('Error while calling isSameCozy', err)
+    return false
+  }
+}
 /**
  * Compare current URL and target URL and detect if the app should navigate to another cozy-app
  * or if it is another type of navigation (same cozy-app or outgoing link)

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -121,7 +121,7 @@ export const localMethods = (
     hideSplashScreen: nativeMethodWrapper(hideSplashScreen),
     logout: () => asyncLogout(client),
     openApp: (href, app, iconParams) =>
-      openApp(RootNavigation, href, app, iconParams),
+      openApp(client, RootNavigation, href, app, iconParams),
     toggleSetting,
     setFlagshipUI,
     showInAppBrowser,


### PR DESCRIPTION
We don't want the third party dev to know about the flagship
behavior.

The dev should call openApp() when they want to open a app
even if the app will be opened on an other cozy (for instance
when sharing "cozy to cozy" a note)

So let's check if the URL of the client is the same as the
destination. If not, let's open the IAB.