### PR TITLE
perf: test connector perf

### DIFF
--- a/docs/connectors-perf-method.md
+++ b/docs/connectors-perf-method.md
@@ -1,0 +1,117 @@
+# API used
+
+- Plain console object
+- time(), timeLog(), timeEnd()
+- Will try to automate tests; if not, will use manual tests
+- Template Konnector
+
+# Steps measured
+
+1. Receive `"startLauncher"` message in `<HomeView />` - `onMessage()` handler
+    - Logic will be executed to decide if we should show the launcher
+    - Logic will be executed to create dependencies on the spot for the launcher
+
+2. Instanciation of `<LauncherView />` (first constructor line)
+
+3. `<LauncherView />` - `componentDidMount` handler started
+    - This will trigger multiple things that we could track
+    1. `setStartContext()` ending
+    2. `initConnector()` ending
+    3. `init()` ending
+    4. `start()` ending
+      - Now we are in the connector's `start()` method, which itself contains multiple steps.
+      For now though, we treat it as a single step because we don't want to go into ReactNativeLauncher implementation details.
+  
+4. `<LauncherView />` - `render()` method started
+  
+5. `<LauncherView />` - `willUnmount()` method finished
+    - At this point we estimate the job is finished fully
+
+## Steps filtered
+
+After initial review, we decided to filter out some steps that are not relevant to the performance of the connector and only add noise (very little impact on performance). We're only keeping three main steps:
+- `initConnector()` ending
+- `init()` ending
+- `start()` ending
+
+# Results
+
+## When creating an account without cached bundle
+
+- LauncherFlow: 1.19s initConnector() ended
+
+- LauncherFlow: 1.83s init() ended
+
+- LauncherFlow: 65.519s start() ended
+
+## When creating an account with cached bundle
+
+- LauncherFlow: 0.43s initConnector() ended
+
+- LauncherFlow: 1.14s init() ended
+
+- LauncherFlow: 62.35s start() ended
+
+## When refreshing data
+
+- LauncherFlow: 0.25s initConnector() ended
+
+- LauncherFlow: 1.02s init() ended
+
+- LauncherFlow: 40s start() ended
+
+## ReactNativeLauncher.start() method
+
+### When creating an account without cached bundle
+
+- 0.03s `setContentScriptType()` - `"pilot"` ended
+
+- 0.09s `setContentScriptType()` - `"worker"` ended
+
+- 20.37s `ensureAuthenticated()` ended
+
+- 20.65s `sendLoginSuccess()` ended
+
+- 21.59s `getUserDataFromWebsite()` ended
+
+- 22.04s `ensureAccountNameAndFolder()` ended
+
+- 70.35s `fetch()` - `pilotContext` ended
+
+- 70.59s `stop()` ended
+
+### When creating an account with cached bundle
+
+- 0.03s `setContentScriptType()` - `"pilot"` ended
+
+- 0.08s `setContentScriptType()` - `"worker"` ended
+
+- 24.01s `ensureAuthenticated()` ended
+
+- 24.44s `sendLoginSuccess()` ended
+
+- 25.54s `getUserDataFromWebsite()` ended
+
+- 26.01s `ensureAccountNameAndFolder()` ended
+
+- 76.79s `fetch()` - `pilotContext` ended
+
+- 76.89s `stop()` ended
+
+### When refreshing data
+
+- 0.07s `setContentScriptType()` - `"pilot"` ended
+
+- 0.13s `setContentScriptType()` - `"worker"` ended
+
+- 12.12s `ensureAuthenticated()` ended
+
+- 12.39s `sendLoginSuccess()` ended
+
+- 12.55s `getUserDataFromWebsite()` ended
+
+- 12.55s `ensureAccountNameAndFolder()` ended
+
+- 41.80s `fetch()` - `pilotContext` ended
+
+- 42.07s `stop()` ended

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -117,18 +117,29 @@ class ReactNativeLauncher extends Launcher {
   }
 
   async start({ initConnectorError } = {}) {
+    console.time('ReactNativeLauncher.start')
     try {
       if (initConnectorError) {
         log.info('Got initConnectorError ' + initConnectorError.message)
         throw initConnectorError
       }
       await this.pilot.call('setContentScriptType', 'pilot')
+      console.timeLog('ReactNativeLauncher.start', 'setContentScriptType')
       await this.worker.call('setContentScriptType', 'worker')
+      console.timeLog(
+        'ReactNativeLauncher.start',
+        'setContentScriptType',
+        'worker'
+      )
       await this.pilot.call('ensureAuthenticated')
+      console.timeLog('ReactNativeLauncher.start', 'ensureAuthenticated')
       await this.sendLoginSuccess()
+      console.timeLog('ReactNativeLauncher.start', 'sendLoginSuccess')
 
       this.setUserData(await this.pilot.call('getUserDataFromWebsite'))
+      console.timeLog('ReactNativeLauncher.start', 'getUserDataFromWebsite')
       await this.ensureAccountNameAndFolder()
+      console.timeLog('ReactNativeLauncher.start', 'ensureAccountNameAndFolder')
 
       const pilotContext = []
       // FIXME not used at the moment since the fetched file will not have the proper "createdByApp"
@@ -137,12 +148,15 @@ class ReactNativeLauncher extends Launcher {
       //   slug: manifest.slug,
       // })
       await this.pilot.call('fetch', pilotContext)
+      console.timeLog('ReactNativeLauncher.start', 'fetch')
       await this.stop()
+      console.timeLog('ReactNativeLauncher.start', 'stop')
     } catch (err) {
       log.error(err, 'start error')
       await this.stop({ message: err.message })
     }
     this.emit('CONNECTOR_EXECUTION_END')
+    console.timeEnd('ReactNativeLauncher.start')
   }
 
   async close() {

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -21,6 +21,7 @@ const DEBUG = false
 
 class LauncherView extends Component {
   constructor(props) {
+    console.timeLog('LauncherFlow', 'LauncherView constructor')
     super(props)
     this.onPilotMessage = this.onPilotMessage.bind(this)
     this.onWorkerMessage = this.onWorkerMessage.bind(this)
@@ -71,13 +72,18 @@ class LauncherView extends Component {
   async componentDidMount() {
     this.launcher = new ReactNativeLauncher()
     this.launcher.setLogger(this.props.onKonnectorLog)
+    console.timeLog('LauncherFlow', 'setStartContext() started')
     this.launcher.setStartContext({
       ...this.props.launcherContext,
       client: this.props.client,
       launcherClient: this.props.launcherClient,
       manifest: get(this, 'state.connector.manifest')
     })
+    console.timeLog('LauncherFlow', 'setStartContext() ended')
+
+    console.timeLog('LauncherFlow', 'initConnector() started')
     const initConnectorError = await this.initConnector()
+    console.timeLog('LauncherFlow', 'initConnector() ended')
 
     this.launcher.on('SET_WORKER_STATE', options => {
       this.setState({ worker: { ...this.state.worker, ...options } })
@@ -91,6 +97,7 @@ class LauncherView extends Component {
     })
 
     if (this.state.connector) {
+      console.timeLog('LauncherFlow', 'init() started')
       await this.launcher.init({
         bridgeOptions: {
           pilotWebView: this.pilotWebView,
@@ -98,8 +105,12 @@ class LauncherView extends Component {
         },
         contentScript: get(this, 'state.connector.content')
       })
+      console.timeLog('LauncherFlow', 'init() ended')
     }
+
+    console.timeLog('LauncherFlow', 'start() started')
     await this.launcher.start({ initConnectorError })
+    console.timeLog('LauncherFlow', 'start() ended')
     this.props.setLauncherContext({ state: 'default' })
   }
 
@@ -108,6 +119,8 @@ class LauncherView extends Component {
       this.launcher.removeAllListener()
     }
     this.launcher.close()
+    console.timeEnd('LauncherFlow')
+    console.log('⌚ - LauncherFlow End')
   }
 
   render() {

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -198,8 +198,11 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
 
           if (methodName === 'openApp') nativeIntent?.call(uri, 'openApp')
 
-          if (message === 'startLauncher')
+          if (message === 'startLauncher') {
+            console.log('⌚ - LauncherFlow Start')
+            console.time('LauncherFlow')
             setLauncherContext({ state: 'launch', value })
+          }
         }
       }}
     />


### PR DESCRIPTION
# API used

- Plain console object
- time(), timeLog(), timeEnd()
- Will try to automate tests; if not, will use manual tests
- Template Konnector

# Steps measured

1. Receive `"startLauncher"` message in `<HomeView />` - `onMessage()` handler
    - Logic will be executed to decide if we should show the launcher
    - Logic will be executed to create dependencies on the spot for the launcher

2. Instanciation of `<LauncherView />` (first constructor line)

3. `<LauncherView />` - `componentDidMount` handler started
    - This will trigger multiple things that we could track
    1. `setStartContext()` ending
    2. `initConnector()` ending
    3. `init()` ending
    4. `start()` ending
      - Now we are in the connector's `start()` method, which itself contains multiple steps.
      For now though, we treat it as a single step because we don't want to go into ReactNativeLauncher implementation details.
  
4. `<LauncherView />` - `render()` method started
  
5. `<LauncherView />` - `willUnmount()` method finished
    - At this point we estimate the job is finished fully

## Steps filtered

After initial review, we decided to filter out some steps that are not relevant to the performance of the connector and only add noise (very little impact on performance). We're only keeping three main steps:
- `initConnector()` ending
- `init()` ending
- `start()` ending

# Results

## When creating an account without cached bundle

- LauncherFlow: 1.19s initConnector() ended

- LauncherFlow: 1.83s init() ended

- LauncherFlow: 65.519s start() ended

## When creating an account with cached bundle

- LauncherFlow: 0.43s initConnector() ended

- LauncherFlow: 1.14s init() ended

- LauncherFlow: 62.35s start() ended

## When refreshing data

- LauncherFlow: 0.25s initConnector() ended

- LauncherFlow: 1.02s init() ended

- LauncherFlow: 40s start() ended

## ReactNativeLauncher.start() method

### When creating an account without cached bundle

- 0.03s `setContentScriptType()` - `"pilot"` ended

- 0.09s `setContentScriptType()` - `"worker"` ended

- 20.37s `ensureAuthenticated()` ended

- 20.65s `sendLoginSuccess()` ended

- 21.59s `getUserDataFromWebsite()` ended

- 22.04s `ensureAccountNameAndFolder()` ended

- 70.35s `fetch()` - `pilotContext` ended

- 70.59s `stop()` ended

### When creating an account with cached bundle

- 0.03s `setContentScriptType()` - `"pilot"` ended

- 0.08s `setContentScriptType()` - `"worker"` ended

- 24.01s `ensureAuthenticated()` ended

- 24.44s `sendLoginSuccess()` ended

- 25.54s `getUserDataFromWebsite()` ended

- 26.01s `ensureAccountNameAndFolder()` ended

- 76.79s `fetch()` - `pilotContext` ended

- 76.89s `stop()` ended

### When refreshing data

- 0.07s `setContentScriptType()` - `"pilot"` ended

- 0.13s `setContentScriptType()` - `"worker"` ended

- 12.12s `ensureAuthenticated()` ended

- 12.39s `sendLoginSuccess()` ended

- 12.55s `getUserDataFromWebsite()` ended

- 12.55s `ensureAccountNameAndFolder()` ended

- 41.80s `fetch()` - `pilotContext` ended

- 42.07s `stop()` ended
