### PR TITLE
feat: Send a signal to harvest to release the execution state

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -18,6 +18,12 @@ const log = Minilog('ReactNativeLauncher')
 
 Minilog.enable()
 
+function LauncherEvent() {}
+
+MicroEE.mixin(LauncherEvent)
+
+export const launcherEvent = new LauncherEvent()
+
 /**
  * This is the launcher implementation for a React native application
  */
@@ -111,6 +117,9 @@ class ReactNativeLauncher extends Launcher {
   async stop({ message } = {}) {
     const context = this.getStartContext()
     const client = context.client
+
+    launcherEvent.emit('launchResult', { cancel: true })
+
     await sendKonnectorsLogs(client)
     if (message) {
       await this.updateJobResult({

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -20,6 +20,7 @@ import { routes } from '/constants/routes'
 import { navigate } from '/libs/RootNavigation'
 import { getData, StorageKeys } from '/libs/localStore/storage'
 import { useHomeStateContext } from '/screens/home/HomeStateProvider'
+import { launcherEvent } from '/libs/ReactNativeLauncher'
 
 const unzoomHomeView = webviewRef => {
   webviewRef?.injectJavaScript(
@@ -57,6 +58,22 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
     )
 
     return subscription.remove
+  }, [webviewRef])
+
+  useEffect(() => {
+    const handleLaunchResult = () => {
+      const payload = JSON.stringify({
+        type: 'Clisk',
+        message: 'launchResult',
+        param: {
+          message: 'abort'
+        }
+      })
+      webviewRef?.postMessage(payload)
+    }
+    launcherEvent.on('launchResult', handleLaunchResult)
+    return () =>
+      launcherEvent.removeListener('launchResult', handleLaunchResult)
   }, [webviewRef])
 
   useEffect(() => {


### PR DESCRIPTION
When the user has run a clisk konnector, harvest display a "running"
state. If the user aborts the execution of the clisk konnector (login
failed for example), we want harvest to go back to idle state.

A signal is sent to harvest via postMessage to allow harvest to go to
the proper state.

Harvest side : https://github.com/cozy/cozy-libs/pull/2056

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

