### PR TITLE
feat: Bump app version to 1.0.1 and fix CI

### DIFF
--- a/.github/workflows/build-android-dev.yml
+++ b/.github/workflows/build-android-dev.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set NodeJS version
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Check out Git repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set NodeJS version
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Check out Git repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -67,7 +67,7 @@ jobs:
         id: sign_app
         uses: r0adkll/sign-android-release@v1
         with:
-          releaseDirectory: android/app/build/outputs/apk/release
+          releaseDirectory: android/app/build/outputs/bundle/release
           signingKeyBase64: ${{ secrets.ANDROID_SIGNING_KEY }}
           alias: ${{ secrets.ANDROID_ALIAS }}
           keyStorePassword: ${{ secrets.ANDROID_KEY_STORE_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.3
+# 1.0.4
 
 ## ✨ Features
 
@@ -8,6 +8,32 @@
 
 ## 🔧 Tech
 
+
+# 1.0.3
+
+## ✨ Features
+
+* Improve Client Side Connectors security by enforcint limited permissions ([PR #558](https://github.com/cozy/cozy-react-native/pull/558))
+
+## 🐛 Bug Fixes
+
+* Prevent multiple Client Side Connectors to be executed simultaneously ([PR #572](https://github.com/cozy/cozy-react-native/pull/572))
+* Clean Client Side Connectors state on app startup ([PR #579](https://github.com/cozy/cozy-react-native/pull/579))
+* Shared cozy-notes are now correctly displayed ([PR #596](https://github.com/cozy/cozy-react-native/pull/596))
+
+## 🔧 Tech
+
+* Client Side Connectors can now send execution logs to the cozy-stack ([PR #516](https://github.com/cozy/cozy-react-native/pull/516), [PR #534](https://github.com/cozy/cozy-react-native/pull/534) and [PR #593](https://github.com/cozy/cozy-react-native/pull/593))
+* Client Side Connectors now have an API to normalize files names ([PR #462](https://github.com/cozy/cozy-react-native/pull/462))
+* App's environment variables are now handled by `.env` file ([PR #557](https://github.com/cozy/cozy-react-native/pull/557))
+* Improve dev environement setup ([PR #562](https://github.com/cozy/cozy-react-native/pull/562))
+* Client Side Connectors library has been moved into a dedicated repository ([PR #559](https://github.com/cozy/cozy-react-native/pull/559), [PR #560](https://github.com/cozy/cozy-react-native/pull/560) and [PR #555](https://github.com/cozy/cozy-react-native/pull/555))
+* Client Side Connectors have been moved into their dedicated repositories ([PR #565](https://github.com/cozy/cozy-react-native/pull/565))
+* Fix build error related to `jetified-kotlin-stdlib` ([PR #566](https://github.com/cozy/cozy-react-native/pull/566))
+* Fix build error related to `hermes` ([PR #580](https://github.com/cozy/cozy-react-native/pull/580))
+* Add CI workflows ([PR #551](https://github.com/cozy/cozy-react-native/pull/551), [PR #570](https://github.com/cozy/cozy-react-native/pull/570), [PR #547](https://github.com/cozy/cozy-react-native/pull/547), [PR #584](https://github.com/cozy/cozy-react-native/pull/584), [PR #554](https://github.com/cozy/cozy-react-native/pull/554) and [PR #620](https://github.com/cozy/cozy-react-native/pull/620))
+* Rework app startup algorithms ([PR #550](https://github.com/cozy/cozy-react-native/pull/550))
+* Add foundations for push notifications ([PR #598](https://github.com/cozy/cozy-react-native/pull/598))
 
 # 1.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.2
+# 1.0.3
 
 ## ✨ Features
 
@@ -8,6 +8,24 @@
 
 ## 🔧 Tech
 
+
+# 1.0.2
+
+## ✨ Features
+
+* Client Side Connectors can now be installed from Registry ([PR #525](https://github.com/cozy/cozy-react-native/pull/525))
+* Client Side Connectors are now executed using a permission-limited Client ([PR #533](https://github.com/cozy/cozy-react-native/pull/533))
+
+## 🐛 Bug Fixes
+
+* Fix CozyApp opening animation that was using the wrong screen's width & height calculation ([PR #545](https://github.com/cozy/cozy-react-native/pull/545))
+
+## 🔧 Tech
+
+* Reworked project file structure ([PR #535](https://github.com/cozy/cozy-react-native/pull/535), [PR #541](https://github.com/cozy/cozy-react-native/pull/541) and [PR #546](https://github.com/cozy/cozy-react-native/pull/546))
+* Convert `Template` Client Side Connector to use HTTPS instead of HTTP ([PR #539](https://github.com/cozy/cozy-react-native/pull/539))
+* Local HttpServer now supports `{.CozyFonts}` template tag ([PR #543](https://github.com/cozy/cozy-react-native/pull/543))
+* Prevents phone numbers to be send to Sentry when handling related errors ([PR #544](https://github.com/cozy/cozy-react-native/pull/544))
 
 # 1.0.1
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -169,7 +169,7 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            // signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100021
-        versionName "1.0.2"
+        versionCode 100033
+        versionName "1.0.3"
         multiDexEnabled true
     }
     splits {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100011
-        versionName "1.0.1"
+        versionCode 100021
+        versionName "1.0.2"
         multiDexEnabled true
     }
     splits {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -10,3 +10,4 @@
 # Add any project specific keep options here:
 
 -keep public class com.horcrux.svg.** {*;}
+-keep class io.cozy.flagship.mobile.BuildConfig { *; }

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100011</string>
+	<string>0100021</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100021</string>
+	<string>0100030</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.0.3
- creates a new entry for next 1.0.4 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs

This PR also fixes the CI process by:
- Enforcing Node 16
- Fixing Proguard configuration with react-native-config
- Fixing workflow files