### PR TITLE
feat: Implement OnboardingPartner and ClouderyEnv override using links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import { routes } from '/constants/routes.js'
 import { useAppBootstrap } from '/hooks/useAppBootstrap.js'
 import { useGlobalAppState } from '/hooks/useGlobalAppState'
 import { useCookieResyncOnResume } from '/hooks/useCookieResyncOnResume'
+import { useCozyEnvironmentOverride } from '/hooks/useCozyEnvironmentOverride'
 import { useNotifications } from '/hooks/useNotifications'
 import { useNetService } from '/libs/services/NetService'
 import { withSentry } from '/libs/monitoring/Sentry'
@@ -60,6 +61,7 @@ const App = ({ setClient }) => {
   useGlobalAppState()
   useCookieResyncOnResume()
   useNotifications()
+  useCozyEnvironmentOverride()
 
   if (isLoading) {
     return null

--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -3,6 +3,7 @@
   "BUNDLE_STORAGE_KEY": "@cozy_AmiralAppBundleConfig",
   "COOKIE_STORAGE_KEY": "@cozy_AmiralAppCookieConfig",
   "COZY_SCHEME": "cozy://",
+  "CLOUDERY_ENV_STORAGE_KEY": "@cozy_AmiralAppClouderyEnvConfig",
   "OAUTH_STORAGE_KEY": "@cozy_AmiralAppOAuthConfig",
   "ONBOARDING_PARTNER_STORAGE_KEY": "@cozy_AmiralAppOnboardingPartnerConfig",
   "REDIRECT": "redirect",
@@ -16,8 +17,11 @@
       "backButton": "RETOUR À MON COZY"
     }
   },
