### PR TITLE
feat: Force stop the current job id if any on flagship app start

### DIFF
--- a/src/hooks/useKonnectors.ts
+++ b/src/hooks/useKonnectors.ts
@@ -7,7 +7,8 @@ import {
 } from '/redux/KonnectorState/KonnectorLogsSlice'
 import {
   selectCurrentKonnector,
-  setCurrentRunningKonnector
+  setCurrentRunningKonnector,
+  setCurrentRunningKonnectorJobId
 } from '/redux/KonnectorState/CurrentKonnectorSlice'
 import { sendKonnectorsLogs } from '/libs/konnectors/sendKonnectorsLogs'
 
@@ -16,6 +17,7 @@ export interface UseAddLogHook {
   currentRunningKonnector?: string
   processLogs: () => void
   setCurrentRunningKonnector: (slug: string) => void
+  setCurrentRunningKonnectorJobId: (jobId: string | undefined) => void
 }
 
 export const useKonnectors = (): UseAddLogHook => {
@@ -31,6 +33,12 @@ export const useKonnectors = (): UseAddLogHook => {
     dispatch(setCurrentRunningKonnector(slug))
   }
 
+  const doSetCurrentRunningKonnectorJobId = (
+    jobId: string | undefined
+  ): void => {
+    dispatch(setCurrentRunningKonnectorJobId(jobId))
+  }
+
   const doProcessLogs = (): void => {
     if (!client) return
     void sendKonnectorsLogs(client)
@@ -40,6 +48,7 @@ export const useKonnectors = (): UseAddLogHook => {
     addLog: doAddLog,
     currentRunningKonnector,
     processLogs: doProcessLogs,
-    setCurrentRunningKonnector: doSetCurrentRunningKonnector
+    setCurrentRunningKonnector: doSetCurrentRunningKonnector,
+    setCurrentRunningKonnectorJobId: doSetCurrentRunningKonnectorJobId
   }
 }

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -1,7 +1,6 @@
 // @ts-check
 /* eslint-disable no-unused-vars */
 import Minilog from '@cozy/minilog'
-import get from 'lodash/get'
 import set from 'lodash/set'
 
 import { Q, models } from 'cozy-client'

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -13,6 +13,8 @@ import { dataURItoArrayBuffer } from './utils'
 
 const log = Minilog('Launcher')
 
+export const TIMEOUT_KONNECTOR_ERROR = 'context deadline exceeded'
+
 /**
  * All launchers are supposed to implement this interface
  *

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -120,6 +120,7 @@ class ReactNativeLauncher extends Launcher {
     } else {
       await this.updateJobResult()
     }
+    this.emit('STOPPED_JOB')
     this.close()
   }
 
@@ -155,6 +156,9 @@ class ReactNativeLauncher extends Launcher {
       if (ensureResult.createdAccount) {
         this.emit('CREATED_ACCOUNT', ensureResult.createdAccount)
       }
+      if (ensureResult.createdJob) {
+        this.emit('CREATED_JOB', ensureResult.createdJob)
+      }
       await this.sendLoginSuccess()
 
       const pilotContext = []
@@ -171,6 +175,9 @@ class ReactNativeLauncher extends Launcher {
       const ensureResult = await this.ensureAccountTriggerAndLaunch()
       if (ensureResult.createdAccount) {
         this.emit('CREATED_ACCOUNT', ensureResult.createdAccount)
+      }
+      if (ensureResult.createdJob) {
+        this.emit('CREATED_JOB', ensureResult.createdJob)
       }
       await this.stop({ message: err.message })
     }

--- a/src/libs/konnectors/stopKonnectorJob.ts
+++ b/src/libs/konnectors/stopKonnectorJob.ts
@@ -1,6 +1,6 @@
 import Minilog from '@cozy/minilog'
 
-import CozyClient from 'cozy-client'
+import CozyClient, { Q } from 'cozy-client'
 
 import { TIMEOUT_KONNECTOR_ERROR } from '/libs/Launcher'
 
@@ -11,19 +11,51 @@ export const stopKonnectorJob = async (
   jobId: string
 ): Promise<void> => {
   try {
-    await client.save({
-      _type: 'io.cozy.jobs',
-      _id: jobId,
-      _rev: true, // to force an update on Job collection
-      worker: 'client',
-      attributes: {
-        state: 'errored',
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        error: TIMEOUT_KONNECTOR_ERROR
-      }
-    })
+    await stopJob(client, jobId)
+    await findJobStopTriggerAndRemove(client, jobId)
   } catch (e) {
     log.error('Error while trying to stop job ${jobId}')
     log.error(e)
+  }
+}
+
+/**
+ * Mark the given job as "context deadline exceeded"
+ */
+const stopJob = (client: CozyClient, jobId: string): Promise<unknown> => {
+  return client.save({
+    _type: 'io.cozy.jobs',
+    _id: jobId,
+    _rev: true, // to force an update on Job collection
+    worker: 'client',
+    attributes: {
+      state: 'errored',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      error: TIMEOUT_KONNECTOR_ERROR
+    }
+  })
+}
+
+/**
+ * Remove the @at trigger which will mark the given job as context deadline exceeded since this work is already done
+ */
+const findJobStopTriggerAndRemove = async (
+  client: CozyClient,
+  jobId: string
+): Promise<void> => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const { data: triggers } = await client.query(
+    Q('io.cozy.triggers').where({
+      worker: 'service',
+      type: '@at',
+      'message.fields.cliskJobId': jobId
+    })
+  )
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (triggers.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+    await client.destroy(triggers[0])
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
+    log.info(`Removed a job stop trigger : ${triggers[0]._id}`)
   }
 }

