### PR TITLE
Open app at onboarding end with email link

### DIFF
--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -32,7 +32,7 @@ declare module 'cozy-client' {
 
   interface InstanceOptions {
     capabilities: {
-      flat_subdomains: string
+      flat_subdomains: boolean
     }
   }
 

--- a/src/hooks/useAppBootstrap.functions.ts
+++ b/src/hooks/useAppBootstrap.functions.ts
@@ -6,6 +6,7 @@ const log = Minilog('useAppBootstrap.functions')
 
 interface OnboardingParams {
   onboardUrl: string | null
+  onboardedRedirection: string | null
   fqdn: string | null
 }
 
@@ -23,6 +24,9 @@ export const parseOnboardingURL = (
 
     const onboardingUrl = new URL(url)
     const onboardUrl = onboardingUrl.searchParams.get('onboard_url')
+    const onboardedRedirection = onboardingUrl.searchParams.get(
+      'onboarded_redirection'
+    )
     const fqdn = onboardingUrl.searchParams.get('fqdn')
 
     if (!onboardUrl && !fqdn) {
@@ -31,6 +35,7 @@ export const parseOnboardingURL = (
 
     return {
       onboardUrl,
+      onboardedRedirection,
       fqdn
     }
   } catch (error) {

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -13,6 +13,9 @@ import {
   parseOnboardingURL
 } from '/hooks/useAppBootstrap.functions'
 import { useSplashScreen } from '/hooks/useSplashScreen'
+import { formatOnboardingRedirection } from '/libs/functions/formatOnboardingRedirection'
+
+let OnboardingRedirection = ''
 
 export const useAppBootstrap = client => {
   const [initialRoute, setInitialRoute] = useState('fetching')
@@ -28,7 +31,11 @@ export const useAppBootstrap = client => {
         const onboardingParams = parseOnboardingURL(onboardingUrl)
 
         if (onboardingParams) {
-          const { onboardUrl, fqdn } = onboardingParams
+          const { onboardUrl, onboardedRedirection, fqdn } = onboardingParams
+
+          if (onboardedRedirection) {
+            OnboardingRedirection = onboardedRedirection
+          }
 
           if (onboardUrl) {
             return setInitialRoute({
@@ -50,6 +57,20 @@ export const useAppBootstrap = client => {
             route: routes.welcome
           })
         }
+      } else if (OnboardingRedirection) {
+        const onboardingRedirectionURL = formatOnboardingRedirection(
+          OnboardingRedirection,
+          client
+        )
+
+        OnboardingRedirection = ''
+
+        return setInitialRoute({
+          route: routes.home,
+          params: {
+            cozyAppFallbackURL: onboardingRedirectionURL
+          }
+        })
       } else {
         const payload = await Linking.getInitialURL()
         const { mainAppFallbackURL, cozyAppFallbackURL } =
@@ -91,7 +112,11 @@ export const useAppBootstrap = client => {
       const onboardingParams = parseOnboardingURL(url)
 
       if (onboardingParams) {
-        const { onboardUrl, fqdn } = onboardingParams
+        const { onboardUrl, onboardedRedirection, fqdn } = onboardingParams
+
+        if (onboardedRedirection && !client) {
+          OnboardingRedirection = onboardedRedirection
+        }
 
         if (onboardUrl) {
           navigate(routes.instanceCreation, { onboardUrl })

--- a/src/libs/functions/formatOnboardingRedirection.spec.ts
+++ b/src/libs/functions/formatOnboardingRedirection.spec.ts
@@ -1,0 +1,23 @@
+import CozyClient from 'cozy-client'
+import { formatOnboardingRedirection } from './formatOnboardingRedirection'
+
+describe('formatOnboardingRedirection', () => {
+  const client = {
+    getStackClient: (): { uri: string } => ({ uri: 'http://mycozy.test' }),
+    getInstanceOptions: (): { capabilities: { flat_subdomains: boolean } } => ({
+      capabilities: { flat_subdomains: false }
+    })
+  } as CozyClient
+
+  it('should format onboarding redirection', () => {
+    expect(
+      formatOnboardingRedirection('contacts/#/hash', client)
+    ).toStrictEqual('http://contacts.mycozy.test/#/hash')
+  })
+
+  it('should format onboarding redirection', () => {
+    expect(
+      formatOnboardingRedirection('contacts/path/#/hash', client)
+    ).toStrictEqual('http://contacts.mycozy.test/path/#/hash')
+  })
+})

--- a/src/libs/functions/formatOnboardingRedirection.ts
+++ b/src/libs/functions/formatOnboardingRedirection.ts
@@ -1,0 +1,25 @@
+import CozyClient, {
+  generateWebLink,
+  deconstructRedirectLink
+} from 'cozy-client'
+
+export const formatOnboardingRedirection = (
+  onboardingRedirection: string,
+  client: CozyClient
+): string => {
+  const cozyUrl = client.getStackClient().uri
+  const subDomainType = client.getInstanceOptions().capabilities.flat_subdomains
+    ? 'flat'
+    : 'nested'
+
+  const { slug, path, hash } = deconstructRedirectLink(onboardingRedirection)
+
+  return generateWebLink({
+    cozyUrl,
+    subDomainType,
+    slug,
+    pathname: path,
+    hash,
+    searchParams: []
+  })
+}


### PR DESCRIPTION
**End goal** : be able to open a specific app at the end of the onboarding.

The way to get the _onboarded_redirection_ is not sure for the moment. So it is a first possibility based on the onboarding email, which will be useful for testing purpose anyway.

**About the code**

~~I am not very happy about the result especially because I added code in a lot of different places. Feel free to challenge it. What do you think about the onboardingRedirection state used to pass the redirection between onboarding and the useAppBoostrap hook for example?~~

**How to test**
 - Encode your onboarded_redirection param like _drive/#/_ (root of Cozy Drive app) => _drive%2F%23%2F_
 - Encode your email in the onboard_url param like _oib35043@zslsz.com_ => _oib35043%40zslsz.com_
 - Forge the link and open it with adb or xcrun `adb shell am start -W -a android.intent.action.VIEW -d 'cozy://onboarding?flagship=true\&onboarded_redirection=drive%2F%23%2F\&onboard_url=https%3A%2F%2Fmanager.cozycloud.cc%2Fv2%2Fcozy%2Fonboard%3Femail%3Doib35043%40zslsz.com%26skip_email_step%3Dtrue'` (for Android, [you need to add a backslash to escape '&' for search params](https://stackoverflow.com/a/44782797))
 - Follow the onboarding
 - Check that you are correctly redirected to your onboarded_redirection
 
**Remaining**
 - [x] test on iOS
 - [x] add documentation about how to test in "Scénario de tests"