### PR TITLE
fix(iOS): Download file from Intent

### DIFF
--- a/src/components/webviews/ReloadInterceptorWebView.js
+++ b/src/components/webviews/ReloadInterceptorWebView.js
@@ -45,7 +45,14 @@ const interceptNavigation = ({
   client,
   setDownloadProgress
 }) => {
-  if (Platform.OS === 'ios' && !initialRequest.isTopFrame) {
+  const isPreviewableLink = checkIsPreviewableLink(initialRequest.url, client)
+  // We don't want to intecerpt iframe navigation excepts for iOS and the download
+  // Since we can download file from an iframe (intents)
+  if (
+    Platform.OS === 'ios' &&
+    !initialRequest.isTopFrame &&
+    !isPreviewableLink
+  ) {
     return true
   }
 
@@ -59,8 +66,6 @@ const interceptNavigation = ({
       return false
     }
   }
-
-  const isPreviewableLink = checkIsPreviewableLink(initialRequest.url, client)
 
   if (isPreviewableLink) {
     const fileExtension = getFileExtentionFromCozyDownloadUrl(


### PR DESCRIPTION
We can display a Drive Intent from Cozy-Banks
by clicking on the chip associated to the transactions.

This Drive intent shows the Viewer and this viewer has a "Download" button. This button was not working because for iOS we have to make some work in order to be download files, but we only did it for the
main frame. And since Intents are not in the main
frame, it was not working for them.

I fixed this issue by checking the link for every frames.



#### Checklist

Before merging this PR, the following things must have been done:
* [X] Tested on iOS