--- a/src/libs/konnectors/stopKonnectorJob.ts
+++ b/src/libs/konnectors/stopKonnectorJob.ts
@@ -1,0 +1,29 @@
+import Minilog from '@cozy/minilog'
+
+import CozyClient from 'cozy-client'
+
+import { TIMEOUT_KONNECTOR_ERROR } from '/libs/Launcher'
+
+const log = Minilog('stopKonnectorJob')
+
+export const stopKonnectorJob = async (
+  client: CozyClient,
+  jobId: string
+): Promise<void> => {
+  try {
+    await client.save({
+      _type: 'io.cozy.jobs',
+      _id: jobId,
+      _rev: true, // to force an update on Job collection
+      worker: 'client',
+      attributes: {
+        state: 'errored',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        error: TIMEOUT_KONNECTOR_ERROR
+      }
+    })
+  } catch (e) {
+    log.error('Error while trying to stop job ${jobId}')
+    log.error(e)
+  }
+}

--- a/src/redux/KonnectorState/CurrentKonnectorSlice.ts
+++ b/src/redux/KonnectorState/CurrentKonnectorSlice.ts
@@ -4,10 +4,12 @@ import type { RootState } from '/redux/store'
 
 export interface CurrentKonnectorState {
   currentRunningKonnector?: string
+  currentRunningKonnectorJobId?: string
 }
 
 const initialState: CurrentKonnectorState = {
-  currentRunningKonnector: undefined
+  currentRunningKonnector: undefined,
+  currentRunningKonnectorJobId: undefined
 }
 
 export const currentKonnectorSlice = createSlice({
@@ -19,11 +21,18 @@ export const currentKonnectorSlice = createSlice({
       action: PayloadAction<string | undefined>
     ) => {
       state.currentRunningKonnector = action.payload
+    },
+    setCurrentRunningKonnectorJobId: (
+      state,
+      action: PayloadAction<string | undefined>
+    ) => {
+      state.currentRunningKonnectorJobId = action.payload
     }
   }
 })
 
