### PR TITLE
feat: Bump app version to 1.0.4

### DIFF
--- a/.github/workflows/build-android-dev.yml
+++ b/.github/workflows/build-android-dev.yml
@@ -74,7 +74,7 @@ jobs:
           ANDROID_SAFETY_NET_API_KEY: ${{ secrets.ANDROID_SAFETY_NET_API_KEY }}
 
       - name: Sign Dev APK
-        id: sign_app
+        id: sign_app_dev
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: android/app/build/outputs/apk/dev/release
@@ -91,7 +91,7 @@ jobs:
             android/app/build/outputs/apk/dev/release/*-signed.apk
 
       - name: Sign Prod APK
-        id: sign_app
+        id: sign_app_prod
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: android/app/build/outputs/apk/prod/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.4
+# 1.0.5
 
 ## ✨ Features
 
@@ -8,6 +8,30 @@
 
 ## 🔧 Tech
 
+
+# 1.0.4
+
+## ✨ Features
+
+* The App can now receive notifications from the user's Cozy ([PR #594](https://github.com/cozy/cozy-react-native/pull/594))
+
+## 🐛 Bug Fixes
+
+* Fix a bug that prevented Connectors to be opened from cozy-store ([PR #618](https://github.com/cozy/cozy-react-native/pull/618))
+* Canceling login step when executin a Client Side Connector doesn't block the connector anymore ([PR #607](https://github.com/cozy/cozy-react-native/pull/607), [PR #630](https://github.com/cozy/cozy-react-native/pull/630) and [PR #631](https://github.com/cozy/cozy-react-native/pull/631))
+
+## 🔧 Tech
+
+* Client Side Connectors execution duration is now limited to 15min ([PR #571](https://github.com/cozy/cozy-react-native/pull/571))
+* Use cache for fetch apps query ([PR #597](https://github.com/cozy/cozy-react-native/pull/597))
+* Fix ESLint warnings ([PR #602](https://github.com/cozy/cozy-react-native/pull/602))
+* Extract Client Side Connectors code into `cozy-clisk` library ([PR #599](https://github.com/cozy/cozy-react-native/pull/599) and [PR #621](https://github.com/cozy/cozy-react-native/pull/621))
+* Increase default `PBKDF2` iteration number to from `100000` to `650000` ([PR #606](https://github.com/cozy/cozy-react-native/pull/606))
+* Fix URL interception for Cozys with nested domain configuration ([PR #619](https://github.com/cozy/cozy-react-native/pull/619))
+* Remove dependency to cozy-ui ([PR #609](https://github.com/cozy/cozy-react-native/pull/609))
+* Use `cozy-tsconfig` for Typescript configuration ([PR #627](https://github.com/cozy/cozy-react-native/pull/627))
+* Homogenize `Konnector/Connector` naming convention by using only `Konnector` ([PR #617](https://github.com/cozy/cozy-react-native/pull/617))
+* Add foundations for OnboardingPartner context interception ([PR #632](https://github.com/cozy/cozy-react-native/pull/632))
 
 # 1.0.3
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100033
-        versionName "1.0.3"
+        versionCode 100040
+        versionName "1.0.4"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100030</string>
+	<string>0100040</string>
 	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
 	<true/>
 	<key>GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.0.4
- creates a new entry for next 1.0.5 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs