### PR TITLE
fix: handle shouldRepaintStatusBar better

### DIFF
--- a/src/libs/intents/setFlagshipUI.ts
+++ b/src/libs/intents/setFlagshipUI.ts
@@ -56,11 +56,19 @@ const shouldRepaintStatusBar = (
 ): void => {
   const lastTopTheme = ui.state.topTheme
 
-  if (topTheme && topTheme !== bottomTheme)
-    return StatusBar.setBarStyle(topTheme)
+  /**
+   * If the topTheme is defined, we should update the StatusBar
+   * even if it's not strictly necessary because changeBarColors() already did it.
+   */
+  if (topTheme) return StatusBar.setBarStyle(topTheme)
 
-  if (lastTopTheme && lastTopTheme !== bottomTheme)
-    return StatusBar.setBarStyle(lastTopTheme)
+  /**
+   * If the event does not have a topTheme, we should compare the last topTheme
+   * with the bottomTheme. If they are different, we want to override the
+   * changeBarColors() behavior and set the StatusBar to the last topTheme.
+   */
+  if (lastTopTheme !== bottomTheme)
+    StatusBar.setBarStyle(lastTopTheme ?? 'default')
 }
 
 const handleSideEffects = ({


### PR DESCRIPTION
shouldRepaintStatusBar() had a bug where it would detect false positives and repaint when it should not