### PR TITLE
fix: Use @in trigger for CliskTimeout service

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -387,10 +387,8 @@ export default class Launcher {
     const { data: timeoutTrigger } = await client.save({
       _type: 'io.cozy.triggers',
       worker: 'service',
-      type: '@at', // did not use @in because only @at triggers remove themselves after use
-      arguments: new Date(
-        Date.now() + constants.serviceTimeoutDuration
-      ).toISOString(),
+      type: '@in',
+      arguments: constants.serviceTimeoutDuration,
       message: {
         slug: 'home',
         name: 'cliskTimeout',

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -128,7 +128,7 @@ describe('ReactNativeLauncher', () => {
         4,
         expect.objectContaining({
           _type: 'io.cozy.triggers',
-          type: '@at',
+          type: '@in',
           worker: 'service',
           message: {
             slug: 'home',
@@ -182,7 +182,7 @@ describe('ReactNativeLauncher', () => {
       expect(client.destroy).toHaveBeenCalledWith(
         expect.objectContaining({
           _type: 'io.cozy.triggers',
-          type: '@at',
+          type: '@in',
           worker: 'service',
           message: {
             slug: 'home',
@@ -203,7 +203,7 @@ describe('ReactNativeLauncher', () => {
         2,
         expect.objectContaining({
           _type: 'io.cozy.triggers',
-          type: '@at',
+          type: '@in',
           worker: 'service',
           message: {
             slug: 'home',

--- a/src/screens/konnectors/constants/konnectors-constants.ts
+++ b/src/screens/konnectors/constants/konnectors-constants.ts
@@ -2,5 +2,5 @@ import { minutesToMilliseconds } from '/libs/functions/convertMinutesToMs'
 
 export const constants = {
   timeoutDuration: minutesToMilliseconds(15),
-  serviceTimeoutDuration: minutesToMilliseconds(20)
+  serviceTimeoutDuration: '20m'
 }


### PR DESCRIPTION
This avoids problems when client and service clocks are not synchronized
and it is now confirmed that @in triggers are well cleaned after run (on
redis)

