### PR TITLE
fix: handle nested domains for `isSameCozy`

### DIFF
--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -30,8 +30,6 @@
   },
   "errors": {
     "cozyClientMismatch": "Could not validate redirect url, Cozy Client mismatch",
-    "domainMismatch": "Could not validate redirect url, domain mismatch",
-    "protocolMismatch": "Could not validate redirect url, protocol mismatch",
     "clearPersistentIconTable": "Could not clear icon cache. Saved cache might be corrupted.",
     "getPersistentIconTable": "Could not get icon cache.",
     "setPersistentIconTable": "Could not set icon cache. Cache to save might be corrupted.",

--- a/src/libs/functions/openApp.js
+++ b/src/libs/functions/openApp.js
@@ -113,11 +113,11 @@ const openConnectorInHome = (navigation, connector) => {
  * @returns {Promise}
  */
 export const openApp = (client, navigation, href, app, iconParams) => {
-  const subdomainType = client.capabilities?.flat_subdomains ? 'flat' : 'nested'
+  const subDomainType = client.capabilities?.flat_subdomains ? 'flat' : 'nested'
   const shouldOpenInIAB = !isSameCozy({
     cozyUrl: client.getStackClient().uri,
     destinationUrl: href,
-    subdomainType
+    subDomainType
   })
 
   if (shouldOpenInIAB) {

--- a/src/libs/functions/openApp.spec.js
+++ b/src/libs/functions/openApp.spec.js
@@ -26,6 +26,10 @@ jest.mock('react-native', () => ({
   }
 }))
 
+jest.mock('react-native-ios11-devicecheck', () => ({
+  isEmulator: jest.fn().mockResolvedValue(false)
+}))
+
 const navigation = {
   navigate: jest.fn()
 }

--- a/src/libs/functions/urlHelpers.spec.js
+++ b/src/libs/functions/urlHelpers.spec.js
@@ -4,7 +4,8 @@ import {
   checkIsReload,
   checkIsRedirectOutside,
   checkIsSameApp,
-  checkIsSlugSwitch
+  checkIsSlugSwitch,
+  isSameCozy
 } from './urlHelpers'
 
 jest.mock('react-native-inappbrowser-reborn', () => ({
@@ -276,6 +277,94 @@ describe('urlHelpers', () => {
         expect(
           checkIsSameApp({ currentUrl, destinationUrl, subdomainType })
         ).toEqual(result)
+      }
+    )
+  })
+
+  describe('isSameCozy', () => {
+    it.each([
+      [
+        'http://claude.mycozy.cloud',
+        'http://drive.claude.mycozy.cloud',
+        'nested',
+        true
+      ],
+      [
+        'http://dev.10-0-2-2.nip.io:8080',
+        'http://contacts.dev.10-0-2-2.nip.io:8080/',
+        'nested',
+        true
+      ],
+      [
+        'http://claude.mycozy.cloud',
+        'http://drive.paul.mycozy.cloud',
+        'nested',
+        false
+      ],
+      [
+        'http://claude.mycozy.cloud#hash1',
+        'http://drive.claude.mycozy.cloud#hash2',
+        'nested',
+        true
+      ],
+      [
+        'http://claude.mycozy.cloud/path1',
+        'http://drive.claude.mycozy.cloud/path2',
+        'nested',
+        true
+      ],
+      [
+        'http://claude.mycozy.cloud/path1#hash1',
+        'http://drive.claude.mycozy.cloud/path1#hash2',
+        'nested',
+        true
+      ],
+      ['http://claude.mycozy.cloud', 'http://google.com', 'nested', false],
+      ['http://claude.mycozy.cloud', 'google.com', 'nested', false],
+      [
+        'http://claude.mycozy.cloud',
+        'http://claude-drive.mycozy.cloud',
+        'flat',
+        true
+      ],
+      [
+        'http://dev.10-0-2-2.nip.io:8080',
+        'http://dev-contacts.10-0-2-2.nip.io:8080/',
+        'flat',
+        true
+      ],
+      [
+        'http://claude.mycozy.cloud',
+        'http://paul-drive.mycozy.cloud',
+        'flat',
+        false
+      ],
+      [
+        'http://claude.mycozy.cloud#hash1',
+        'http://claude-drive.mycozy.cloud#hash2',
+        'flat',
+        true
+      ],
+      [
+        'http://claude.mycozy.cloud/path1',
+        'http://claude-drive.mycozy.cloud/path2',
+        'flat',
+        true
+      ],
+      [
+        'http://claude.mycozy.cloud/path1#hash1',
+        'http://claude-drive.mycozy.cloud/path1#hash2',
+        'flat',
+        true
+      ],
+      ['http://claude.mycozy.cloud', 'http://google.com', 'flat', false],
+      ['http://claude-drive.mycozy.cloud', 'google.com', 'flat', false]
+    ])(
+      'should compare %p with %p with %p subDomain and return isSameCozy=%p',
+      (cozyUrl, destinationUrl, subDomainType, result) => {
+        expect(isSameCozy({ cozyUrl, destinationUrl, subDomainType })).toEqual(
+          result
+        )
       }
     )
   })


### PR DESCRIPTION
## What does this do?

- This will check when opening an URL if it's from the same nested cozy

## Why did you do this?

- Previously we determined that a nested cozy could never navigate to itself

## Who/what does this impact?

- It impacts everyone with a nested cozy, so mainly dev environments

## How did you test this?

- Manually, no unit tests as of now. The shape of deconstructed cozy web link is strange in nested mode though, I'm not sure if it's returning correct data