### PR TITLE
feat: allow direct konnector fetching

### DIFF
--- a/src/constants/dev-config.ts
+++ b/src/constants/dev-config.ts
@@ -9,5 +9,6 @@ export const devConfig = {
   enableReduxLogger: false, // Outputs to console every Redux action with payload, prev and next state
   forceHideSplashScreen: false, // Hide react-native splash screen renders, useful for debugging in case of a webview crash
   forceOffline: false, // Force offline mode by overwriting the NetInfo module and returning a fake offline state,
-  ignoreLogBox: false // Hide react-native LogBox renders but still display logs to the console,
+  ignoreLogBox: true, // Hide react-native LogBox renders but still display logs to the console,
+  konnectorServer: 'http://172.28.246.230:3000' // Use local konnectors instead of the ones from the stack, e.g. "http://172.31.47.56:3000"
 }

--- a/src/core/tools/dev.ts
+++ b/src/core/tools/dev.ts
@@ -31,5 +31,8 @@ export const getDevConfig = (isDev: boolean): DevConfig =>
   isDev
     ? devConfig
     : (Object.fromEntries(
-        Object.entries(devConfig).map(([key]) => [key, false])
+        Object.entries(devConfig).map(([key, value]) => [
+          key,
+          typeof value === 'boolean' ? false : ''
+        ])
       ) as DevConfig)

--- a/src/core/tools/env.ts
+++ b/src/core/tools/env.ts
@@ -45,9 +45,12 @@ export const devlog = isDev() && !isTest() ? console.debug : (): void => void 0
 
 initDev(isDev()).catch(error => devlog('failed to init dev env', error))
 
-const { disableGetIndex, enableLocalSentry, enableReduxLogger } = getDevConfig(
-  isDev()
-)
+const {
+  disableGetIndex,
+  enableLocalSentry,
+  enableReduxLogger,
+  konnectorServer
+} = getDevConfig(isDev())
 
 if (enableLocalSentry) toggleLocalSentry(true)
 
@@ -57,6 +60,8 @@ export const shouldDisableGetIndex = (): boolean => disableGetIndex
 
 export const shouldEnableReduxLogger = (): boolean =>
   enableReduxLogger && !isTest()
+
+export { konnectorServer }
 
 export const EnvService = {
   name,

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -4,10 +4,14 @@ import Minilog from '@cozy/minilog'
 import ContentScriptBridge from './bridge/ContentScriptBridge'
 import CookieManager from '@react-native-cookies/cookies'
 import Launcher from './Launcher'
-import { getKonnectorBundle } from '/libs/cozyAppBundle/cozyAppBundle.functions'
+import {
+  fetchKonnectorFromUrl,
+  getKonnectorBundle
+} from '/libs/cozyAppBundle/cozyAppBundle.functions'
 import { saveCookie, getCookie, removeCookie } from './keychain'
 import { updateCozyAppBundle } from '/libs/cozyAppBundle/cozyAppBundle'
 import { sendKonnectorsLogs } from '/libs/konnectors/sendKonnectorsLogs'
+import { konnectorServer } from '/core/tools/env'
 
 const log = Minilog('ReactNativeLauncher')
 
@@ -89,6 +93,8 @@ class ReactNativeLauncher extends Launcher {
     }
 
     try {
+      log.info('Fetching konnector bundle from ' + konnectorServer)
+      // const bundle = await fetchKonnectorFromUrl(konnectorServer)
       const bundle = await getKonnectorBundle({ client, slug })
 
       if (!bundle) throw new Error('No konnector bundle found')

--- a/src/libs/cozyAppBundle/cozyAppBundle.functions.ts
+++ b/src/libs/cozyAppBundle/cozyAppBundle.functions.ts
@@ -102,3 +102,24 @@ export const getVersionsToKeep = ({
   // If it's a webapp, we need to keep the current and the next versions because the bundle is updated only after a restart
   return [currentVersion, stackVersion]
 }
+
+/**
+ * Returns the manifest and the content of the main.js file for a given connector
+ * using the HTTP server
+ * @param {string} url - The URL of the HTTP server
+ * @returns {ConnectorBundle} The manifest and main.js file for the connector
+ * @throws {Error} If the manifest or main.js file could not be fetched
+ * @throws {Error} If the manifest or main.js file could not be parsed
+ * @throws {Error} If the manifest or main.js file could not be read
+ */
+export const fetchKonnectorFromUrl = async (
+  url: string
+): Promise<KonnectorBundle> => {
+  const manifest = await fetch(`${url}/manifest.konnector`)
+  const content = await fetch(`${url}/main.js`)
+
+  return {
+    manifest: (await manifest.json()) as Record<string, unknown>,
+    content: await content.text()
+  }
+}


### PR DESCRIPTION
## What does this do?

- Enable dev user to fetch Konnector file from any server

## Why did you do this?

- Crucial for easy development flow

## Who/what does this impact?

- Anyone who wants to work on Konnectors in real time

## How did you test this?

- Tested locally and manually
- I would consider this feature experimental for now