### PR TITLE
feat: Patch rnfs to handle 303 http code on download

### DIFF
--- a/patches/react-native-fs+2.20.0.patch
+++ b/patches/react-native-fs+2.20.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/react-native-fs/android/src/main/java/com/rnfs/Downloader.java b/node_modules/react-native-fs/android/src/main/java/com/rnfs/Downloader.java
+index 4da698e..3dbe830 100644
+--- a/node_modules/react-native-fs/android/src/main/java/com/rnfs/Downloader.java
++++ b/node_modules/react-native-fs/android/src/main/java/com/rnfs/Downloader.java
+@@ -67,6 +67,7 @@ public class Downloader extends AsyncTask<DownloadParams, long[], DownloadResult
+         (
+           statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
+           statusCode == HttpURLConnection.HTTP_MOVED_TEMP ||
++          statusCode == HttpURLConnection.HTTP_SEE_OTHER ||
+           statusCode == 307 ||
+           statusCode == 308
+         )


### PR DESCRIPTION
This patch will handle 303 response on download when using the local stack with a http url and not https.

An issue has been created on the react-native-fs : https://github.com/itinance/react-native-fs/pull/1153

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

