### PR TITLE
feat: Display custom WelcomeScreen when OnboardingPartner context found

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   package="io.cozy.flagship.mobile">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"/>
     <queries>
       <intent>
         <action android:name="android.intent.action.VIEW" />

--- a/docs/how-to-debug-onboarding-partner.md
+++ b/docs/how-to-debug-onboarding-partner.md
@@ -1,0 +1,44 @@
+# How to debug Onboarding Partner
+
+On App's first launch, we try to detect the installation context so we can extract Onboarding Partner and display custom instructions to our users
+
+The Onboarding Partner feature is based on [Google Play Install Referrer API](https://developer.android.com/google/play/installreferrer)
+
+> **Note**
+> When an app is installed using a Referrer URI, the referrer value won't change until the App is reinstalled (or after 90days but our code will use the initial value anyway)
+
+## Build a Referrer URI
+
+In order to build a Rerrer URI, you can use the following generator
+- https://developers.google.com/analytics/devguides/collection/android/v4/campaigns#google-play-url-builder
+
+The expected values are the following:
+- Application ID: `io.cozy.flagship.mobile`
+- Campaign Source: the partner name
+- Campaign Content: the provided context (i.e `MesPapiers`, `default` etc)
+- Campaign Name: `onboarding_partner`
+
+## Testing on production (phone with Play Store installed)
+
+When testing on production, build a referrer URI and install the App by opening this URI from your device
+
+## Testing on local dev (phone with Play Store installed)
+
+If the feature you want to test is not deployed yet, then do the following:
+- Build a referrer URI and open it from your device
+- When the Play Store is opened, DO NOT click on `Install`
+- Use a command line to manually install the app on the device
+  - `yarn android` or `adb install -r XXX.apk`
+
+## Testing on emulator (if no Play Store installed)
+
+As the Install Referrer API depends on the Play Store app, if your device does not have it, then you won't be able to test the entire scenario
+
+However it is still possible to test the app's behavior when it detects an Install Referrer
+
+To do this, do the following:
+- Using flipper, edit the App's AsyncStorage and delete the `ONBOARDING_PARTNER_STORAGE_KEY` entry
+  - Key corresponding to `ONBOARDING_PARTNER_STORAGE_KEY` can be found in `strings.json`
+- Edit `dev-config.ts` and set `forceInstallReferrer` to `true`
+  - If needed, edit the `enforcedInstallReferrer` entry with expected values
+- Restart the App

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-native-ios11-devicecheck": "https://github.com/cozy/react-native-devicecheck#app-attest-v0.1",
     "react-native-keychain": "^8.0.0",
     "react-native-mask-input": "1.2.1",
+    "react-native-play-install-referrer": "^1.1.8",
     "react-native-safe-area-context": "^4.5.0",
     "react-native-screens": "3.18.2",
     "react-native-svg": "12.3.0",

--- a/src/constants/dev-config.ts
+++ b/src/constants/dev-config.ts
@@ -9,5 +9,8 @@ export const devConfig = {
   enableReduxLogger: false, // Outputs to console every Redux action with payload, prev and next state
   forceHideSplashScreen: false, // Hide react-native splash screen renders, useful for debugging in case of a webview crash
   forceOffline: false, // Force offline mode by overwriting the NetInfo module and returning a fake offline state,
-  ignoreLogBox: false // Hide react-native LogBox renders but still display logs to the console,
+  ignoreLogBox: false, // Hide react-native LogBox renders but still display logs to the console,
+  forceInstallReferrer: false, // Enforce InstallReferrer with the 'enforcedInstallReferrer' string (strings.ONBOARDING_PARTNER_STORAGE_KEY must be clear to apply this value)
+  enforcedInstallReferrer:
+    'utm_source=SOME_PARTNER&utm_content=SOME_CONTEXT&utm_campaign=onboarding_partner&anid=admob'
 }

--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -4,6 +4,7 @@
   "COOKIE_STORAGE_KEY": "@cozy_AmiralAppCookieConfig",
   "COZY_SCHEME": "cozy://",
   "OAUTH_STORAGE_KEY": "@cozy_AmiralAppOAuthConfig",
+  "ONBOARDING_PARTNER_STORAGE_KEY": "@cozy_AmiralAppOnboardingPartnerConfig",
   "REDIRECT": "redirect",
   "SESSION_CODE": "session_code",
   "SESSION_CREATED_FLAG": "@cozy_AmiralAppSessionCreated",

--- a/src/core/tools/dev.ts
+++ b/src/core/tools/dev.ts
@@ -31,5 +31,8 @@ export const getDevConfig = (isDev: boolean): DevConfig =>
   isDev
     ? devConfig
     : (Object.fromEntries(
-        Object.entries(devConfig).map(([key]) => [key, false])
+        Object.entries(devConfig).map(([key, value]) => [
+          key,
+          typeof value === 'boolean' ? false : ''
+        ])
       ) as DevConfig)

--- a/src/core/tools/env.ts
+++ b/src/core/tools/env.ts
@@ -45,15 +45,22 @@ export const devlog = isDev() && !isTest() ? console.debug : (): void => void 0
 
 initDev(isDev()).catch(error => devlog('failed to init dev env', error))
 
-const { disableGetIndex, enableLocalSentry, enableReduxLogger } = getDevConfig(
-  isDev()
-)
+const {
+  disableGetIndex,
+  enableLocalSentry,
+  enableReduxLogger,
+  enforcedInstallReferrer,
+  forceInstallReferrer
+} = getDevConfig(isDev())
 
 if (enableLocalSentry) toggleLocalSentry(true)
 
 export const isSentryDebugMode = (): boolean => enableLocalSentry
 
 export const shouldDisableGetIndex = (): boolean => disableGetIndex
+
+export const shouldForceInstallReferrer = (): boolean => forceInstallReferrer
+export const getEnforcedInstallReferrer = (): string => enforcedInstallReferrer
 
 export const shouldEnableReduxLogger = (): boolean =>
   enableReduxLogger && !isTest()

--- a/src/screens/welcome/WelcomeScreen.jsx
+++ b/src/screens/welcome/WelcomeScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { BackHandler, StyleSheet, View } from 'react-native'
+import { BackHandler, StyleSheet, Text, View } from 'react-native'
 
 import { WelcomePage } from '/components/html/WelcomePage'
 import { makeHTML } from '/components/makeHTML'
@@ -8,6 +8,7 @@ import { makeHandlers } from '/libs/functions/makeHandlers'
 import { getColors } from '/ui/colors'
 import { useDimensions } from '/libs/dimensions'
 import { LoginScreen } from '/screens/login/LoginScreen'
+import { useInstallReferrer } from '/screens/welcome/install-referrer/useInstallReferrer'
 
 const WelcomeView = ({ setIsWelcomeModalDisplayed }) => {
   const colors = getColors()
@@ -39,7 +40,7 @@ const WelcomeView = ({ setIsWelcomeModalDisplayed }) => {
   )
 }
 
-export const WelcomeScreen = ({ navigation, route, setClient }) => {
+export const CozyWelcomeScreen = ({ navigation, route, setClient }) => {
   const [isWelcomeModalDisplayed, setIsWelcomeModalDisplayed] = useState(true)
 
   const handleBackPress = () => {
@@ -64,6 +65,40 @@ export const WelcomeScreen = ({ navigation, route, setClient }) => {
         <WelcomeView setIsWelcomeModalDisplayed={setIsWelcomeModalDisplayed} />
       )}
     </>
+  )
+}
+
+export const OnboardingPartnerWelcomeScreen = ({ partner }) => {
+  return (
+    <View style={{ marginTop: 50, backgroundColor: '#000' }}>
+      <Text>ONBOARDING PARTNER:</Text>
+      <Text>- SOURCE: {partner.source}</Text>
+      <Text>- CONTEXT: {partner.context}</Text>
+    </View>
+  )
+}
+
+export const WelcomeScreen = ({ navigation, route, setClient }) => {
+  const { isInitialized, onboardingPartner } = useInstallReferrer()
+
+  if (!isInitialized) return null
+
+  if (onboardingPartner.hasReferral)
+    return (
+      <OnboardingPartnerWelcomeScreen
+        navigation={navigation}
+        partner={onboardingPartner}
+        route={route}
+        setClient={setClient}
+      />
+    )
+
+  return (
+    <CozyWelcomeScreen
+      navigation={navigation}
+      route={route}
+      setClient={setClient}
+    />
   )
 }
 

--- a/src/screens/welcome/install-referrer/androidPlayInstallReferrer.ts
+++ b/src/screens/welcome/install-referrer/androidPlayInstallReferrer.ts
@@ -1,0 +1,41 @@
+import Minilog from '@cozy/minilog'
+import {
+  PlayInstallReferrer,
+  PlayInstallReferrerInfo
+} from 'react-native-play-install-referrer'
+
+import {
+  getEnforcedInstallReferrer,
+  shouldForceInstallReferrer
+} from '/core/tools/env'
+
+const log = Minilog('AndroidPlayInstallReferrer')
+
+export const getInstallReferrer =
+  (): Promise<PlayInstallReferrerInfo | null> => {
+    if (shouldForceInstallReferrer()) {
+      const installReferrer = getEnforcedInstallReferrer()
+      log.debug('Enforce InstallReferrer with: ' + installReferrer)
+      return Promise.resolve({
+        installReferrer
+      } as PlayInstallReferrerInfo)
+    }
+
+    return new Promise(resolve => {
+      PlayInstallReferrer.getInstallReferrerInfo(
+        (installReferrerInfo, error): void => {
+          if (!error) {
+            resolve(installReferrerInfo)
+          } else {
+            // Here we silence the error as non-google devices would trigger it
+            // In this case we prefer the code to act as if no referrer is provided
+            // Also we don't want to trigger a Sentry alert in this case so `log.info` is enough
+            log.info('Failed to get install referrer info!')
+            log.info('Response code: ' + error.responseCode)
+            log.info('Message: ' + error.message)
+            resolve(null)
+          }
+        }
+      )
+    })
+  }

--- a/src/screens/welcome/install-referrer/onboardingPartner.spec.js
+++ b/src/screens/welcome/install-referrer/onboardingPartner.spec.js
@@ -1,0 +1,127 @@
+import { Platform } from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+import strings from '/constants/strings.json'
+
+import { getInstallReferrer } from './androidPlayInstallReferrer'
+import { getOnboardingPartner } from './onboardingPartner'
+
+jest.mock('./androidPlayInstallReferrer', () => ({
+  getInstallReferrer: jest.fn()
+}))
+
+describe('onboardingPartner', () => {
+  beforeEach(() => {
+    AsyncStorage.clear()
+    jest.clearAllMocks()
+    Platform.OS = 'android'
+  })
+
+  it(`should retrieve onboarding partner from "onboarding_partner" campaign links`, async () => {
+    getInstallReferrer.mockResolvedValue({
+      installReferrer:
+        'utm_source=SOME_SOURCE&utm_content=SOME_CONTEXT&utm_campaign=onboarding_partner&anid=admob'
+    })
+
+    const onboardingPartner = await getOnboardingPartner()
+
+    expect(onboardingPartner).toStrictEqual({
+      source: 'SOME_SOURCE',
+      context: 'SOME_CONTEXT',
+      hasReferral: true
+    })
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      strings.ONBOARDING_PARTNER_STORAGE_KEY,
+      '{"source":"SOME_SOURCE","context":"SOME_CONTEXT","hasReferral":true}'
+    )
+  })
+
+  it(`should retrieve NO_ONBOARDING_PARTNER from non "onboarding_partner" campaigns`, async () => {
+    getInstallReferrer.mockResolvedValue({
+      installReferrer:
+        'utm_source=SOME_SOURCE&utm_content=SOME_CONTEXT&utm_campaign=ANOTHER_CAMPAIGN&anid=admob'
+    })
+
+    const onboardingPartner = await getOnboardingPartner()
+
+    expect(onboardingPartner.hasReferral).toBe(false)
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      strings.ONBOARDING_PARTNER_STORAGE_KEY,
+      '{"hasReferral":false}'
+    )
+  })
+
+  it(`should retrieve NO_ONBOARDING_PARTNER from classic install`, async () => {
+    getInstallReferrer.mockResolvedValue({
+      installReferrer: 'utm_source=google-play&utm_medium=organic'
+    })
+
+    const onboardingPartner = await getOnboardingPartner()
+
+    expect(onboardingPartner.hasReferral).toBe(false)
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      strings.ONBOARDING_PARTNER_STORAGE_KEY,
+      '{"hasReferral":false}'
+    )
+  })
+
+  it(`should retrieve NO_ONBOARDING_PARTNER if getInstallReferrer return null (in case of error)`, async () => {
+    getInstallReferrer.mockResolvedValue(null)
+
+    const onboardingPartner = await getOnboardingPartner()
+
+    expect(onboardingPartner.hasReferral).toBe(false)
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      strings.ONBOARDING_PARTNER_STORAGE_KEY,
+      '{"hasReferral":false}'
+    )
+  })
+
+  it(`should retrieve onboarding partner from AsyncStorage if any`, async () => {
+    AsyncStorage.getItem.mockResolvedValue(
+      '{"source":"SOME_PARTNER", "context":"SOME_CONTEXT"}'
+    )
+    getInstallReferrer.mockResolvedValue({
+      installReferrer: 'utm_source=google-play&utm_medium=organic'
+    })
+
+    const onboardingPartner = await getOnboardingPartner()
+
+    expect(getInstallReferrer).not.toHaveBeenCalled()
+    expect(onboardingPartner.source).toBe('SOME_PARTNER')
+    expect(onboardingPartner.context).toBe('SOME_CONTEXT')
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled()
+  })
+
+  it(`should handle AsyncStorage with wrong format`, async () => {
+    AsyncStorage.getItem.mockResolvedValue('SOME_BAD_FORMAT')
+    getInstallReferrer.mockResolvedValue({
+      installReferrer: 'utm_source=google-play&utm_medium=organic'
+    })
+
+    const onboardingPartner = await getOnboardingPartner()
+
+    expect(AsyncStorage.getItem).toHaveBeenCalled()
+    expect(getInstallReferrer).toHaveBeenCalled()
+    expect(onboardingPartner.hasReferral).toBe(false)
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      strings.ONBOARDING_PARTNER_STORAGE_KEY,
+      '{"hasReferral":false}'
+    )
+  })
+
+  it(`should return NO_ONBOARDING_PARTNER on iOS`, async () => {
+    Platform.OS = 'ios'
+    AsyncStorage.getItem.mockResolvedValue('SOME_PARTNER')
+    getInstallReferrer.mockResolvedValue({
+      installReferrer: 'utm_source=google-play&utm_medium=organic'
+    })
+
+    const onboardingPartner = await getOnboardingPartner()
+
+    expect(getInstallReferrer).not.toHaveBeenCalled()
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled()
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled()
+    expect(onboardingPartner.hasReferral).toBe(false)
+  })
+})