-  "clouderyiOSUri": "https://manager.cozycloud.cc/v2/cozy/start?redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
-  "clouderyAndroidUri": "https://manager.cozycloud.cc/v2/cozy/start?redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "clouderyProdBaseUri": "https://manager.cozycloud.cc",
+  "clouderyIntBaseUri": "https://staging-manager.cozycloud.cc",
+  "clouderyDevBaseUri": "https://manager-dev.cozycloud.cc",
+  "clouderyiOSRelativeUri": "/v2/cozy/start?redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "clouderyAndroidRelativeUri": "/v2/cozy/start?redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
   "defaultHttpScheme": "https://",
   "emptyString": "",
   "environments": {

--- a/src/hooks/useCozyEnvironmentOverride.functions.ts
+++ b/src/hooks/useCozyEnvironmentOverride.functions.ts
@@ -1,0 +1,97 @@
+import { Alert, Platform } from 'react-native'
+
+import {
+  getOnboardingPartner,
+  noOnboardingPartner,
+  OnboardingPartner,
+  saveOnboardingPartnerOnAsyncStorage
+} from '/screens/welcome/install-referrer/onboardingPartner'
+import {
+  ClouderyEnv,
+  isClouderyEnv,
+  getClouderyEnvFromAsyncStorage,
+  saveClouderyEnvOnAsyncStorage
+} from '/screens/login/cloudery-env/clouderyEnv'
+
+const ENV_OVERRIDE_PATH = 'cozy_env_override' as const
+
+const parseOnboardingPartnerFromUrl = (
+  url: string
+): OnboardingPartner | null => {
+  if (Platform.OS !== 'android') return null
+
+  const partnerUrl = new URL(url)
+
+  const partnerSource = partnerUrl.searchParams.get('partner_source')
+  const partnerContext = partnerUrl.searchParams.get('partner_context')
+  const clearPartner = partnerUrl.searchParams.get('clear_partner')
+
+  if (clearPartner) {
+    return noOnboardingPartner()
+  }
+
+  if (!partnerSource || !partnerContext) {
+    return null
+  }
+
+  return {
+    source: partnerSource,
+    context: partnerContext,
+    hasReferral: true
+  }
+}
+
+const parseClouderyEnvFromUrl = (url: string): ClouderyEnv | null => {
+  const partnerUrl = new URL(url)
+
+  const clouderyEnv = partnerUrl.searchParams.get('cloudery_environment')
+
+  if (!clouderyEnv || !isClouderyEnv(clouderyEnv)) {
+    return null
+  }
+
+  return clouderyEnv
+}
+
+const alertNewEnvironment = async (): Promise<void> => {
+  const clouderyEnv = await getClouderyEnvFromAsyncStorage()
+  const partner = await getOnboardingPartner()
+
+  const partnerString = partner.hasReferral
+    ? `Partner: ${partner.source} / ${partner.context}`
+    : 'Partner: (none)'
+  const environmentString = `Cloudery: ${clouderyEnv}`
+
+  Alert.alert(
+    'Environment',
+    `Environment has been overriden\n\n${partnerString}\n${environmentString}`,
+    undefined,
+    {
+      cancelable: true
+    }
+  )
+}
+
+export const extractEnvFromUrl = async (url: string | null): Promise<void> => {
+  if (!url?.includes(ENV_OVERRIDE_PATH)) {
+    return
+  }
+
+  let envHasChanged = false
+
+  const onboardingPartner = parseOnboardingPartnerFromUrl(url)
+  if (onboardingPartner) {
+    await saveOnboardingPartnerOnAsyncStorage(onboardingPartner)
+    envHasChanged = true
+  }
+
+  const clouderyEnv = parseClouderyEnvFromUrl(url)
+  if (clouderyEnv) {
+    await saveClouderyEnvOnAsyncStorage(clouderyEnv)
+    envHasChanged = true
+  }
+
+  if (envHasChanged) {
+    await alertNewEnvironment()
+  }
+}

--- a/src/hooks/useCozyEnvironmentOverride.spec.ts
+++ b/src/hooks/useCozyEnvironmentOverride.spec.ts
@@ -1,0 +1,171 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Alert, Platform } from 'react-native'
+
+import { extractEnvFromUrl } from './useCozyEnvironmentOverride.functions'
+
+import strings from '/constants/strings.json'
+
+jest.spyOn(Alert, 'alert')
+jest.mock(
+  '/screens/welcome/install-referrer/androidPlayInstallReferrer',
+  () => ({
+    getInstallReferrer: jest.fn()
+  })
+)
+
+describe('extractEnvFromUrl', () => {
+  beforeEach(async () => {
+    await AsyncStorage.removeItem(strings.ONBOARDING_PARTNER_STORAGE_KEY)
+    await AsyncStorage.removeItem(strings.CLOUDERY_ENV_STORAGE_KEY)
+    Platform.OS = 'android'
+  })
+
+  it('should intercept cloudery_environment=PROD', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?cloudery_environment=PROD'
+    )
+
+    expect(await AsyncStorage.getItem(strings.CLOUDERY_ENV_STORAGE_KEY)).toBe(
+      'PROD'
+    )
+  })
+
+  it('should intercept cloudery_environment=DEV', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?cloudery_environment=DEV'
+    )
+
+    expect(await AsyncStorage.getItem(strings.CLOUDERY_ENV_STORAGE_KEY)).toBe(
+      'DEV'
+    )
+  })
+
+  it('should intercept cloudery_environment=INT', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?cloudery_environment=INT'
+    )
+
+    expect(await AsyncStorage.getItem(strings.CLOUDERY_ENV_STORAGE_KEY)).toBe(
+      'INT'
+    )
+  })
+
+  it('should ignore unexpected cloudery_environment values', async () => {
+    await AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, 'DEV')
+
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?cloudery_environment=SOME_BAD_ENV'
+    )
+
+    expect(await AsyncStorage.getItem(strings.CLOUDERY_ENV_STORAGE_KEY)).toBe(
+      'DEV'
+    )
+  })
+
+  it('should intercept clear_partner instruction', async () => {
+    await AsyncStorage.setItem(
+      strings.ONBOARDING_PARTNER_STORAGE_KEY,
+      '{"source":"SOME_SOURCE","context":"SOME_CONTEXT","hasReferral":true}'
+    )
+
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?clear_partner=true'
+    )
+
+    expect(
+      await AsyncStorage.getItem(strings.ONBOARDING_PARTNER_STORAGE_KEY)
+    ).toBe('{"hasReferral":false}')
+  })
+
+  it('should intercept partner_source and partner_context', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?partner_source=SOME_PARTNER&partner_context=SOME_CONTEXT'
+    )
+
+    expect(
+      await AsyncStorage.getItem(strings.ONBOARDING_PARTNER_STORAGE_KEY)
+    ).toBe(
+      '{"source":"SOME_PARTNER","context":"SOME_CONTEXT","hasReferral":true}'
+    )
+  })
+
+  it('should not intercept partner if partner_source is null', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?partner_context=SOME_CONTEXT'
+    )
+
+    expect(
+      await AsyncStorage.getItem(strings.ONBOARDING_PARTNER_STORAGE_KEY)
+    ).toBeNull()
+  })
+
+  it('should not intercept partner if partner_context is null', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?partner_source=SOME_PARTNER'
+    )
+
+    expect(
+      await AsyncStorage.getItem(strings.ONBOARDING_PARTNER_STORAGE_KEY)
+    ).toBeNull()
+  })
+
+  it('should not intercept partner on iOS', async () => {
+    Platform.OS = 'ios'
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?partner_source=SOME_PARTNER&partner_context=SOME_CONTEXT'
+    )
+
+    expect(
+      await AsyncStorage.getItem(strings.ONBOARDING_PARTNER_STORAGE_KEY)
+    ).toBeNull()
+  })
+
+  it('should handle both partner and cloudery_environment params', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?partner_source=SOME_PARTNER&partner_context=SOME_CONTEXT&cloudery_environment=DEV'
+    )
+
+    expect(
+      await AsyncStorage.getItem(strings.ONBOARDING_PARTNER_STORAGE_KEY)
+    ).toBe(
+      '{"source":"SOME_PARTNER","context":"SOME_CONTEXT","hasReferral":true}'
+    )
+    expect(await AsyncStorage.getItem(strings.CLOUDERY_ENV_STORAGE_KEY)).toBe(
+      'DEV'
+    )
+  })
+
+  it('should alert the user about changes', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?partner_source=SOME_PARTNER&partner_context=SOME_CONTEXT&cloudery_environment=DEV'
+    )
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Environment',
+      'Environment has been overriden\n\nPartner: SOME_PARTNER / SOME_CONTEXT\nCloudery: DEV',
+      undefined,
+      { cancelable: true }
+    )
+  })
+
+  it('should alert the user about changes with no partner', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override?cloudery_environment=DEV'
+    )
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Environment',
+      'Environment has been overriden\n\nPartner: (none)\nCloudery: DEV',
+      undefined,
+      { cancelable: true }
+    )
+  })
+
+  it('should not alert the user if no changes', async () => {
+    await extractEnvFromUrl(
+      'https://links.mycozy.cloud/flagship/cozy_env_override'
+    )
+
+    expect(Alert.alert).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useCozyEnvironmentOverride.ts
+++ b/src/hooks/useCozyEnvironmentOverride.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { Linking } from 'react-native'
+
+import { extractEnvFromUrl } from './useCozyEnvironmentOverride.functions'
+
+export const useCozyEnvironmentOverride = (): void => {
+  useEffect(function CheckInitialUrl() {
+    const doAsync = async (): Promise<void> => {
+      const initialUrl = await Linking.getInitialURL()
+      await extractEnvFromUrl(initialUrl)
+    }
+
+    void doAsync()
+  }, [])
+
+  useEffect(function InterceptDeepLink() {
+    const subscription = Linking.addEventListener('url', ({ url }) => {
+      void extractEnvFromUrl(url)
+    })
+
+    return (): void => {
+      subscription.remove()
+    }
+  }, [])
+}

--- a/src/screens/login/cloudery-env/clouderyEnv.spec.ts
+++ b/src/screens/login/cloudery-env/clouderyEnv.spec.ts
@@ -1,0 +1,72 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Platform } from 'react-native'
+
+import { getClouderyUrl } from '/screens/login/cloudery-env/clouderyEnv'
+import strings from '/constants/strings.json'
+
+describe('extractEnvFromUrl', () => {
+  beforeEach(async () => {
+    await AsyncStorage.removeItem(strings.ONBOARDING_PARTNER_STORAGE_KEY)
+    await AsyncStorage.removeItem(strings.CLOUDERY_ENV_STORAGE_KEY)
+    Platform.OS = 'android'
+  })
+
+  it(`should return Android's PROD url`, async () => {
+    await AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, 'PROD')
+
+    const result = await getClouderyUrl()
+
+    expect(result).toBe(
+      strings.clouderyProdBaseUri + strings.clouderyAndroidRelativeUri
+    )
+  })
+
+  it(`should return Android's DEV url`, async () => {
+    await AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, 'DEV')
+
+    const result = await getClouderyUrl()
+
+    expect(result).toBe(
+      strings.clouderyDevBaseUri + strings.clouderyAndroidRelativeUri
+    )
+  })
+
+  it(`should return Android's INT url`, async () => {
+    await AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, 'INT')
+
+    const result = await getClouderyUrl()
+
+    expect(result).toBe(
+      strings.clouderyIntBaseUri + strings.clouderyAndroidRelativeUri
+    )
+  })
+
+  it(`should return iOS's INT url`, async () => {
+    Platform.OS = 'ios'
+    await AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, 'INT')
+
+    const result = await getClouderyUrl()
+
+    expect(result).toBe(
+      strings.clouderyIntBaseUri + strings.clouderyiOSRelativeUri
+    )
+  })
+
+  it(`should return PROD url if nothing in AsyncStorage`, async () => {
+    const result = await getClouderyUrl()
+
+    expect(result).toBe(
+      strings.clouderyProdBaseUri + strings.clouderyAndroidRelativeUri
+    )
+  })
+
+  it(`should return PROD url if BAD_FORMAT in AsyncStorage`, async () => {
+    await AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, 'BAD_FORMAT')
+
+    const result = await getClouderyUrl()
+
+    expect(result).toBe(
+      strings.clouderyProdBaseUri + strings.clouderyAndroidRelativeUri
+    )
+  })
+})

