### PR TITLE
fix: Keep embedded folder on cozyAppBundle update

### DIFF
--- a/src/libs/cozyAppBundle/cozyAppBundle.functions.ts
+++ b/src/libs/cozyAppBundle/cozyAppBundle.functions.ts
@@ -73,7 +73,7 @@ export const handleCleanup = async ({
     )
 
   for (const dir of dirs) {
-    if (!versionsToKeep.includes(dir.name))
+    if (!versionsToKeep.includes(dir.name) && dir.name !== 'embedded')
       await RNFS.unlink(`${path}/${dir.name}`)
   }
 }


### PR DESCRIPTION
On #525 we added bundle cleanup feature to remove all previous bundle
versions

This introduced a bug as the initial bundle is stored in "embedded"
folder which is not named after the version (i.e 1.50.0)

To prevent this, chose to never delete the "embedded" folder.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