--- a/src/screens/welcome/install-referrer/onboardingPartner.ts
+++ b/src/screens/welcome/install-referrer/onboardingPartner.ts
@@ -1,0 +1,127 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Platform } from 'react-native'
+
+import Minilog from '@cozy/minilog'
+
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+import { getInstallReferrer } from '/screens/welcome/install-referrer/androidPlayInstallReferrer'
+
+import strings from '/constants/strings.json'
+
+const log = Minilog('Referral')
+
+const ONBOARDING_PARTNER_CAMPAIGN = 'onboarding_partner'
+
+export const NO_ONBOARDING_PARTNER = 'NO_ONBOARDING_PARTNER'
+
+interface NoOnboardingPartner {
+  hasReferral: false
+}
+
+interface WithOnboardingPartner {
+  source: string
+  context: string
+  hasReferral: true
+}
+
+export type OnboardingPartner = WithOnboardingPartner | NoOnboardingPartner
+
+const noOnboardingPartner = (): NoOnboardingPartner => ({ hasReferral: false })
+
+const extractOnboardingPartner = (
+  installReferrer: string
+): OnboardingPartner | null => {
+  const url = new URL(`https://cozy.io?${installReferrer}`)
+
+  const utmSource = url.searchParams.get('utm_source')
+  const utmCampaign = url.searchParams.get('utm_campaign')
+  const utmContent = url.searchParams.get('utm_content')
+
+  if (
+    utmCampaign === ONBOARDING_PARTNER_CAMPAIGN &&
+    utmSource !== null &&
+    utmContent !== null
+  ) {
+    return {
+      source: utmSource,
+      context: utmContent,
+      hasReferral: true
+    }
+  }
+
+  return null
+}
+
+const saveOnboardingPartnerOnAsyncStorage = async (
+  onboardingPartner: OnboardingPartner
+): Promise<void> => {
+  const serializedOnboardingPartner = JSON.stringify(onboardingPartner)
+  log.debug(
+    `saving onboardingPartner=${serializedOnboardingPartner} into AsyncStorage`
+  )
+  await AsyncStorage.setItem(
+    strings.ONBOARDING_PARTNER_STORAGE_KEY,
+    serializedOnboardingPartner
+  )
+}
+
+const getOnboardingPartnerFromAsyncStorage =
+  async (): Promise<OnboardingPartner | null> => {
+    log.debug('get onboardingPartner from AsyncStorage')
+
+    try {
+      const onboardingPartnerString = await AsyncStorage.getItem(
+        strings.ONBOARDING_PARTNER_STORAGE_KEY
+      )
+      log.debug(
+        `got onboardingPartner=${
+          onboardingPartnerString ?? ''
+        } from AsyncStorage`
+      )
+
+      const onboardingPartner = onboardingPartnerString
+        ? (JSON.parse(onboardingPartnerString) as OnboardingPartner)
+        : null
+
+      return onboardingPartner
+    } catch (error) {
+      const errorMessage = getErrorMessage(error)
+      log.error(
+        `Error while reading OnboardingPartner from async storage: ${errorMessage}`
+      )
+      return null
+    }
+  }
+
+const getOnboardingPartnerFromPlayStore =
+  async (): Promise<OnboardingPartner | null> => {
+    const installReferrerInfo = await getInstallReferrer()
+
+    if (!installReferrerInfo) {
+      return null
+    }
+
+    const onboardingPartner = extractOnboardingPartner(
+      installReferrerInfo.installReferrer
+    )
+
+    return onboardingPartner
+  }
+
+export const getOnboardingPartner = async (): Promise<OnboardingPartner> => {
+  if (Platform.OS !== 'android') return noOnboardingPartner()
+
+  const onboardingPartnerFromAsyncStorage =
+    await getOnboardingPartnerFromAsyncStorage()
+
+  if (onboardingPartnerFromAsyncStorage) {
+    return onboardingPartnerFromAsyncStorage
+  }
+
+  const onboardingPartnerFromPlayStore =
+    (await getOnboardingPartnerFromPlayStore()) ?? noOnboardingPartner()
+
+  await saveOnboardingPartnerOnAsyncStorage(onboardingPartnerFromPlayStore)
+
+  return onboardingPartnerFromPlayStore
+}