--- a/src/screens/login/cloudery-env/clouderyEnv.ts
+++ b/src/screens/login/cloudery-env/clouderyEnv.ts
@@ -1,0 +1,49 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Platform } from 'react-native'
+
+import strings from '/constants/strings.json'
+
+const ALL_CLOUDERY_ENV = ['DEV', 'INT', 'PROD'] as const
+const CLOUDERY_DEFAULT_ENV = 'PROD'
+type ClouderyEnvTuple = typeof ALL_CLOUDERY_ENV
+export type ClouderyEnv = ClouderyEnvTuple[number]
+
+export const isClouderyEnv = (value: string): value is ClouderyEnv => {
+  return ALL_CLOUDERY_ENV.includes(value as ClouderyEnv)
+}
+
+export const saveClouderyEnvOnAsyncStorage = (
+  environment: ClouderyEnv
+): Promise<void> => {
+  return AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, environment)
+}
+
+export const getClouderyEnvFromAsyncStorage =
+  async (): Promise<ClouderyEnv> => {
+    const clouderyEnv = await AsyncStorage.getItem(
+      strings.CLOUDERY_ENV_STORAGE_KEY
+    )
+
+    if (!clouderyEnv || !isClouderyEnv(clouderyEnv)) {
+      return CLOUDERY_DEFAULT_ENV
+    }
+
+    return clouderyEnv
+  }
+
+export const getClouderyUrl = async (): Promise<string> => {
+  const clouderyEnv = await getClouderyEnvFromAsyncStorage()
+
+  const baseUris: Record<ClouderyEnv, string> = {
+    PROD: strings.clouderyProdBaseUri,
+    INT: strings.clouderyIntBaseUri,
+    DEV: strings.clouderyDevBaseUri
+  }
+
+  const relativeUri =
+    Platform.OS === 'ios'
+      ? strings.clouderyiOSRelativeUri
+      : strings.clouderyAndroidRelativeUri
+
+  return baseUris[clouderyEnv] + relativeUri
+}

