### PR TITLE
fix: update openConnectorInHome

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,9 +3,9 @@ import FlipperAsyncStorage from 'rn-flipper-async-storage-advanced'
 import RNAsyncStorageFlipper from 'rn-async-storage-flipper'
 import React, { useEffect, useState } from 'react'
 import { NavigationContainer } from '@react-navigation/native'
-import { StatusBar, StyleSheet, View } from 'react-native'
-import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
+import { Provider } from 'react-redux'
+import { StatusBar, StyleSheet, View } from 'react-native'
 import { createStackNavigator } from '@react-navigation/stack'
 import { decode, encode } from 'base-64'
 
@@ -25,18 +25,17 @@ import { LoginScreen } from '/screens/login/LoginScreen'
 import { OnboardingScreen } from '/screens/login/OnboardingScreen'
 import { SplashScreenProvider } from '/components/providers/SplashScreenProvider'
 import { WelcomeScreen } from '/screens/welcome/WelcomeScreen'
+import { cleanConnectorsOnBootInBackground } from '/libs/connectors/cleanConnectorsOnBoot'
 import { getClient } from '/libs/client'
 import { getColors } from '/ui/colors'
 import { localMethods } from '/libs/intents/localMethods'
+import { persistor, store } from '/redux/store'
 import { routes } from '/constants/routes.js'
 import { useAppBootstrap } from '/hooks/useAppBootstrap.js'
 import { useCookieResyncOnResume } from '/hooks/useCookieResyncOnResume'
 import { useGlobalAppState } from '/hooks/useGlobalAppState'
 import { useNetService } from '/libs/services/NetService'
 import { withSentry } from '/libs/monitoring/Sentry'
-import { persistor, store } from '/redux/store'
-
-import { cleanConnectorsOnBootInBackground } from '/libs/connectors/cleanConnectorsOnBoot'
 
 const Root = createStackNavigator()
 const Stack = createStackNavigator()
@@ -66,11 +65,11 @@ const App = ({ setClient }) => {
 
   const MainAppNavigator = () => (
     <Root.Navigator
-      initialRouteName="default"
+      initialRouteName={routes.default}
       screenOptions={{ headerShown: false }}
     >
       <Stack.Screen
-        name="default"
+        name={routes.default}
         component={HomeScreen}
         initialParams={initialRoute.params}
       />

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,6 +1,7 @@
 export const routes = {
   authenticate: 'authenticate',
   cozyapp: 'cozyapp',
+  default: 'default',
   error: 'error',
   home: 'home',
   instanceCreation: 'instanceCreation',

--- a/src/libs/functions/openApp.js
+++ b/src/libs/functions/openApp.js
@@ -1,6 +1,9 @@
 import { Alert, Linking, Platform } from 'react-native'
+
 import { getDimensions } from '/libs/dimensions'
 import { isSameCozy, openUrlInAppBrowser } from '/libs/functions/urlHelpers'
+import { navigate } from '/libs/RootNavigation'
+import { routes } from '/constants/routes'
 /**
  * App's mobile information. Used to describe the app scheme and its store urls
  * @typedef {object} AppManifestMobileInfo
@@ -88,14 +91,13 @@ const openAppNative = async appNativeData => {
 
 /**
  * Open the connector pane in the Home view
- * @param {any} navigation - The React navigation context
  * @param {AppManifest} connector - The connector information
  */
-const openConnectorInHome = (navigation, connector) => {
+const openConnectorInHome = connector => {
   const { slug } = connector
 
-  navigation.navigate({
-    name: 'home',
+  navigate({
+    name: routes.default,
     params: {
       konnector: slug
     }
@@ -125,7 +127,7 @@ export const openApp = (client, navigation, href, app, iconParams) => {
     return
   }
   if (app?.type === 'konnector') {
-    openConnectorInHome(navigation, app)
+    openConnectorInHome(app)
     return
   }
 


### PR DESCRIPTION
## What does this do?

Previously this function opened the URL "home". But this route is a Navigator route and the slug param was lost.
By navigating to "default" instead (which is the actual home route), we correctly keep the slug param and the connector opens.

## Why did you do this?

The HomeView did not receive any param after a navigation so we could not open a Konnector from the cozy-store
