### PR TITLE
fix: Let worker error throw back to the pilot

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -296,14 +296,19 @@ class ReactNativeLauncher extends Launcher {
           // This way, the pilot can call the worker one more time
           // and be sure it is ready
           this.once('WORKER_RELOADED', () => {
-            reject('WORKER_RELOADED')
+            reject(new Error('WORKER_RELOADED'))
           })
         })
         // eslint-disable-next-line promise/catch-or-return
-        this.worker.call(method, ...args).then(resolve)
+        this.worker
+          .call(method, ...args)
+          .then(resolve)
+          .catch(err => reject(err))
       })
     } catch (err) {
-      log.info(`Got error in runInWorker ${err}`)
+      if (err.message !== 'WORKER_RELOADED') {
+        throw err
+      }
       return false
     }
   }

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -291,7 +291,7 @@ describe('ReactNativeLauncher', () => {
       expect(launcher.worker.call).toHaveBeenCalledTimes(1)
       expect(result).toEqual('worker result')
     })
-    it('should return false WORKER_WILL_RELOAD event is emitted', async () => {
+    it('should return false when WORKER_WILL_RELOAD event is emitted', async () => {
       const { launcher } = setup()
       launcher.worker.call.mockImplementation(async () => {
         launcher.emit('WORKER_WILL_RELOAD')
@@ -300,6 +300,13 @@ describe('ReactNativeLauncher', () => {
       })
       const result = await launcher.runInWorker('toRunInworker')
       expect(result).toEqual(false)
+    })
+    it('should throw error if any other error occured in the worker', async () => {
+      const { launcher } = setup()
+      launcher.worker.call.mockRejectedValue(new Error('worker error'))
+      await expect(() => launcher.runInWorker('toRunInworker')).rejects.toThrow(
+        'worker error'
+      )
     })
   })
   describe('getCookiesByDomain', () => {


### PR DESCRIPTION
Now when an error occurs in the worker, launcher will throw it back to
the pilot to have the konnector execution stopped without any unhandled
rejected promise



#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