-export const { setCurrentRunningKonnector } = currentKonnectorSlice.actions
+export const { setCurrentRunningKonnector, setCurrentRunningKonnectorJobId } =
+  currentKonnectorSlice.actions
 
 export const selectCurrentKonnector = (
   state: RootState

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -29,6 +29,7 @@ export const HomeScreen = ({
     launcherClient,
     launcherContext,
     onKonnectorLog,
+    onKonnectorJobUpdate,
     resetLauncherContext,
     setLauncherContext,
     trySetLauncherContext
@@ -52,6 +53,7 @@ export const HomeScreen = ({
           retry={resetLauncherContext}
           setLauncherContext={setLauncherContext}
           onKonnectorLog={onKonnectorLog}
+          onKonnectorJobUpdate={onKonnectorJobUpdate}
         />
       )}
 

--- a/src/screens/home/hooks/useLauncherContext.tsx
+++ b/src/screens/home/hooks/useLauncherContext.tsx
@@ -19,6 +19,7 @@ interface useLauncherContextReturn {
   launcherClient?: CozyClient
   launcherContext: LauncherContext
   onKonnectorLog: (logObj: LogObj) => void
+  onKonnectorJobUpdate: (jobId: string | undefined) => void
   resetLauncherContext: () => void
   setConcurrentKonnector: (konnectorSlug?: string) => void
   setLauncherContext: (candidateContext: LauncherContext) => void
@@ -32,7 +33,7 @@ export const useLauncherContext = (): useLauncherContextReturn => {
   const { canDisplayLauncher, launcherClient } =
     useLauncherWrapper(launcherContext)
   const [concurrentKonnector, setConcurrentKonnector] = useState<string>()
-  const { addLog } = useKonnectors()
+  const { addLog, setCurrentRunningKonnectorJobId } = useKonnectors()
 
   const onKonnectorLog = (logObj: LogObj): void => {
     const level = logObj.level
@@ -41,6 +42,10 @@ export const useLauncherContext = (): useLauncherContextReturn => {
       konnLog[key](`${logObj.slug}: ${logObj.msg}`)
     }
     addLog(logObj)
+  }
+
+  const onKonnectorJobUpdate = (jobId: string | undefined): void => {
+    setCurrentRunningKonnectorJobId(jobId)
   }
 
   const trySetLauncherContext = (candidateContext: LauncherContext): void => {
@@ -71,6 +76,7 @@ export const useLauncherContext = (): useLauncherContextReturn => {
     setConcurrentKonnector,
     setLauncherContext,
     trySetLauncherContext,
-    onKonnectorLog
+    onKonnectorLog,
+    onKonnectorJobUpdate
   }
 }

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -18,6 +18,7 @@ import {
   stopTimeout
 } from '/screens/konnectors/core/handleTimeout'
 import { navigate } from '/libs/RootNavigation'
+import { TIMEOUT_KONNECTOR_ERROR } from '/libs/Launcher'
 
 const log = Minilog('LauncherView')
 
@@ -119,7 +120,7 @@ class LauncherView extends Component {
     }
 
     startTimeout(() => {
-      this.launcher.stop({ message: 'context deadline exceeded' })
+      this.launcher.stop({ message: TIMEOUT_KONNECTOR_ERROR })
       this.props.setLauncherContext({ state: 'default' })
     })
 

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -34,6 +34,8 @@ class LauncherView extends Component {
     this.onWorkerMessage = this.onWorkerMessage.bind(this)
     this.onStopExecution = this.onStopExecution.bind(this)
     this.onCreatedAccount = this.onCreatedAccount.bind(this)
+    this.onCreatedJob = this.onCreatedJob.bind(this)
+    this.onStoppedJob = this.onStoppedJob.bind(this)
     this.onWorkerWillReload = debounce(this.onWorkerWillReload.bind(this), 1000)
     this.pilotWebView = null
     this.workerWebview = null
@@ -48,6 +50,14 @@ class LauncherView extends Component {
   onStopExecution() {
     this.launcher.stop({ message: 'stopped by user' })
     this.props.setLauncherContext({ state: 'default' })
+  }
+
+  onCreatedJob(job) {
+    this.props.onKonnectorJobUpdate(job._id)
+  }
+
+  onStoppedJob() {
+    this.props.onKonnectorJobUpdate()
   }
 
   onCreatedAccount(account) {
@@ -108,6 +118,8 @@ class LauncherView extends Component {
       this.setState({ workerReady: true })
     })
     this.launcher.on('CREATED_ACCOUNT', this.onCreatedAccount)
+    this.launcher.on('CREATED_JOB', this.onCreatedJob)
+    this.launcher.on('STOPPED_JOB', this.onStoppedJob)
 
     if (this.state.konnector) {
       await this.launcher.init({

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -47,21 +47,33 @@ class LauncherView extends Component {
     }
   }
 
+  /**
+   * Run when the job is stopped by the user
+   */
   onStopExecution() {
     this.launcher.stop({ message: 'stopped by user' })
     this.props.setLauncherContext({ state: 'default' })
   }
 
+  /**
+   * Run when a job is created by the launcher. Update the current job id in the redux store.
+   */
   onCreatedJob(job) {
     this.props.onKonnectorJobUpdate(job._id)
   }
 
+  /**
+   * Run when a job is normally stopped. Remove the current job id from the redux store.
+   */
   onStoppedJob() {
     this.props.onKonnectorJobUpdate()
   }
 
+  /**
+   * Run when an account is created by the flagship app
+   * make the webview navigate to the the harvest route associated to the account
+   */
   onCreatedAccount(account) {
-    // make the webview navigate to the the harvest route associated to the account
     const { launcherContext } = this.props
     const konnector = launcherContext.konnector.slug
     navigate('default', { konnector, account: account._id })


### PR DESCRIPTION
The current job id is saves in the redux store when the job is stated by the flagship app and removed on the end of the clisk konnector execution.

If the job id is still in redux store when reloading the flagship app, it means that the flagship app failed while running the clisk konnector job. The flagship app then mark the current job as "context deadline exceeded" which is the error code for timeout job error on cozy stack.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

