### PR TITLE
feat: Pass OnboardingPartner context to ClouderyView when exist

### DIFF
--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -21,8 +21,9 @@
   "clouderyProdBaseUri": "https://manager.cozycloud.cc",
   "clouderyIntBaseUri": "https://staging-manager.cozycloud.cc",
   "clouderyDevBaseUri": "https://manager-dev.cozycloud.cc",
-  "clouderyiOSRelativeUri": "/v2/cozy/start?redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
-  "clouderyAndroidRelativeUri": "/v2/cozy/start?redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "clouderyCozyRelativeUri": "/v2/cozy/start",
+  "clouderyiOSQueryString": "redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "clouderyAndroidQueryString": "redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
   "defaultHttpScheme": "https://",
   "emptyString": "",
   "environments": {

--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -18,12 +18,14 @@
       "backButton": "RETOUR À MON COZY"
     }
   },
-  "clouderyProdBaseUri": "https://manager.cozycloud.cc",
-  "clouderyIntBaseUri": "https://staging-manager.cozycloud.cc",
-  "clouderyDevBaseUri": "https://manager-dev.cozycloud.cc",
-  "clouderyCozyRelativeUri": "/v2/cozy/start",
-  "clouderyiOSQueryString": "redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
-  "clouderyAndroidQueryString": "redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+  "cloudery": {
+    "prodBaseUri": "https://manager.cozycloud.cc",
+    "intBaseUri": "https://staging-manager.cozycloud.cc",
+    "devBaseUri": "https://manager-dev.cozycloud.cc",
+    "cozyRelativeUri": "/v2/cozy/start",
+    "iOSQueryString": "redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+    "androidQueryString": "redirect_after_email=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue&redirect_after_login=https%3A%2F%2Floginflagship"
+  },
   "defaultHttpScheme": "https://",
   "emptyString": "",
   "environments": {

--- a/src/screens/login/cloudery-env/clouderyEnv.spec.ts
+++ b/src/screens/login/cloudery-env/clouderyEnv.spec.ts
@@ -2,7 +2,15 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
 
 import { getClouderyUrl } from '/screens/login/cloudery-env/clouderyEnv'
+
 import strings from '/constants/strings.json'
+
+jest.mock(
+  '/screens/welcome/install-referrer/androidPlayInstallReferrer',
+  () => ({
+    getInstallReferrer: jest.fn()
+  })
+)
 
 describe('extractEnvFromUrl', () => {
   beforeEach(async () => {
@@ -17,7 +25,7 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyProdBaseUri + strings.clouderyAndroidRelativeUri
+      strings.clouderyProdBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
     )
   })
 
@@ -27,7 +35,7 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyDevBaseUri + strings.clouderyAndroidRelativeUri
+      strings.clouderyDevBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
     )
   })
 
@@ -37,7 +45,7 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyIntBaseUri + strings.clouderyAndroidRelativeUri
+      strings.clouderyIntBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
     )
   })
 
@@ -48,7 +56,7 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyIntBaseUri + strings.clouderyiOSRelativeUri
+      strings.clouderyIntBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyiOSQueryString
     )
   })
 
@@ -56,7 +64,7 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyProdBaseUri + strings.clouderyAndroidRelativeUri
+      strings.clouderyProdBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
     )
   })
 
@@ -66,7 +74,35 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyProdBaseUri + strings.clouderyAndroidRelativeUri
+      strings.clouderyProdBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
+    )
+  })
+
+  it(`should return OnboardingPartner url if detected`, async () => {
+    await AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, 'PROD')
+    await AsyncStorage.setItem(
+      strings.ONBOARDING_PARTNER_STORAGE_KEY,
+      '{"source":"SOME_SOURCE","context":"SOME_CONTEXT","hasReferral":true}'
+    )
+
+    const result = await getClouderyUrl()
+
+    expect(result).toBe(
+      strings.clouderyProdBaseUri + '/v2/SOME_SOURCE/SOME_CONTEXT?' + strings.clouderyAndroidQueryString
+    )
+  })
+
+  it(`should return Cozy url if no OnboardingPartner is detected`, async () => {
+    await AsyncStorage.setItem(strings.CLOUDERY_ENV_STORAGE_KEY, 'PROD')
+    await AsyncStorage.setItem(
+      strings.ONBOARDING_PARTNER_STORAGE_KEY,
+      '{"hasReferral":false}'
+    )
+
+    const result = await getClouderyUrl()
+
+    expect(result).toBe(
+      strings.clouderyProdBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
     )
   })
 })

