### PR TITLE
fix: update install home script

### DIFF
--- a/scripts/install-home-registry.cmd.ts
+++ b/scripts/install-home-registry.cmd.ts
@@ -4,6 +4,6 @@ void installHomeRegistry(
   'https://apps-registry.cozycloud.cc/registry/home/stable/latest',
   [
     'android/app/src/main/assets/cozy-home/build',
-    'iOS/assets/resources/cozy-home/build'
+    'ios/assets/resources/cozy-home/build'
   ]
 )


### PR DESCRIPTION
## What does this do?

Update ios home dir

## Why did you do this?

It used the 'iOS' dir, but the correct casing is 'ios'.
It seems it still worked for some reason, but it's best to be safe

## Who/what does this impact?

ci/dev