### PR TITLE
feat: remove placeholder text

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -200,11 +200,7 @@ class LauncherView extends Component {
               />
             </View>
           </>
-        ) : (
-          <View>
-            <Text>Loading...</Text>
-          </View>
-        )}
+        ) : null}
       </>
     )
   }


### PR DESCRIPTION
Just display an empty view instead.
The "loading" text was clashing with the backdrop overlay and created a visual artifact.
You can see the bug it created on the following image:
![image](https://user-images.githubusercontent.com/12577784/223137766-9cdcf3ea-476e-4d93-964a-b26ddfe60128.png)