--- a/src/screens/login/cloudery-env/clouderyEnv.spec.ts
+++ b/src/screens/login/cloudery-env/clouderyEnv.spec.ts
@@ -2,7 +2,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
 
 import { getClouderyUrl } from '/screens/login/cloudery-env/clouderyEnv'
-
 import strings from '/constants/strings.json'
 
 jest.mock(
@@ -25,7 +24,10 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyProdBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
+      strings.cloudery.prodBaseUri +
+        strings.cloudery.cozyRelativeUri +
+        '?' +
+        strings.cloudery.androidQueryString
     )
   })
 
@@ -35,7 +37,10 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyDevBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
+      strings.cloudery.devBaseUri +
+        strings.cloudery.cozyRelativeUri +
+        '?' +
+        strings.cloudery.androidQueryString
     )
   })
 
@@ -45,7 +50,10 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyIntBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
+      strings.cloudery.intBaseUri +
+        strings.cloudery.cozyRelativeUri +
+        '?' +
+        strings.cloudery.androidQueryString
     )
   })
 
@@ -56,7 +64,10 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyIntBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyiOSQueryString
+      strings.cloudery.intBaseUri +
+        strings.cloudery.cozyRelativeUri +
+        '?' +
+        strings.cloudery.iOSQueryString
     )
   })
 
@@ -64,7 +75,10 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyProdBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
+      strings.cloudery.prodBaseUri +
+        strings.cloudery.cozyRelativeUri +
+        '?' +
+        strings.cloudery.androidQueryString
     )
   })
 
@@ -74,7 +88,10 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyProdBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
+      strings.cloudery.prodBaseUri +
+        strings.cloudery.cozyRelativeUri +
+        '?' +
+        strings.cloudery.androidQueryString
     )
   })
 
@@ -88,7 +105,9 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyProdBaseUri + '/v2/SOME_SOURCE/SOME_CONTEXT?' + strings.clouderyAndroidQueryString
+      strings.cloudery.prodBaseUri +
+        '/v2/SOME_SOURCE/SOME_CONTEXT?' +
+        strings.cloudery.androidQueryString
     )
   })
 
@@ -102,7 +121,10 @@ describe('extractEnvFromUrl', () => {
     const result = await getClouderyUrl()
 
     expect(result).toBe(
-      strings.clouderyProdBaseUri + strings.clouderyCozyRelativeUri + '?' + strings.clouderyAndroidQueryString
+      strings.cloudery.prodBaseUri +
+        strings.cloudery.cozyRelativeUri +
+        '?' +
+        strings.cloudery.androidQueryString
     )
   })
 })

--- a/src/screens/login/cloudery-env/clouderyEnv.ts
+++ b/src/screens/login/cloudery-env/clouderyEnv.ts
@@ -2,7 +2,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
 
 import { getOnboardingPartner } from '/screens/welcome/install-referrer/onboardingPartner'
-
 import strings from '/constants/strings.json'
 
 const ALL_CLOUDERY_ENV = ['DEV', 'INT', 'PROD'] as const
