### PR TITLE
fix: Remove @in cliskTimeoutTrigger instead of @at

### DIFF
--- a/src/libs/konnectors/stopKonnectorJob.ts
+++ b/src/libs/konnectors/stopKonnectorJob.ts
@@ -44,7 +44,7 @@ const stopJob = async (client: CozyClient, jobId: string): Promise<unknown> => {
 }
 
 /**
- * Remove the @at trigger which will mark the given job as context deadline exceeded since this work is already done
+ * Remove the @in trigger which will mark the given job as context deadline exceeded since this work is already done
  */
 const findJobStopTriggerAndRemove = async (
   client: CozyClient,
@@ -53,7 +53,7 @@ const findJobStopTriggerAndRemove = async (
   const { data: triggers } = (await client.query(
     Q('io.cozy.triggers').where({
       worker: 'service',
-      type: '@at',
+      type: '@in',
       'message.fields.cliskJobId': jobId
     })
   )) as CozyClientQueryResult


### PR DESCRIPTION
We changed the cliskTimeout Trigger to @in trigger. This is now
reflected when we remove the trigger when the job is stopped (to avoid
to run a service to stop a job which is already stopped)


