### PR TITLE
feat: Ensure account and trigger on the flagship app side

### DIFF
--- a/src/@types/cozy-clisk.d.ts
+++ b/src/@types/cozy-clisk.d.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+declare module 'cozy-clisk' {
+  export class LauncherBridge {
+    constructor(options: object)
+    init(options: object)
+  }
+  export class ContentScriptMessenger {
+    constructor(options: object)
+    postMessage(message: string)
+    addMessageListener(listener: function): function
+  }
+  export const addData: (
+    entries: object[],
+    doctype: string,
+    options: object
+  ) => Promise<object[]>
+  export const hydrateAndFilter: (
+    documents: object[],
+    doctype: string,
+    options: object
+  ) => Promise<object[]>
+  export const saveFiles: (
+    client: object,
+    entries: object[],
+    folderPath: string,
+    options: object
+  ) => Promise<object[]>
+  export const saveBills: (
+    entries: object[],
+    options: object
+  ) => Promise<object[]>
+  export const saveIdentity: (
+    contractOrIdentity: object,
+    accountIdentifier: string | null | undefined,
+    options: object
+  ) => Promise<void>
+  export const updateOrCreate: (
+    entries: object[],
+    doctype: string,
+    matchingAttributes: string[],
+    options: object
+  ) => Promise<object>
+}

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -91,14 +91,18 @@ export default class Launcher {
    */
   async updateJobResult({ state, error } = { state: 'done' }) {
     const { job, client } = this.getStartContext()
-    return await client.save({
-      ...job,
-      attributes: {
-        // @ts-ignore
-        ...job.attributes,
-        ...{ state, error }
-      }
-    })
+    if (job) {
+      return await client.save({
+        ...job,
+        attributes: {
+          // @ts-ignore
+          ...job.attributes,
+          ...{ state, error }
+        }
+      })
+    } else {
+      log.info('Konnector execution stopped by user, no job to stop')
+    }
   }
 
   /**

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -140,11 +140,11 @@ class ReactNativeLauncher extends Launcher {
         log.info('Got initConnectorError ' + initConnectorError.message)
         throw initConnectorError
       }
-      await this.ensureAccountTriggerAndLaunch()
       await this.pilot.call('setContentScriptType', 'pilot')
       await this.worker.call('setContentScriptType', 'worker')
       await this.pilot.call('ensureAuthenticated')
       await this.sendLoginSuccess()
+      await this.ensureAccountTriggerAndLaunch()
 
       this.setUserData(await this.pilot.call('getUserDataFromWebsite'))
       await this.ensureAccountNameAndFolder()
@@ -159,6 +159,7 @@ class ReactNativeLauncher extends Launcher {
       await this.stop()
     } catch (err) {
       log.error(err, 'start error')
+      await this.ensureAccountTriggerAndLaunch() // to create the job even if the error was raised before sendLoginSuccess
       await this.stop({ message: err.message })
     }
     this.emit('CONNECTOR_EXECUTION_END')

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -122,6 +122,7 @@ class ReactNativeLauncher extends Launcher {
         log.info('Got initConnectorError ' + initConnectorError.message)
         throw initConnectorError
       }
+      await this.ensureAccountTriggerAndLaunch()
       await this.pilot.call('setContentScriptType', 'pilot')
       await this.worker.call('setContentScriptType', 'worker')
       await this.pilot.call('ensureAuthenticated')

--- a/src/screens/connectors/LauncherView.js
+++ b/src/screens/connectors/LauncherView.js
@@ -47,7 +47,7 @@ class LauncherView extends Component {
 
   async initConnector() {
     const { client, launcherContext } = this.props
-    const slug = launcherContext.job.message.konnector
+    const slug = launcherContext.connector.slug
 
     try {
       this.setState({

--- a/src/screens/home/hooks/useLauncherClient.ts
+++ b/src/screens/home/hooks/useLauncherClient.ts
@@ -16,11 +16,11 @@ export const useLauncherClient = (
   const client = useClient()
 
   useEffect(() => {
-    const slug = launcherContextValue?.job.message.konnector
+    const slug = launcherContextValue?.connector.slug
 
     if (slug) void getLauncherClient(client, slug, setLauncherClient)
     else setLauncherClient(undefined)
-  }, [client, launcherContextValue?.job.message.konnector])
+  }, [client, launcherContextValue?.connector.slug])
 
   return { launcherClient }
 }


### PR DESCRIPTION
Now, the Launcher creates the account and trigger, not harvest.
The trigger is also launched.

This allows for faster account and trigger creation since the flagship
app will only have to check clisk specific aspects.

At the moment, account and trigger are still created even if the login fails.
What is missing is a way to display an error in the amiral application or harvest without a job
And we need to have a job result to trace connections attempts which have failed in logs

- feat: Use connector slug in launcher
- feat: Upgrade cozy-client to v35
- feat: Ensure account and trigger on flagship app side
- docs: Add @ts-check

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [X] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

