### PR TITLE
feat: add shell script to reset Android env

### DIFF
--- a/scripts/reset-android.sh
+++ b/scripts/reset-android.sh
@@ -1,6 +1,7 @@
 rm -rf $HOME/.gradle/caches/
 cd android && ./gradlew clean && ./gradlew cleanBuildCache
 rm -rf app/src/main/assets/cozy-home
+rm -rf app/build
 cd ..
 rm -rf node_modules
 yarn cache clean --force

--- a/scripts/reset-android.sh
+++ b/scripts/reset-android.sh
@@ -1,0 +1,7 @@
+rm -rf $HOME/.gradle/caches/
+cd android && ./gradlew clean && ./gradlew cleanBuildCache
+rm -rf app/src/main/assets/cozy-home
+cd ..
+rm -rf node_modules
+yarn cache clean --force
+yarn install


### PR DESCRIPTION
This will erase everything gradle/npm/yarn,
and reinstall node modules.
But not gradle files.

You have to chmod +x the file before using it