### PR TITLE
feat: Use cache for fetch apps query

### DIFF
--- a/src/libs/functions/iconTable.spec.ts
+++ b/src/libs/functions/iconTable.spec.ts
@@ -12,16 +12,9 @@ import {
 
 const client = {
   getStackClient: (): { fetchJSON: jest.Mock } => ({
-    fetchJSON: jest
-      .fn()
-      .mockImplementation((_method: string, path: string) =>
-        path.includes('apps')
-          ? getApps
-          : path.includes('icon')
-          ? '<svg></svg>'
-          : null
-      )
-  })
+    fetchJSON: jest.fn().mockImplementation(() => '<svg></svg>')
+  }),
+  fetchQueryAndGetFromState: jest.fn().mockImplementation(() => getApps)
 }
 
 afterEach(async () => {
@@ -137,16 +130,11 @@ it('works with unusual semver', async () => {
 
   const client = {
     getStackClient: (): { fetchJSON: jest.Mock } => ({
-      fetchJSON: jest.fn().mockImplementation((_method: string, path: string) =>
-        path.includes('apps')
-          ? {
-              data: [{ attributes: { slug: 'store', version: '1.0.0-beta.1' } }]
-            }
-          : path.includes('icon')
-          ? '<svg></svg>'
-          : null
-      )
-    })
+      fetchJSON: jest.fn().mockImplementation(() => '<svg></svg>')
+    }),
+    fetchQueryAndGetFromState: jest.fn().mockImplementation(() => ({
+      data: [{ attributes: { slug: 'store', version: '1.0.0-beta.1' } }]
+    }))
   }
 
   await manageIconCache(client)
@@ -193,10 +181,8 @@ it('works with an incomplete and obsolete cache', async () => {
 
 it('works offline or with network issues without cache', async () => {
   const client = {
-    getStackClient: (): { fetchJSON: jest.Mock } => ({
-      fetchJSON: jest.fn().mockImplementation(() => {
-        // Empty response
-      })
+    fetchQueryAndGetFromState: jest.fn().mockImplementation(() => {
+      // Empty response
     })
   }
 
@@ -209,10 +195,8 @@ it('works offline or with network issues without cache', async () => {
 
 it('works offline or with network issues with cache', async () => {
   const client = {
-    getStackClient: (): { fetchJSON: jest.Mock } => ({
-      fetchJSON: jest.fn().mockImplementation(() => {
-        // Empty response
-      })
+    fetchQueryAndGetFromState: jest.fn().mockImplementation(() => {
+      // Empty response
     })
   }
 

--- a/src/libs/functions/iconTable.spec.ts
+++ b/src/libs/functions/iconTable.spec.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import CozyClient from 'cozy-client'
 
 import strings from '/constants/strings.json'
 import { expectedTable } from '/tests/fixtures/expected-table'
@@ -15,7 +16,7 @@ const client = {
     fetchJSON: jest.fn().mockImplementation(() => '<svg></svg>')
   }),
   fetchQueryAndGetFromState: jest.fn().mockImplementation(() => getApps)
-}
+} as unknown as CozyClient
 
 afterEach(async () => {
   jest.clearAllMocks()
@@ -135,7 +136,7 @@ it('works with unusual semver', async () => {
     fetchQueryAndGetFromState: jest.fn().mockImplementation(() => ({
       data: [{ attributes: { slug: 'store', version: '1.0.0-beta.1' } }]
     }))
-  }
+  } as unknown as CozyClient
 
   await manageIconCache(client)
 
@@ -184,7 +185,7 @@ it('works offline or with network issues without cache', async () => {
     fetchQueryAndGetFromState: jest.fn().mockImplementation(() => {
       // Empty response
     })
-  }
+  } as unknown as CozyClient
 
   await manageIconCache(client)
 
@@ -198,7 +199,7 @@ it('works offline or with network issues with cache', async () => {
     fetchQueryAndGetFromState: jest.fn().mockImplementation(() => {
       // Empty response
     })
-  }
+  } as unknown as CozyClient
 
   await AsyncStorage.setItem(
     strings.APPS_ICONS,

--- a/src/libs/functions/iconTable.ts
+++ b/src/libs/functions/iconTable.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise */
-import { Q } from 'cozy-client'
+import CozyClient, { Q } from 'cozy-client'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
 import Minilog from '@cozy/minilog'
@@ -55,22 +55,16 @@ interface FetchedApps {
   data: App[]
 }
 
-declare interface CozyClient {
-  getStackClient: () => {
-    fetchJSON: <T>(method: string, path: string) => Promise<T>
-  }
-}
-
 const attemptFetchApps = async (
   client: CozyClient
 ): Promise<FetchedApps | undefined> => {
   try {
-    return await client.fetchQueryAndGetFromState({
+    return (await client.fetchQueryAndGetFromState({
       definition: Q('io.cozy.apps'),
       options: {
         as: 'io.cozy.apps'
       }
-    })
+    })) as FetchedApps
   } catch (error) {
     log.error(strings.errors.attemptFetchApps, error)
     if (getErrorMessage(error).includes('Invalid token')) await clearClient()

--- a/src/libs/functions/iconTable.ts
+++ b/src/libs/functions/iconTable.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-bitwise */
+import { Q } from 'cozy-client'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
 import Minilog from '@cozy/minilog'
@@ -64,7 +65,12 @@ const attemptFetchApps = async (
   client: CozyClient
 ): Promise<FetchedApps | undefined> => {
   try {
-    return await client.getStackClient().fetchJSON('GET', '/apps/')
+    return await client.fetchQueryAndGetFromState({
+      definition: Q('io.cozy.apps'),
+      options: {
+        as: 'io.cozy.apps'
+      }
+    })
   } catch (error) {
     log.error(strings.errors.attemptFetchApps, error)
     if (getErrorMessage(error).includes('Invalid token')) await clearClient()


### PR DESCRIPTION
`attemptFetchApps` used directly `fetchJSON` bypassing cozy-client cache. Now we use `fetchQueryAndGetFromState` which uses cozy-client cache.