### PR TITLE
fix: Bind onWorkerError to launcherView

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -32,6 +32,7 @@ class LauncherView extends Component {
     super(props)
     this.onPilotMessage = this.onPilotMessage.bind(this)
     this.onWorkerMessage = this.onWorkerMessage.bind(this)
+    this.onWorkerError = this.onWorkerError.bind(this)
     this.onStopExecution = this.onStopExecution.bind(this)
     this.onCreatedAccount = this.onCreatedAccount.bind(this)
     this.onCreatedJob = this.onCreatedJob.bind(this)


### PR DESCRIPTION
onWorkerError can be called when the the webview fails to load.
I could not reproduce it but it happens.

Now, with the proper binding, the job will be properly stopped on this error

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

