### PR TITLE
Feat/open cozy app at flagship opening

### DIFF
--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -5,6 +5,7 @@
   "COZY_SCHEME": "cozy://",
   "OAUTH_STORAGE_KEY": "@cozy_AmiralAppOAuthConfig",
   "ONBOARDING_PARTNER_STORAGE_KEY": "@cozy_AmiralAppOnboardingPartnerConfig",
+  "DEFAULT_REDIRECTION_URL_STORAGE_KEY": "@cozy_AmiralAppDefaultRedirectionUrl",
   "REDIRECT": "redirect",
   "SESSION_CODE": "session_code",
   "SESSION_CREATED_FLAG": "@cozy_AmiralAppSessionCreated",

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -14,7 +14,10 @@ import {
 } from '/hooks/useAppBootstrap.functions'
 import { useSplashScreen } from '/hooks/useSplashScreen'
 import { formatRedirectLink } from '/libs/functions/formatRedirectLink'
-import { getOrFetchDefaultRedirectionUrl } from '/libs/defaultRedirection/defaultRedirection'
+import {
+  getOrFetchDefaultRedirectionUrl,
+  getParamsWithDefaultRedirectionUrl
+} from '/libs/defaultRedirection/defaultRedirection'
 
 let OnboardingRedirection = ''
 
@@ -90,10 +93,7 @@ export const useAppBootstrap = client => {
 
         return setInitialRoute({
           route: routes.home,
-          params: {
-            mainAppFallbackURL: undefined,
-            cozyAppFallbackURL: defaultRedirectUrl
-          }
+          params: getParamsWithDefaultRedirectionUrl(defaultRedirectUrl, client)
         })
       }
     }

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -14,6 +14,7 @@ import {
 } from '/hooks/useAppBootstrap.functions'
 import { useSplashScreen } from '/hooks/useSplashScreen'
 import { formatOnboardingRedirection } from '/libs/functions/formatOnboardingRedirection'
+import { getOrFetchDefaultRedirectionUrl } from '/libs/defaultRedirection/defaultRedirection'
 
 let OnboardingRedirection = ''
 
@@ -75,12 +76,23 @@ export const useAppBootstrap = client => {
         const payload = await Linking.getInitialURL()
         const { mainAppFallbackURL, cozyAppFallbackURL } =
           parseFallbackURL(payload)
+        if (mainAppFallbackURL || cozyAppFallbackURL) {
+          return setInitialRoute({
+            route: routes.home,
+            params: {
+              mainAppFallbackURL,
+              cozyAppFallbackURL
+            }
+          })
+        }
+
+        const defaultRedirectUrl = await getOrFetchDefaultRedirectionUrl(client)
 
         return setInitialRoute({
           route: routes.home,
           params: {
-            mainAppFallbackURL,
-            cozyAppFallbackURL
+            mainAppFallbackURL: undefined,
+            cozyAppFallbackURL: defaultRedirectUrl
           }
         })
       }

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -13,7 +13,7 @@ import {
   parseOnboardingURL
 } from '/hooks/useAppBootstrap.functions'
 import { useSplashScreen } from '/hooks/useSplashScreen'
-import { formatOnboardingRedirection } from '/libs/functions/formatOnboardingRedirection'
+import { formatRedirectLink } from '/libs/functions/formatRedirectLink'
 import { getOrFetchDefaultRedirectionUrl } from '/libs/defaultRedirection/defaultRedirection'
 
 let OnboardingRedirection = ''
