### PR TITLE
feat: Redirect to created account after creation

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -188,9 +188,19 @@ export default class Launcher {
   }
 
   /**
+   * @typedef ensureAccountTriggerAndLaunchResult
+   * @property {import('cozy-client/types/types').IOCozyAccount} [createdAccount] - the created account if an account was created in the process
+   * @property {import('cozy-client/types/types').IOCozyTrigger} [createdTrigger] - the created trigger if a trigger was created in the process
+   * @property {import('cozy-client/types/types').CozyClientDocument} [createdJob] - the created job if any job was created
+   */
+
+  /**
    * Ensures that account and triggers are created and launch the trigger
+   *
+   * @returns {Promise<ensureAccountTriggerAndLaunchResult>}
    */
   async ensureAccountTriggerAndLaunch() {
+    const result = {}
     const startContext = this.getStartContext()
     let { trigger, account, konnector, client, job, launcherClient } =
       startContext
@@ -204,6 +214,7 @@ export default class Launcher {
       const accountResponse = await client.save(accountData)
       account = accountResponse.data
       log.debug(`ensureAccountAndTriggerAndJob: created account`, account)
+      result.createdAccount = account
     }
     account = await this.ensureAccountName(account)
     const folder = await ensureKonnectorFolder(client, {
@@ -222,6 +233,7 @@ export default class Launcher {
       triggerData._type = 'io.cozy.triggers'
       const triggerResponse = await client.save(triggerData)
       trigger = triggerResponse.data
+      result.createdTrigger = trigger
       log.debug(`ensureAccountAndTriggerAndJob: created trigger`, trigger)
     }
 
@@ -232,6 +244,7 @@ export default class Launcher {
         .collection('io.cozy.triggers')
         .launch(trigger)
       job = launchResponse.data
+      result.createdJob = job
     }
     log.debug(`ensureAccountAndTriggerAndJob: launched job`, job)
 
@@ -243,6 +256,7 @@ export default class Launcher {
       konnector,
       launcherClient
     })
+    return result
   }
 
   /**

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -146,7 +146,10 @@ class ReactNativeLauncher extends Launcher {
 
       this.setUserData(await this.pilot.call('getUserDataFromWebsite'))
 
-      await this.ensureAccountTriggerAndLaunch()
+      const ensureResult = await this.ensureAccountTriggerAndLaunch()
+      if (ensureResult.createdAccount) {
+        this.emit('CREATED_ACCOUNT', ensureResult.createdAccount)
+      }
       await this.sendLoginSuccess()
 
       const pilotContext = []
@@ -160,7 +163,10 @@ class ReactNativeLauncher extends Launcher {
     } catch (err) {
       log.error(err, 'start error')
       // to create the job even if the error was raised before sendLoginSuccess
-      await this.ensureAccountTriggerAndLaunch()
+      const ensureResult = await this.ensureAccountTriggerAndLaunch()
+      if (ensureResult.createdAccount) {
+        this.emit('CREATED_ACCOUNT', ensureResult.createdAccount)
+      }
       await this.stop({ message: err.message })
     }
     this.emit('KONNECTOR_EXECUTION_END')

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -89,6 +89,15 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
           const url = new URL(uri)
           url.hash = `/connected/${konnectorParam}`
 
+          const accountParam = consumeRouteParameter(
+            'account',
+            route,
+            navigation
+          )
+          if (accountParam) {
+            url.hash += `/accounts/${accountParam}`
+          }
+
           const targetUri = url.toString()
           setUri(targetUri)
         }

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -15,6 +15,7 @@ import {
   startTimeout,
   stopTimeout
 } from '/screens/konnectors/core/handleTimeout'
+import { navigate } from '/libs/RootNavigation'
 
 const log = Minilog('LauncherView')
 
@@ -29,6 +30,7 @@ class LauncherView extends Component {
     this.onPilotMessage = this.onPilotMessage.bind(this)
     this.onWorkerMessage = this.onWorkerMessage.bind(this)
     this.onStopExecution = this.onStopExecution.bind(this)
+    this.onCreatedAccount = this.onCreatedAccount.bind(this)
     this.onWorkerWillReload = debounce(this.onWorkerWillReload.bind(this), 1000)
     this.pilotWebView = null
     this.workerWebview = null
@@ -43,6 +45,13 @@ class LauncherView extends Component {
   onStopExecution() {
     this.launcher.stop({ message: 'stopped by user' })
     this.props.setLauncherContext({ state: 'default' })
+  }
+
+  onCreatedAccount(account) {
+    // make the webview navigate to the the harvest route associated to the account
+    const { launcherContext } = this.props
+    const konnector = launcherContext.konnector.slug
+    navigate('default', { konnector, account: account._id })
   }
 
   async initKonnector() {
@@ -95,6 +104,7 @@ class LauncherView extends Component {
     this.launcher.on('WORKER_READY', () => {
       this.setState({ workerReady: true })
     })
+    this.launcher.on('CREATED_ACCOUNT', this.onCreatedAccount)
 
     if (this.state.konnector) {
       await this.launcher.init({


### PR DESCRIPTION
When the launcher needs to create an account and trigger, it will
redirect the home application to the harvest route related to the
created account.

This will allow the user to see the execution of his konnector