### PR TITLE
chore: remove babel-plugin-react-native-web

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5101,11 +5101,6 @@ babel-plugin-polyfill-regenerator@^0.4.1:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.3"
 
-babel-plugin-react-native-web@0.17.7:
-  version "0.17.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.17.7.tgz#1580e27a2e3c6692127535d3880fe1e247ef6414"
-  integrity sha512-UBLfIsfU3vi//Ab4i0WSWAfm1whLTK9uJoH0RPZ6a67eS/h9JGYjKy7+1RpHxSBviHi9NIMiYfWseTLjyIsE1g==
-
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"


### PR DESCRIPTION
We don't use react-native-web at all.
This dependency can be removed.
cf:

```
anc@desktop:~/cozy/cozy-react-native$ yarn why babel-plugin-react-native-web
yarn why v1.22.19
[1/4] Why do we have the module "babel-plugin-react-native-web"...?
[2/4] Initialising dependency graph...
warning Resolution field "@typescript-eslint/eslint-plugin@5.36.0" is incompatible with requested version "@typescript-eslint/eslint-plugin@^4.5.0"
warning Resolution field "@typescript-eslint/eslint-plugin@5.36.0" is incompatible with requested version "@typescript-eslint/eslint-plugin@5.44.0"
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "babel-plugin-react-native-web@0.17.7"
info Has been hoisted to "babel-plugin-react-native-web"
info This module exists because it's specified in "devDependencies".
info Disk size without dependencies: "48KB"
info Disk size with unique dependencies: "48KB"
info Disk size with transitive dependencies: "48KB"
info Number of shared dependencies: 0
Done in 0.77s.
```