@@ -59,7 +59,7 @@ export const useAppBootstrap = client => {
           })
         }
       } else if (OnboardingRedirection) {
-        const onboardingRedirectionURL = formatOnboardingRedirection(
+        const onboardingRedirectionURL = formatRedirectLink(
           OnboardingRedirection,
           client
         )

--- a/src/hooks/useAppBootstrap.spec.js
+++ b/src/hooks/useAppBootstrap.spec.js
@@ -24,6 +24,7 @@ const APP_FALLBACK_URL_ENCODED = `https%3A%2F%2Fclaude-drive.mycozy.cloud%2F%23%
 const APP_UNIVERSAL_LINK = `https://links.mycozy.cloud/flagship/drive/folder/SOME_FOLDER_ID?fallback=${APP_FALLBACK_URL_ENCODED}`
 const APP_ANDROID_SCHEME = `cozy://drive/folder/SOME_FOLDER_ID?fallback=${APP_FALLBACK_URL_ENCODED}`
 const INVALID_LINK = 'https://foo.com'
+const REDIRECTION_URL = 'http://drive.mycozy.test/#/folder'
 
 jest.mock('../libs/client', () => ({
   clearClient: jest.fn()
@@ -50,13 +51,18 @@ jest.mock('/libs/functions/openApp', () => ({
   getDefaultIconParams: jest.fn().mockReturnValue({})
 }))
 
-jest.mock('/libs/defaultRedirection/defaultRedirection')
+jest.mock('/libs/defaultRedirection/defaultRedirection', () => ({
+  ...jest.requireActual('/libs/defaultRedirection/defaultRedirection'),
+  getOrFetchDefaultRedirectionUrl: jest.fn()
+}))
 
 jest.mock('cozy-client', () => ({
   deconstructCozyWebLinkWithSlug: jest.fn().mockImplementation(url => {
     if (url === HOME_FALLBACK_URL) {
       return { slug: 'home' }
     } else if (url === APP_FALLBACK_URL) {
+      return { slug: 'drive' }
+    } else if (url === REDIRECTION_URL) {
       return { slug: 'drive' }
     } else {
       throw new Error('Should not happen')
@@ -446,8 +452,6 @@ it('Should handle WITH lifecycle URL as INVALID', async () => {
 })
 
 it('Should handle WITH client WITH redirect URL', async () => {
-  const REDIRECTION_URL = 'http://drive.mycozy.test/#/folder'
-
   getOrFetchDefaultRedirectionUrl.mockReturnValue(REDIRECTION_URL)
 
   const { result, waitForValueToChange } = renderHook(() =>

--- a/src/libs/defaultRedirection/defaultRedirection.spec.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.spec.ts
@@ -8,13 +8,13 @@ import {
   NAVIGATION_APP_SLUG,
   DEFAULT_REDIRECTION_DELAY_IN_MS,
   InstanceSettings,
-  isDefaultRedirectionUrlNavigationApp,
   fetchDefaultRedirectionUrl,
   setDefaultRedirectionUrl,
   getDefaultRedirectionUrl,
   fetchAndSetDefaultRedirectionUrl,
   fetchAndSetDefaultRedirectionUrlInBackground,
-  getOrFetchDefaultRedirectionUrl
+  getOrFetchDefaultRedirectionUrl,
+  getParamsWithDefaultRedirectionUrl
 } from '/libs/defaultRedirection/defaultRedirection'
 import { formatRedirectLink } from '/libs/functions/formatRedirectLink'
 
@@ -25,30 +25,9 @@ const mockedFormatRedirectLink = formatRedirectLink as jest.MockedFunction<
   typeof formatRedirectLink
 >
 
-const NAVIGATION_APP_URL = `http://${NAVIGATION_APP_SLUG}.mycozy.test/#/`
+const NAVIGATION_APP_URL = `http://${NAVIGATION_APP_SLUG}.mycozy.test/#/alan`
 const DRIVE_URL = 'http://drive.mycozy.test/#/folder'
 const CONTACT_URL = 'http://contacts.mycozy.test/#/'
-
-describe('isDefaultRedirectionUrlNavigationApp', () => {
-  const client = createMockClient({}) as CozyClient
-  client.capabilities = {
-    flat_subdomains: false
-  }
-
-  beforeAll(() => {
-    jest.resetAllMocks()
-  })
-
-  it('should return true if slug of default redirection url is same than navigation app', () => {
-    expect(
-      isDefaultRedirectionUrlNavigationApp(NAVIGATION_APP_URL, client)
-    ).toBe(true)
-  })
-
-  it('should return false if slug of default redirection url is different than navigation app', () => {
-    expect(isDefaultRedirectionUrlNavigationApp(DRIVE_URL, client)).toBe(false)
-  })
-})
 
 describe('fetchDefaultRedirectionUrl', () => {
   const client = createMockClient({}) as CozyClient
@@ -186,10 +165,6 @@ describe('getOrFetchDefaultRedirectionUrl', () => {
   beforeAll(() => {
     jest.resetAllMocks()
 
-    jest
-      .spyOn(DefaultRedirection, 'isDefaultRedirectionUrlNavigationApp')
-      .mockImplementation(() => false)
-
     spyFetchAndSetDefaultRedirectionUrlInBackground = jest
       .spyOn(DefaultRedirection, 'fetchAndSetDefaultRedirectionUrlInBackground')
       .mockReturnValue(Promise.resolve(undefined))
@@ -227,5 +202,41 @@ describe('getOrFetchDefaultRedirectionUrl', () => {
     expect(
       spyFetchAndSetDefaultRedirectionUrlInBackground
     ).not.toHaveBeenCalled()
+  })
+})
+
+describe('getParamsWithDefaultRedirectionUrl', () => {
+  const client = createMockClient({}) as CozyClient
+  client.capabilities = {
+    flat_subdomains: false
+  }
+
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return undefined urls if default redirection url is null', () => {
+    expect(getParamsWithDefaultRedirectionUrl(null, client)).toMatchObject({
+      mainAppFallbackURL: undefined,
+      cozyAppFallbackURL: undefined
+    })
+  })
+
+  it('should return default redirection url for main app if default redirection url slug = navigation app slug', () => {
+    expect(
+      getParamsWithDefaultRedirectionUrl(NAVIGATION_APP_URL, client)
+    ).toMatchObject({
+      mainAppFallbackURL: NAVIGATION_APP_URL,
+      cozyAppFallbackURL: undefined
+    })
+  })
+
+  it('should return default redirection url for main app if default redirection url slug = navigation app slug', () => {
+    expect(getParamsWithDefaultRedirectionUrl(DRIVE_URL, client)).toMatchObject(
+      {
+        mainAppFallbackURL: undefined,
+        cozyAppFallbackURL: DRIVE_URL
+      }
+    )
   })
 })

--- a/src/libs/defaultRedirection/defaultRedirection.spec.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.spec.ts
@@ -16,15 +16,14 @@ import {
   fetchAndSetDefaultRedirectionUrlInBackground,
   getOrFetchDefaultRedirectionUrl
 } from '/libs/defaultRedirection/defaultRedirection'
-import { formatOnboardingRedirection } from '/libs/functions/formatOnboardingRedirection'
+import { formatRedirectLink } from '/libs/functions/formatRedirectLink'
 
 jest.mock('@react-native-async-storage/async-storage')
-jest.mock('/libs/functions/formatOnboardingRedirection')
+jest.mock('/libs/functions/formatRedirectLink')
 
-const mockedFormatOnboardingRedirection =
-  formatOnboardingRedirection as jest.MockedFunction<
-    typeof formatOnboardingRedirection
-  >
+const mockedFormatRedirectLink = formatRedirectLink as jest.MockedFunction<
+  typeof formatRedirectLink
+>
 
 const NAVIGATION_APP_URL = `http://${NAVIGATION_APP_SLUG}.mycozy.test/#/`
 const DRIVE_URL = 'http://drive.mycozy.test/#/folder'
@@ -69,11 +68,11 @@ describe('fetchDefaultRedirectionUrl', () => {
       })
     }
 
-    mockedFormatOnboardingRedirection.mockReturnValue(DRIVE_URL)
+    mockedFormatRedirectLink.mockReturnValue(DRIVE_URL)
 
     const defaultRedirectionUrl = await fetchDefaultRedirectionUrl(client)
 
-    expect(formatOnboardingRedirection).toHaveBeenCalled()
+    expect(formatRedirectLink).toHaveBeenCalled()
     expect(defaultRedirectionUrl).toBe(DRIVE_URL)
   })
 
@@ -84,11 +83,11 @@ describe('fetchDefaultRedirectionUrl', () => {
       })
     }
 
-    mockedFormatOnboardingRedirection.mockReturnValue(DRIVE_URL)
+    mockedFormatRedirectLink.mockReturnValue(DRIVE_URL)
 
     const defaultRedirectionUrl = await fetchDefaultRedirectionUrl(client)
 
-    expect(formatOnboardingRedirection).not.toHaveBeenCalled()
+    expect(formatRedirectLink).not.toHaveBeenCalled()
     expect(defaultRedirectionUrl).toBe(null)
   })
 })

--- a/src/libs/defaultRedirection/defaultRedirection.spec.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.spec.ts
@@ -1,0 +1,232 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+import CozyClient, { createMockClient } from 'cozy-client'
+
+import strings from '/constants/strings.json'
+import * as DefaultRedirection from '/libs/defaultRedirection/defaultRedirection'
+import {
+  NAVIGATION_APP_SLUG,
+  DEFAULT_REDIRECTION_DELAY_IN_MS,
+  InstanceSettings,
+  isDefaultRedirectionUrlNavigationApp,
+  fetchDefaultRedirectionUrl,
+  setDefaultRedirectionUrl,
+  getDefaultRedirectionUrl,
+  fetchAndSetDefaultRedirectionUrl,
+  fetchAndSetDefaultRedirectionUrlInBackground,
+  getOrFetchDefaultRedirectionUrl
+} from '/libs/defaultRedirection/defaultRedirection'
+import { formatOnboardingRedirection } from '/libs/functions/formatOnboardingRedirection'
+
+jest.mock('@react-native-async-storage/async-storage')
+jest.mock('/libs/functions/formatOnboardingRedirection')
+
+const mockedFormatOnboardingRedirection =
+  formatOnboardingRedirection as jest.MockedFunction<
+    typeof formatOnboardingRedirection
+  >
+
+const NAVIGATION_APP_URL = `http://${NAVIGATION_APP_SLUG}.mycozy.test/#/`
+const DRIVE_URL = 'http://drive.mycozy.test/#/folder'
+const CONTACT_URL = 'http://contacts.mycozy.test/#/'
+
+describe('isDefaultRedirectionUrlNavigationApp', () => {
+  const client = createMockClient({}) as CozyClient
+  client.capabilities = {
+    flat_subdomains: false
+  }
+
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return true if slug of default redirection url is same than navigation app', () => {
+    expect(
+      isDefaultRedirectionUrlNavigationApp(NAVIGATION_APP_URL, client)
+    ).toBe(true)
+  })
+
+  it('should return false if slug of default redirection url is different than navigation app', () => {
+    expect(isDefaultRedirectionUrlNavigationApp(DRIVE_URL, client)).toBe(false)
+  })
+})
+
+describe('fetchDefaultRedirectionUrl', () => {
+  const client = createMockClient({}) as CozyClient
+
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return default redirection url if request was good', async () => {
+    client.query = async (): Promise<InstanceSettings> => {
+      return Promise.resolve({
+        data: {
+          attributes: {
+            default_redirection: 'drive/#/folder'
+          }
+        }
+      })
+    }
+
+    mockedFormatOnboardingRedirection.mockReturnValue(DRIVE_URL)
+
+    const defaultRedirectionUrl = await fetchDefaultRedirectionUrl(client)
+
+    expect(formatOnboardingRedirection).toHaveBeenCalled()
+    expect(defaultRedirectionUrl).toBe(DRIVE_URL)
+  })
+
+  it('should return null if request was bad', async () => {
+    client.query = async (): Promise<object> => {
+      return Promise.resolve({
+        data: {}
+      })
+    }
+
+    mockedFormatOnboardingRedirection.mockReturnValue(DRIVE_URL)
+
+    const defaultRedirectionUrl = await fetchDefaultRedirectionUrl(client)
+
+    expect(formatOnboardingRedirection).not.toHaveBeenCalled()
+    expect(defaultRedirectionUrl).toBe(null)
+  })
+})
+
+describe('setDefaultRedirectionUrl', () => {
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should set default redirection url in async storage', async () => {
+    await setDefaultRedirectionUrl(DRIVE_URL)
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      strings.DEFAULT_REDIRECTION_URL_STORAGE_KEY,
+      DRIVE_URL
+    )
+  })
+})
+
+describe('getDefaultRedirectionUrl', () => {
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should get default redirection url in async storage', async () => {
+    await getDefaultRedirectionUrl()
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith(
+      strings.DEFAULT_REDIRECTION_URL_STORAGE_KEY
+    )
+  })
+})
+
+describe('fetchAndSetDefaultRedirectionUrl', () => {
+  const client = createMockClient({}) as CozyClient
+
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should set default redirection url if fetch return correct value', async () => {
+    jest
+      .spyOn(DefaultRedirection, 'fetchDefaultRedirectionUrl')
+      .mockReturnValue(Promise.resolve(DRIVE_URL))
+
+    const spy = jest.spyOn(DefaultRedirection, 'setDefaultRedirectionUrl')
+    await fetchAndSetDefaultRedirectionUrl(client)
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('should not set default redirection url if fetch return incorrect value', async () => {
+    jest
+      .spyOn(DefaultRedirection, 'fetchDefaultRedirectionUrl')
+      .mockReturnValue(Promise.resolve(null))
+
+    const spy = jest.spyOn(DefaultRedirection, 'setDefaultRedirectionUrl')
+    await fetchAndSetDefaultRedirectionUrl(client)
+    expect(spy).not.toHaveBeenCalled()
+  })
+})
+
+describe('fetchAndSetDefaultRedirectionUrlInBackground', () => {
+  const client = createMockClient({}) as CozyClient
+
+  beforeAll(() => {
+    jest.resetAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  it('should fetch and set default redirection url after delay', () => {
+    const spyFetchAndSetDefaultRedirectionUrl = jest.spyOn(
+      DefaultRedirection,
+      'fetchAndSetDefaultRedirectionUrl'
+    )
+    void fetchAndSetDefaultRedirectionUrlInBackground(
+      client,
+      DEFAULT_REDIRECTION_DELAY_IN_MS
+    )
+
+    jest.runAllTimers()
+
+    expect(spyFetchAndSetDefaultRedirectionUrl).toHaveBeenCalled()
+  })
+})
+
+describe('getOrFetchDefaultRedirectionUrl', () => {
+  const client = createMockClient({}) as CozyClient
+
+  let spyFetchAndSetDefaultRedirectionUrlInBackground: jest.SpyInstance<
+    Promise<void>,
+    [client: CozyClient, delayInMs?: number | undefined]
+  >
+
+  beforeAll(() => {
+    jest.resetAllMocks()
+
+    jest
+      .spyOn(DefaultRedirection, 'isDefaultRedirectionUrlNavigationApp')
+      .mockImplementation(() => false)
+
+    spyFetchAndSetDefaultRedirectionUrlInBackground = jest
+      .spyOn(DefaultRedirection, 'fetchAndSetDefaultRedirectionUrlInBackground')
+      .mockReturnValue(Promise.resolve(undefined))
+  })
+
+  it('should fetch later if default redirection url in async storage', async () => {
+    jest
+      .spyOn(DefaultRedirection, 'getDefaultRedirectionUrl')
+      .mockReturnValue(Promise.resolve(DRIVE_URL))
+
+    const spyFetchDefaultRedirectionUrl = jest
+      .spyOn(DefaultRedirection, 'fetchDefaultRedirectionUrl')
+      .mockReturnValue(Promise.resolve(null))
+
+    const defaultRedirectionUrl = await getOrFetchDefaultRedirectionUrl(client)
+
+    expect(defaultRedirectionUrl).toBe(DRIVE_URL)
+    expect(spyFetchDefaultRedirectionUrl).not.toHaveBeenCalled()
+    expect(spyFetchAndSetDefaultRedirectionUrlInBackground).toHaveBeenCalled()
+  })
+
+  it('should fetch now if nothing in async storage', async () => {
+    jest
+      .spyOn(DefaultRedirection, 'getDefaultRedirectionUrl')
+      .mockReturnValue(Promise.resolve(null))
+
+    const spyFetchDefaultRedirectionUrl = jest
+      .spyOn(DefaultRedirection, 'fetchDefaultRedirectionUrl')
+      .mockReturnValue(Promise.resolve(CONTACT_URL))
+
+    const defaultRedirectionUrl = await getOrFetchDefaultRedirectionUrl(client)
+
+    expect(defaultRedirectionUrl).toBe(CONTACT_URL)
+    expect(spyFetchDefaultRedirectionUrl).toHaveBeenCalled()
+    expect(
+      spyFetchAndSetDefaultRedirectionUrlInBackground
+    ).not.toHaveBeenCalled()
+  })
+})

--- a/src/libs/defaultRedirection/defaultRedirection.spec.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.spec.ts
@@ -26,7 +26,9 @@ const mockedFormatRedirectLink = formatRedirectLink as jest.MockedFunction<
 >
 
 const NAVIGATION_APP_URL = `http://${NAVIGATION_APP_SLUG}.mycozy.test/#/alan`
+const NAVIGATION_APP_URL_FLAT = `http://mycozy-${NAVIGATION_APP_SLUG}.test/#/alan`
 const DRIVE_URL = 'http://drive.mycozy.test/#/folder'
+const DRIVE_URL_FLAT = 'http://mycozy-drive.test/#/folder'
 const CONTACT_URL = 'http://contacts.mycozy.test/#/'
 
 describe('fetchDefaultRedirectionUrl', () => {
@@ -206,37 +208,73 @@ describe('getOrFetchDefaultRedirectionUrl', () => {
 })
 
 describe('getParamsWithDefaultRedirectionUrl', () => {
-  const client = createMockClient({}) as CozyClient
-  client.capabilities = {
-    flat_subdomains: false
-  }
-
   beforeAll(() => {
     jest.resetAllMocks()
   })
 
-  it('should return undefined urls if default redirection url is null', () => {
-    expect(getParamsWithDefaultRedirectionUrl(null, client)).toMatchObject({
-      mainAppFallbackURL: undefined,
-      cozyAppFallbackURL: undefined
-    })
-  })
+  describe('with nested subdomain', () => {
+    const client = createMockClient({}) as CozyClient
 
-  it('should return default redirection url for main app if default redirection url slug = navigation app slug', () => {
-    expect(
-      getParamsWithDefaultRedirectionUrl(NAVIGATION_APP_URL, client)
-    ).toMatchObject({
-      mainAppFallbackURL: NAVIGATION_APP_URL,
-      cozyAppFallbackURL: undefined
-    })
-  })
+    client.capabilities = {
+      flat_subdomains: false
+    }
 
-  it('should return default redirection url for main app if default redirection url slug = navigation app slug', () => {
-    expect(getParamsWithDefaultRedirectionUrl(DRIVE_URL, client)).toMatchObject(
-      {
+    it('should return undefined urls if default redirection url is null', () => {
+      expect(getParamsWithDefaultRedirectionUrl(null, client)).toMatchObject({
+        mainAppFallbackURL: undefined,
+        cozyAppFallbackURL: undefined
+      })
+    })
+
+    it('should return default redirection url for main app if default redirection url slug = navigation app slug', () => {
+      expect(
+        getParamsWithDefaultRedirectionUrl(NAVIGATION_APP_URL, client)
+      ).toMatchObject({
+        mainAppFallbackURL: NAVIGATION_APP_URL,
+        cozyAppFallbackURL: undefined
+      })
+    })
+
+    it('should return default redirection url for main app if default redirection url slug = navigation app slug', () => {
+      expect(
+        getParamsWithDefaultRedirectionUrl(DRIVE_URL, client)
+      ).toMatchObject({
         mainAppFallbackURL: undefined,
         cozyAppFallbackURL: DRIVE_URL
-      }
-    )
+      })
+    })
+  })
+
+  describe('with flat subdomain', () => {
+    const client = createMockClient({}) as CozyClient
+
+    client.capabilities = {
+      flat_subdomains: true
+    }
+
+    it('should return undefined urls if default redirection url is null', () => {
+      expect(getParamsWithDefaultRedirectionUrl(null, client)).toMatchObject({
+        mainAppFallbackURL: undefined,
+        cozyAppFallbackURL: undefined
+      })
+    })
+
+    it('should return default redirection url for main app if default redirection url slug = navigation app slug', () => {
+      expect(
+        getParamsWithDefaultRedirectionUrl(NAVIGATION_APP_URL_FLAT, client)
+      ).toMatchObject({
+        mainAppFallbackURL: NAVIGATION_APP_URL_FLAT,
+        cozyAppFallbackURL: undefined
+      })
+    })
+
+    it('should return default redirection url for main app if default redirection url slug = navigation app slug', () => {
+      expect(
+        getParamsWithDefaultRedirectionUrl(DRIVE_URL_FLAT, client)
+      ).toMatchObject({
+        mainAppFallbackURL: undefined,
+        cozyAppFallbackURL: DRIVE_URL_FLAT
+      })
+    })
   })
 })

--- a/src/libs/defaultRedirection/defaultRedirection.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.ts
@@ -3,7 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import type CozyClient from 'cozy-client'
 import { Q, deconstructCozyWebLinkWithSlug } from 'cozy-client'
 
-import { formatOnboardingRedirection } from '/libs/functions/formatOnboardingRedirection'
+import { formatRedirectLink } from '/libs/functions/formatRedirectLink'
 import { logger } from '/libs/functions/logger'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
 import strings from '/constants/strings.json'
@@ -51,10 +51,7 @@ export const fetchDefaultRedirectionUrl = async (
 
     const defaultRedirection = data.attributes.default_redirection
 
-    defaultRedirectionUrl = formatOnboardingRedirection(
-      defaultRedirection,
-      client
-    )
+    defaultRedirectionUrl = formatRedirectLink(defaultRedirection, client)
   } catch {
     defaultRedirectionUrl = null
   }

--- a/src/libs/functions/formatRedirectLink.spec.ts
+++ b/src/libs/functions/formatRedirectLink.spec.ts
@@ -1,7 +1,8 @@
 import CozyClient from 'cozy-client'
-import { formatOnboardingRedirection } from './formatOnboardingRedirection'
 
-describe('formatOnboardingRedirection', () => {
+import { formatRedirectLink } from '/libs/functions/formatRedirectLink'
+
+describe('formatRedirectLink', () => {
   const client = {
     getStackClient: (): { uri: string } => ({ uri: 'http://mycozy.test' }),
     getInstanceOptions: (): { capabilities: { flat_subdomains: boolean } } => ({
@@ -10,14 +11,14 @@ describe('formatOnboardingRedirection', () => {
   } as CozyClient
 
   it('should format onboarding redirection', () => {
-    expect(
-      formatOnboardingRedirection('contacts/#/hash', client)
-    ).toStrictEqual('http://contacts.mycozy.test/#/hash')
+    expect(formatRedirectLink('contacts/#/hash', client)).toStrictEqual(
+      'http://contacts.mycozy.test/#/hash'
+    )
   })
 
   it('should format onboarding redirection', () => {
-    expect(
-      formatOnboardingRedirection('contacts/path/#/hash', client)
-    ).toStrictEqual('http://contacts.mycozy.test/path/#/hash')
+    expect(formatRedirectLink('contacts/path/#/hash', client)).toStrictEqual(
+      'http://contacts.mycozy.test/path/#/hash'
+    )
   })
 })

--- a/src/libs/functions/formatRedirectLink.ts
+++ b/src/libs/functions/formatRedirectLink.ts
@@ -3,7 +3,7 @@ import CozyClient, {
   deconstructRedirectLink
 } from 'cozy-client'
 
-export const formatOnboardingRedirection = (
+export const formatRedirectLink = (
   onboardingRedirection: string,
   client: CozyClient
 ): string => {


### PR DESCRIPTION
Manage _default_redirection_ from instance settings to open a Cozy app different from home when you open the app : 
- fetch it [from stack](https://docs.cozy.io/en/cozy-stack/settings/#get-settingsinstance)
- store it in AsyncStorage
- fetch it from AsyncStorage
- use it in useAppBootstrap according to the product request to redirect when you open the app

To test, just add _"default_redirection": "drive/#/folder"_ in your io.cozy.settings.instance database.