--- a/src/screens/login/cloudery-env/useClouderyUrl.ts
+++ b/src/screens/login/cloudery-env/useClouderyUrl.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+import { getClouderyUrl } from '/screens/login/cloudery-env/clouderyEnv'
+
+export interface UseClouderyUrlHook {
+  uri?: string
+}
+
+export const useClouderyUrl = (): UseClouderyUrlHook => {
+  const [uri, setUri] = useState<string | undefined>(undefined)
+
+  useEffect(function getClouderyUri() {
+    const doAsync = async (): Promise<void> => {
+      const clouderyUrl = await getClouderyUrl()
+
+      setUri(clouderyUrl)
+    }
+
+    void doAsync()
+  }, [])
+
+  return { uri }
+}

--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -18,6 +18,7 @@ import { jsLogInterception } from '/components/webviews/jsInteractions/jsLogInte
 import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
 import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
+import { useClouderyUrl } from '/screens/login/cloudery-env/useClouderyUrl'
 
 import { rootCozyUrl } from 'cozy-client'
 
@@ -59,9 +60,7 @@ const handleError = async webviewErrorEvent => {
  * @returns {import('react').ComponentClass}
  */
 export const ClouderyView = ({ setInstanceData, disabledFocus }) => {
-  const [uri] = useState(
-    Platform.OS === 'ios' ? strings.clouderyiOSUri : strings.clouderyAndroidUri
-  )
+  const { uri } = useClouderyUrl()
   const [loading, setLoading] = useState(true)
   const [checkInstanceData, setCheckInstanceData] = useState()
   const webviewRef = useRef()
@@ -137,20 +136,22 @@ export const ClouderyView = ({ setInstanceData, disabledFocus }) => {
 
   return (
     <Wrapper style={styles.view} behavior="height">
-      <SupervisedWebView
-        source={{ uri: uri }}
-        ref={webviewRef}
-        onNavigationStateChange={event => {
-          setCanGoBack(event.canGoBack)
-        }}
-        onShouldStartLoadWithRequest={handleNavigation}
-        onLoadEnd={() => setLoading(false)}
-        injectedJavaScriptBeforeContentLoaded={run}
-        style={{
-          backgroundColor: colors.primaryColor
-        }}
-        onError={handleError}
-      />
+      {uri && (
+        <SupervisedWebView
+          source={{ uri: uri }}
+          ref={webviewRef}
+          onNavigationStateChange={event => {
+            setCanGoBack(event.canGoBack)
+          }}
+          onShouldStartLoadWithRequest={handleNavigation}
+          onLoadEnd={() => setLoading(false)}
+          injectedJavaScriptBeforeContentLoaded={run}
+          style={{
+            backgroundColor: colors.primaryColor
+          }}
+          onError={handleError}
+        />
+      )}
       {displayOverlay && (
         <View
           testID="overlay"

--- a/src/screens/login/components/ClouderyView.spec.js
+++ b/src/screens/login/components/ClouderyView.spec.js
@@ -49,6 +49,12 @@ jest.mock('react-native-webview', () => {
   return { WebView }
 })
 
+jest.mock('/screens/login/cloudery-env/useClouderyUrl', () => {
+  return {
+    useClouderyUrl: jest.fn().mockReturnValue({ uri: 'http://SOME_URI' })
+  }
+})
+
 describe('ClouderyView', () => {
   describe('on handleNavigation', () => {
     const props = {

--- a/src/screens/welcome/install-referrer/onboardingPartner.ts
+++ b/src/screens/welcome/install-referrer/onboardingPartner.ts
@@ -24,7 +24,9 @@ interface WithOnboardingPartner {
 
 export type OnboardingPartner = WithOnboardingPartner | NoOnboardingPartner
 
-const noOnboardingPartner = (): NoOnboardingPartner => ({ hasReferral: false })
+export const noOnboardingPartner = (): NoOnboardingPartner => ({
+  hasReferral: false
+})
 
 const extractOnboardingPartner = (
   installReferrer: string
@@ -50,7 +52,7 @@ const extractOnboardingPartner = (
   return null
 }
 
-const saveOnboardingPartnerOnAsyncStorage = async (
+export const saveOnboardingPartnerOnAsyncStorage = async (
   onboardingPartner: OnboardingPartner
 ): Promise<void> => {
   const serializedOnboardingPartner = JSON.stringify(onboardingPartner)


### PR DESCRIPTION
We want to be able to override OnboardingPartner and ClouderyEnv by using an universal link or a scheme link

ClouderyEnv is a new configuration that allow to define if the ClouderyView should display the production, integration or development cloudery

The app should be able to intercept links containing `cozy_env_override` keyword and extract new OnboardingParner and
ClouderyEnv configuration from it

This feature is needed for debugging purpose so we display a react-native alert when a link is intercepted and the configuration is overriden

___

TODO:

- [x] Fix unit tests