### PR TITLE
feat: Bump app version to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.5
+# 1.0.6
 
 ## ✨ Features
 
@@ -8,6 +8,22 @@
 
 ## 🔧 Tech
 
+
+# 1.0.5
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+* Fix a bug that prevented cozy-home to be updated to latest version ([PR #639](https://github.com/cozy/cozy-react-native/pull/639))
+
+## 🔧 Tech
+
+* Add shell script to reset Android development environment ([PR #637](https://github.com/cozy/cozy-react-native/pull/637))
+* Fix a bug that prevented to update local cozy-app bundles on Android from a local development environment ([PR #638](https://github.com/cozy/cozy-react-native/pull/638))
+* Update ESLint config ([PR #646](https://github.com/cozy/cozy-react-native/pull/646))
+* Add foundations for `onboarded_redirection` param handling on Onbarding scenario ([PR #635](https://github.com/cozy/cozy-react-native/pull/635))
 
 # 1.0.4
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100040
-        versionName "1.0.4"
+        versionCode 100050
+        versionName "1.0.5"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.4</string>
+	<string>1.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100040</string>
+	<string>0100050</string>
 	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
 	<true/>
 	<key>GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.0.5
- creates a new entry for next 1.0.6 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs