### PR TITLE
Feat/set default redirection from settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cozy-clisk": "^0.9.2",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
-    "cozy-intent": "^2.9.0",
+    "cozy-intent": "^2.10.0",
     "cozy-logger": "^1.10.0",
     "lodash": "^4.17.21",
     "microee": "^0.0.6",

--- a/src/libs/defaultRedirection/defaultRedirection.spec.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.spec.ts
@@ -11,6 +11,7 @@ import {
   fetchDefaultRedirectionUrl,
   setDefaultRedirectionUrl,
   getDefaultRedirectionUrl,
+  setDefaultRedirection,
   fetchAndSetDefaultRedirectionUrl,
   fetchAndSetDefaultRedirectionUrlInBackground,
   getOrFetchDefaultRedirectionUrl,
@@ -96,6 +97,23 @@ describe('getDefaultRedirectionUrl', () => {
     await getDefaultRedirectionUrl()
     expect(AsyncStorage.getItem).toHaveBeenCalledWith(
       strings.DEFAULT_REDIRECTION_URL_STORAGE_KEY
+    )
+  })
+})
+
+describe('setDefaultRedirection', () => {
+  const client = createMockClient({}) as CozyClient
+
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should set default redirection in async storage', async () => {
+    mockedFormatRedirectLink.mockReturnValue(DRIVE_URL)
+    await setDefaultRedirection('drive/', client)
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      strings.DEFAULT_REDIRECTION_URL_STORAGE_KEY,
+      DRIVE_URL
     )
   })
 })

--- a/src/libs/defaultRedirection/defaultRedirection.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.ts
@@ -63,6 +63,15 @@ export const getDefaultRedirectionUrl =
     )
   }
 
+export const setDefaultRedirection = async (
+  defaultRedirection: string,
+  client: CozyClient
+): Promise<void> => {
+  const defaultRedirectionUrl = formatRedirectLink(defaultRedirection, client)
+
+  await setDefaultRedirectionUrl(defaultRedirectionUrl)
+}
+
 export const fetchAndSetDefaultRedirectionUrl = async (
   client: CozyClient
 ): Promise<DefaultRedirectionUrl> => {

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -17,6 +17,7 @@ import { openApp } from '/libs/functions/openApp'
 import { resetSessionToken } from '/libs/functions/session'
 import { routes } from '/constants/routes'
 import { sendKonnectorsLogs } from '/libs/konnectors/sendKonnectorsLogs'
+import { setDefaultRedirection } from '/libs/defaultRedirection/defaultRedirection'
 import { setFlagshipUI } from '/libs/intents/setFlagshipUI'
 import { showInAppBrowser, closeInAppBrowser } from '/libs/intents/InAppBrowser'
 import { toggleSetting } from '/libs/intents/toggleSetting'
@@ -78,6 +79,19 @@ const openAppOSSettings = async (): Promise<null> => {
   return null
 }
 
+const setDefaultRedirectionWithClient = async (
+  defaultRedirection: string,
+  client?: CozyClient
+): Promise<null> => {
+  if (!client) {
+    return null
+  }
+
+  await setDefaultRedirection(defaultRedirection, client)
+
+  return null
+}
+
 export const internalMethods = {
   setFlagshipUI: (intent: FlagshipUI): Promise<null> => {
     const caller = (): string => {
@@ -123,6 +137,8 @@ export const localMethods = (
     openApp: (href, app, iconParams) =>
       openApp(client, RootNavigation, href, app, iconParams),
     toggleSetting,
+    setDefaultRedirection: defaultRedirection =>
+      setDefaultRedirectionWithClient(defaultRedirection, client),
     setFlagshipUI,
     showInAppBrowser,
     isBiometryDenied,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6380,10 +6380,10 @@ cozy-flags@^2.11.0:
   dependencies:
     microee "^0.0.6"
 
-cozy-intent@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.9.0.tgz#6651aac5cf8ac8bdc6faf4e34f22ab89534650ae"
-  integrity sha512-GrV/0hAQ2atbKrbmRTYUBFmq5ak2ZL1zEty7yQCi7S/OuTjkDIE4vVa42q3dFVtIiNGPMkyhsSuaB6mqTomYxQ==
+cozy-intent@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.10.0.tgz#606cd823442b0bc9b5914aec05272159f0158b4c"
+  integrity sha512-BxyErWLCIUrfQPBqgKlhPowQlSiL+auZtvjEg/DDjDkP36IdvbRBPGeG+56357rslgVeG8o+wchYr/8nCQRbPA==
   dependencies:
     post-me "0.4.5"
 


### PR DESCRIPTION
**Goal** : when you change default redirection in the _settings_ app, change it instantly on _flagship_ app to avoid the need to restart the app two times before seeing the change

This PR add a setDefaultRedirection method which can be called with a default redirection (and not a default redirection url), format the default redirection into a default redirection url and store it.

It also add a localMethod to use this method with webview intent.

Related : 
- https://github.com/cozy/cozy-libs/pull/2069 (will be updated here when merged)
- https://github.com/cozy/cozy-settings/pull/572