### PR TITLE
feat: Wait for CozyApp to be loaded before loading HomeView if DeepLink

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import { CreateInstanceScreen } from '/screens/login/CreateInstanceScreen'
 import { CryptoWebView } from '/components/webviews/CryptoWebView/CryptoWebView'
 import { ErrorScreen } from '/screens/error/ErrorScreen'
 import { HomeScreen } from '/screens/home/HomeScreen'
+import { HomeStateProvider } from '/screens/home/HomeStateProvider'
 import { HttpServerProvider } from '/libs/httpserver/httpServerProvider'
 import { LockScreen } from '/screens/lock/LockScreen'
 import { LoginScreen } from '/screens/login/LoginScreen'
@@ -218,11 +219,13 @@ const Wrapper = () => {
         <Provider store={store}>
           <PersistGate loading={null} persistor={persistor}>
             <HttpServerProvider>
-              <SplashScreenProvider>
-                <NetStatusBoundary>
-                  <WrappedApp />
-                </NetStatusBoundary>
-              </SplashScreenProvider>
+              <HomeStateProvider>
+                <SplashScreenProvider>
+                  <NetStatusBoundary>
+                    <WrappedApp />
+                  </NetStatusBoundary>
+                </SplashScreenProvider>
+              </HomeStateProvider>
             </HttpServerProvider>
           </PersistGate>
         </Provider>

--- a/src/screens/cozy-app/CozyAppScreen.js
+++ b/src/screens/cozy-app/CozyAppScreen.js
@@ -14,6 +14,7 @@ import { useDimensions } from '/libs/dimensions'
 import { internalMethods } from '../../libs/intents/localMethods'
 
 import { routes } from '/constants/routes'
+import { useHomeStateContext } from '/screens/home/HomeStateProvider'
 
 const firstHalfUI = () =>
   internalMethods.setFlagshipUI({
@@ -44,6 +45,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
   const [isReady, setReady] = useState(false)
   const [isFirstHalf, setFirstHalf] = useState(false)
   const [shouldExitAnimation, setShouldExitAnimation] = useState(false)
+  const { setShouldWaitCozyApp } = useHomeStateContext()
 
   useEffect(() => {
     flagshipUI.on('change', state => {
@@ -66,7 +68,8 @@ export const CozyAppScreen = ({ route, navigation }) => {
 
   const onLoadEnd = useCallback(() => {
     setShouldExitAnimation(true)
-  }, [])
+    setShouldWaitCozyApp(false)
+  }, [setShouldWaitCozyApp])
 
   const webViewStyle = useMemo(
     () => ({ ...styles[isFirstHalf ? 'ready' : 'notReady'] }),

--- a/src/screens/home/HomeStateProvider.js
+++ b/src/screens/home/HomeStateProvider.js
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState } from 'react'
+
+export const HomeStateContext = createContext(undefined)
+
+export const useHomeStateContext = () => {
+  const homeStateContext = useContext(HomeStateContext)
+
+  return homeStateContext
+}
+
+export const HomeStateProvider = props => {
+  const [shouldWaitCozyApp, setShouldWaitCozyApp] = useState(undefined)
+
+  return (
+    <HomeStateContext.Provider
+      value={{
+        shouldWaitCozyApp,
+        setShouldWaitCozyApp
+      }}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
When opening the app from a deep link that target a CozyApp, the current implementation start loading the HomeView and the CozyAppScreen simultaneously

This is not optimal as we want to display CozyAppScreen as fast as possible. The HomeView only needs to be loaded when the user clicks on the Home button or the Back button

So we want to start loading the HomeView only after the CozyAppScreen finished loading