@@ -48,18 +47,19 @@ export const getClouderyUrl = async (): Promise<string> => {
   const clouderyEnv = await getClouderyEnvFromAsyncStorage()
 
   const baseUris: Record<ClouderyEnv, string> = {
-    PROD: strings.clouderyProdBaseUri,
-    INT: strings.clouderyIntBaseUri,
-    DEV: strings.clouderyDevBaseUri
+    PROD: strings.cloudery.prodBaseUri,
+    INT: strings.cloudery.intBaseUri,
+    DEV: strings.cloudery.devBaseUri
   }
   const baseUri = baseUris[clouderyEnv]
 
   const onboardingPartnerPath = await getOnboardingPartnerRelativeUrl()
-  const relativeUri = onboardingPartnerPath ?? strings.clouderyCozyRelativeUri
+  const relativeUri = onboardingPartnerPath ?? strings.cloudery.cozyRelativeUri
 
-  const queryString = Platform.OS === 'ios'
-      ? strings.clouderyiOSQueryString
-      : strings.clouderyAndroidQueryString
+  const queryString =
+    Platform.OS === 'ios'
+      ? strings.cloudery.iOSQueryString
+      : strings.cloudery.androidQueryString
 
   return `${baseUri}${relativeUri}?${queryString}`
 }

--- a/src/screens/welcome/WelcomeScreen.jsx
+++ b/src/screens/welcome/WelcomeScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { BackHandler, StyleSheet, Text, View } from 'react-native'
+import { BackHandler, StyleSheet, View } from 'react-native'
 
 import { WelcomePage } from '/components/html/WelcomePage'
 import { makeHTML } from '/components/makeHTML'
@@ -40,16 +40,19 @@ const WelcomeView = ({ setIsWelcomeModalDisplayed }) => {
   )
 }
 
-export const CozyWelcomeScreen = ({ navigation, route, setClient }) => {
+export const WelcomeScreen = ({ navigation, route, setClient }) => {
   const [isWelcomeModalDisplayed, setIsWelcomeModalDisplayed] = useState(true)
+  const { isInitialized, onboardingPartner } = useInstallReferrer()
 
   const handleBackPress = () => {
-    if (isWelcomeModalDisplayed) {
+    if (isWelcomeModalDisplayed || !onboardingPartner?.hasReferral) {
       BackHandler.exitApp()
     } else {
       setIsWelcomeModalDisplayed(true)
     }
   }
+
+  if (!isInitialized) return null
 
   return (
     <>
@@ -61,44 +64,10 @@ export const CozyWelcomeScreen = ({ navigation, route, setClient }) => {
         setClient={setClient}
         goBack={handleBackPress}
       />
-      {isWelcomeModalDisplayed && (
+      {isWelcomeModalDisplayed && !onboardingPartner.hasReferral && (
         <WelcomeView setIsWelcomeModalDisplayed={setIsWelcomeModalDisplayed} />
       )}
     </>
-  )
-}
-
-export const OnboardingPartnerWelcomeScreen = ({ partner }) => {
-  return (
-    <View style={{ marginTop: 50, backgroundColor: '#000' }}>
-      <Text>ONBOARDING PARTNER:</Text>
-      <Text>- SOURCE: {partner.source}</Text>
-      <Text>- CONTEXT: {partner.context}</Text>
-    </View>
-  )
-}
-
-export const WelcomeScreen = ({ navigation, route, setClient }) => {
-  const { isInitialized, onboardingPartner } = useInstallReferrer()
-
-  if (!isInitialized) return null
-
-  if (onboardingPartner.hasReferral)
-    return (
-      <OnboardingPartnerWelcomeScreen
-        navigation={navigation}
-        partner={onboardingPartner}
-        route={route}
-        setClient={setClient}
-      />
-    )
-
-  return (
-    <CozyWelcomeScreen
-      navigation={navigation}
-      route={route}
-      setClient={setClient}
-    />
   )
 }
 


### PR DESCRIPTION
> **Warning**
> This PR relies on cozy-stack new routes that are not implemented yet 

When the App detect OnboardingPartner context, it should skip the WelcomeScreen and directly display the ClouderyView instead

Also it should pass OnboardingPartner context to the Cloudery view so it can adapt its content to the detected partner

___

### Related PRs:

- #632
  - This PR reverts the WelcomeScreen custom page as we now want to skip this step instead (it will be handled by the Cloudery when partner is set)