--- a/src/screens/welcome/install-referrer/useInstallReferrer.ts
+++ b/src/screens/welcome/install-referrer/useInstallReferrer.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+
+import { getOnboardingPartner, OnboardingPartner } from './onboardingPartner'
+
+export interface UseInitializationHook {
+  isInitialized: boolean
+  onboardingPartner: OnboardingPartner | undefined
+}
+
+export const useInstallReferrer = (): UseInitializationHook => {
+  const [onboardingPartner, setOnboardingPartner] = useState<
+    OnboardingPartner | undefined
+  >(undefined)
+
+  useEffect(function getReferral() {
+    void getOnboardingPartner().then(onboardingPartner => {
+      return setOnboardingPartner(onboardingPartner)
+    })
+  }, [])
+
+  return {
+    isInitialized: onboardingPartner != undefined,
+    onboardingPartner
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14829,6 +14829,11 @@ react-native-mask-input@1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-mask-input/-/react-native-mask-input-1.2.1.tgz#2f01683844ded3693d0d845bd1beeb2b8367f2e2"
   integrity sha512-OsVKhdJjljWIt373CPmsyTAjynlMpQKPkz3UQJ0Y48ZTVQa8zyejb9nmwoe15Zvi0uC49RxggDRACgkUxOjt3w==
 
+react-native-play-install-referrer@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/react-native-play-install-referrer/-/react-native-play-install-referrer-1.1.8.tgz#db9b7ab787be0af9a335c939cf0d165c91069fa9"
+  integrity sha512-g+LLv4Tkt3gWJ68OnhaBy25zYpP43OlLydL6siRjGAcl1fMc/DvfnNFWL4Oe1zrpwW4cmB0QGrKYtcbKnSGK3Q==
+
 react-native-safe-area-context@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz#9208313236e8f49e1920ac1e2a2c975f03aed284"


### PR DESCRIPTION
On App's first launch, we want to detect the installation context so we
can extract Onboarding Partner and display custom instructions to our
users

To do this we use Google Play Install Referrer API, and so it is
enabled only on Android phones

This PR only displays the raw OnboardingPartner info (if found)
Real screen implementation will be done later