### PR TITLE
feat: Bump app version to 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.6
+# 1.0.7
 
 ## ✨ Features
 
@@ -8,6 +8,27 @@
 
 ## 🔧 Tech
 
+
+# 1.0.6
+
+## ✨ Features
+
+* Client Side Connectors now display a "loading" screen until they are initialized ([PR #647](https://github.com/cozy/cozy-react-native/pull/647))
+* The App now redirects to the urser's default cozy-app on startup ([PR #653](https://github.com/cozy/cozy-react-native/pull/653) and [PR #650](https://github.com/cozy/cozy-react-native/pull/650))
+
+## 🐛 Bug Fixes
+
+* Fix a bug that prevented cozy-home to be updated ([PR #651](https://github.com/cozy/cozy-react-native/pull/651))
+* Fix some scenario where the status bar was not displayed with the correct color ([PR #657](https://github.com/cozy/cozy-react-native/pull/657))
+* Fix a bug that prevented Client Side Connectors to be openned from cozy-store ([PR #656](https://github.com/cozy/cozy-react-native/pull/656))
+* Improve Client Side Connectors life-cycle ([PR #649](https://github.com/cozy/cozy-react-native/pull/649), [PR #636](https://github.com/cozy/cozy-react-native/pull/636), [PR #662](https://github.com/cozy/cozy-react-native/pull/662) and [PR #663](https://github.com/cozy/cozy-react-native/pull/663))
+
+## 🔧 Tech
+
+* Remove Client Side Connectors specific code since it has been moved into Clisk library ([PR #640](https://github.com/cozy/cozy-react-native/pull/640))
+* Fix casing in install:home script ([PR #625](https://github.com/cozy/cozy-react-native/pull/625))
+* Implement OnboardingPartner and ClouderyEnv override using links ([PR #654](https://github.com/cozy/cozy-react-native/pull/654))
+* Add documentation about Android debug with new variants ([PR #664](https://github.com/cozy/cozy-react-native/pull/664))
 
 # 1.0.5
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100050
-        versionName "1.0.5"
+        versionCode 100060
+        versionName "1.0.6"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.5</string>
+	<string>1.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100050</string>
+	<string>0100060</string>
 	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
 	<true/>
 	<key>GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.0.6
- creates a new entry for next 1.0.7 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs