### PR TITLE
feat: Encode Cozy's data before injecting it into Password form

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cozy-flags": "^2.11.0",
     "cozy-intent": "^2.9.0",
     "cozy-logger": "^1.10.0",
+    "html-entities": "^2.3.3",
     "lodash": "^4.17.21",
     "microee": "^0.0.6",
     "patch-package": "^6.4.7",

--- a/src/screens/login/components/assets/PasswordView/htmlPasswordInjection.js
+++ b/src/screens/login/components/assets/PasswordView/htmlPasswordInjection.js
@@ -2,6 +2,8 @@
 /* This code should reflect cozy-stack/assets/templates/login.html */
 /********************************************************************/
 
+import { encode } from 'html-entities'
+
 import { handleErrorMessage } from './js/jsHandleErrorMessage'
 import { loginJs } from './js/jsLogin'
 import { passwordHelperJs } from './js/jsPasswordHelper'
@@ -62,8 +64,8 @@ export const getHtml = (title, fqdn, instance) => {
 
         <div class="d-flex flex-column align-items-center">
           <img src="${avatarSvgUrl}" alt="" id="avatar" class="avatar my-3 border border-primary border-2 rounded-circle" style="box-sizing: content-box;" />
-          <h1 class="h4 h2-md mb-0 text-center">${title}</h1>
-          <p class="mb-4 mb-md-5 text-muted">${fqdn}</p>
+          <h1 class="h4 h2-md mb-0 text-center">${encode(title)}</h1>
+          <p class="mb-4 mb-md-5 text-muted">${encode(fqdn)}</p>
           <div id="login-field" class="input-group form-floating has-validation w-100">
             <input type="password" class="form-control form-control-md-lg" id="password" name="passphrase" autofocus autocomplete="current-password" />
             <label for="password">${strPasswordField}</label>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9140,6 +9140,11 @@ html-entities@^1.2.1, html-entities@^1.3.1:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
   integrity sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==
 
+html-entities@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.3.tgz#117d7626bece327fc8baace8868fa6f5ef856e46"
+  integrity sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"


### PR DESCRIPTION
In the Password form, `title` and `fqdn` injected data may come from the outside, so we want to encode them before injecting them into the HTML to prevent any code injection
