### PR TITLE
Context for ccc

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -209,15 +209,8 @@ export default class Launcher {
   async ensureAccountTriggerAndLaunch() {
     const result = {}
     const startContext = this.getStartContext()
-    let {
-      trigger,
-      account,
-      konnector,
-      client,
-      job,
-      launcherClient,
-      ...restOfContext
-    } = startContext
+    let { trigger, account, konnector, client, job, ...restOfContext } =
+      startContext
 
     if (!account) {
       log.debug(
@@ -267,7 +260,6 @@ export default class Launcher {
       trigger,
       job,
       konnector,
-      launcherClient,
       ...restOfContext
     })
     return result

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -474,6 +474,7 @@ export default class Launcher {
  * @property {import('cozy-client/types/types').CozyClientDocument}       job
  * @property {import('cozy-client/types/types').IOCozyKonnector} konnector
  * @property {import('cozy-client/types/types').IOCozyTrigger} [timeoutTrigger]
+ * @property {import('cozy-client/types/types').Manifest} manifest
  */
 
 /**

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -142,6 +142,9 @@ export default class Launcher {
    */
   async getCredentials() {
     const { account } = this.getStartContext()
+    if (!account) {
+      return null
+    }
     const encAccount = await getCredential(account)
     return encAccount ? encAccount.auth : null
   }

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -206,8 +206,15 @@ export default class Launcher {
   async ensureAccountTriggerAndLaunch() {
     const result = {}
     const startContext = this.getStartContext()
-    let { trigger, account, konnector, client, job, launcherClient } =
-      startContext
+    let {
+      trigger,
+      account,
+      konnector,
+      client,
+      job,
+      launcherClient,
+      ...restOfContext
+    } = startContext
 
     if (!account) {
       log.debug(
@@ -251,14 +258,14 @@ export default class Launcher {
       result.createdJob = job
     }
     log.debug(`ensureAccountAndTriggerAndJob: launched job`, job)
-
     this.setStartContext({
       client,
       account,
       trigger,
       job,
       konnector,
-      launcherClient
+      launcherClient,
+      ...restOfContext
     })
     return result
   }

--- a/src/libs/Launcher.spec.js
+++ b/src/libs/Launcher.spec.js
@@ -1,0 +1,36 @@
+import Launcher from './Launcher'
+
+jest.mock('./folder')
+
+describe('Launcher', () => {
+  describe('ensureAccountTriggerAndLaunch', () => {
+    it('should not remove startContext attributes', async () => {
+      const launcher = new Launcher()
+      const account = {
+        _id: 'testaccount'
+      }
+      const trigger = { _id: 'testtrigger' }
+      const job = { _id: 'testjob' }
+      const client = {}
+      const konnector = {}
+      launcher.ensureAccountName = jest.fn().mockResolvedValue(account)
+      launcher.setStartContext({
+        client,
+        konnector,
+        account,
+        trigger,
+        job,
+        manifest: { name: 'konnector' }
+      })
+      await launcher.ensureAccountTriggerAndLaunch()
+      expect(launcher.getStartContext()).toStrictEqual({
+        account,
+        trigger,
+        job,
+        client,
+        konnector,
+        manifest: { name: 'konnector' }
+      })
+    })
+  })
+})


### PR DESCRIPTION
With @Ldoppea , we find a bug with the recent update regarding the account creation.
In this PR we fix it by giving the rest of the context in addition to the destructurate variables from the startContext.
We spot that an account is needed to save the user's credentials, so it add a little condition returning null if no accounts are present in the startContext at the time getCredentials is called.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

