### PR TITLE
fix: Personalize notification icon in Android release build

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <uses-sdk tools:overrideLibrary="androidx.core.splashscreen" />
 
@@ -16,8 +17,7 @@
       <meta-data android:name="google_analytics_ssaid_collection_enabled" android:value="false" />
       <meta-data
         android:name="com.google.firebase.messaging.default_notification_icon"
-        android:resource="@mipmap/ic_stat_ic_notification"
-      />
+        android:resource="@mipmap/ic_stat_ic_notification" />
       <meta-data
         android:name="com.google.firebase.messaging.default_notification_color"
         android:resource="@color/black"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,10 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="io.cozy.flagship.mobile">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"/>
+    <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE" />
     <queries>
       <intent>
         <action android:name="android.intent.action.VIEW" />
@@ -70,6 +72,13 @@
       <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
       <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
       <meta-data android:name="google_analytics_ssaid_collection_enabled" android:value="false" />
+      <meta-data
+        android:name="com.google.firebase.messaging.default_notification_icon"
+        android:resource="@mipmap/ic_stat_ic_notification" />
+      <meta-data
+        android:name="com.google.firebase.messaging.default_notification_color"
+        android:resource="@color/black"
+        tools:replace="android:resource" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Notification icon was only added in debug/AndroidManifest.xml, so it was not present in release build.

_Please explain what this PR does here._

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] ~~Faithful integration of the mockups at all screen sizes~~
* [ ] ~~Tested on iOS~~
* [x] Tested on Android
* [ ] ~~Localized in English and French~~
* [ ] ~~All changes have test coverage~~
* [ ] ~~Updated README & CHANGELOG, if necessary~~

