### PR TITLE
fix: Increase default PBKDF2 iteration number to from 100000 to 650000

### DIFF
--- a/src/libs/functions/passwordHelpers.js
+++ b/src/libs/functions/passwordHelpers.js
@@ -5,7 +5,7 @@ import { deleteKeychain, saveVaultInformation } from '../keychain'
 
 const log = Minilog('passwordHelpers')
 
-const DEFAULT_ITERATION_NUMBER = 100000
+const DEFAULT_ITERATION_NUMBER = 650000
 
 const getSaltForInstance = instance => {
   const domain = instance.split(':')[0]


### PR DESCRIPTION
PBKDF2 default iteration number has been increased on cozy-stack so we want to replicate this new value on Flagship onboarding scenario

The login scenario is already querying the cozy-stack iteration number from `/public/prelogin` route, so it is not impacted

The onboarding scenario cannot query this value has the `/public/prelogin` route would return `KdfIterations:0` until the onboarding completes, so instead we use the default iteration number that is hard coded into the app's code

Related PR: cozy/cozy-stack#3604