### PR TITLE
fix: Await for setCurrentAppVersionForFqdnAndSlug in updateCozyAppBundle

### DIFF
--- a/src/libs/cozyAppBundle/cozyAppBundle.ts
+++ b/src/libs/cozyAppBundle/cozyAppBundle.ts
@@ -116,7 +116,7 @@ export const updateCozyAppBundle = async ({
     version: stackVersion
   })
 
-  void setCurrentAppVersionForFqdnAndSlug({
+  await setCurrentAppVersionForFqdnAndSlug({
     folder: stackVersion + tarPrefix,
     fqdn,
     slug,


### PR DESCRIPTION
In `updateCozyAppBundle`, `setCurrentAppVersionForFqdnAndSlug` is responsible for storing the newly downloaded cozy-app's version into the device's asyncStorage
 
In the first implementation of `updateCozyAppBundle`, we didn't await for `setCurrentAppVersionForFqdnAndSlug` to be executed as it was the method's last instruction and because we didn't need to read the value from asyncStorage until the next app's cold start. This method was used to handle cozy-apps only

In #525 we started using this method for Client Side Connectors and we needed to read the new value from asyncStorage just after the `updateCozyAppBundle` call

The side effect is that `setCurrentAppVersionForFqdnAndSlug` is in a race condition with `ReactNativeLauncher.getKonnectorBundle()` call that happens just after

So we now want to await for `setCurrentAppVersionForFqdnAndSlug`