### PR TITLE
feat: Bump app version to 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.7
+# 1.0.8
 
 ## ✨ Features
 
@@ -8,6 +8,24 @@
 
 ## 🔧 Tech
 
+
+# 1.0.7
+
+## ✨ Features
+
+* Improve Client Side Connectors performance when downloading files ([PR #633](https://github.com/cozy/cozy-react-native/pull/633))
+
+## 🐛 Bug Fixes
+
+* Fix a bug that makes Client Side Connectors hang after initialization ([PR #652](https://github.com/cozy/cozy-react-native/pull/652))
+* Fix a bug that prevents Client Side Connectors to stop if the user cancel the login step ([PR #659](https://github.com/cozy/cozy-react-native/pull/659))
+* Cozy's font is now correcly used on Welcome and Error screens ([PR #669](https://github.com/cozy/cozy-react-native/pull/669))
+
+## 🔧 Tech
+
+* Add performance logs on Client Side Connectors execution ([PR #668](https://github.com/cozy/cozy-react-native/pull/668))
+* Add foundations for OnboardingPartner onboarding ([PR #655](https://github.com/cozy/cozy-react-native/pull/655))
+* Prevent code injection on Password screen ([PR #672](https://github.com/cozy/cozy-react-native/pull/672))
 
 # 1.0.6
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100060
-        versionName "1.0.6"
+        versionCode 100070
+        versionName "1.0.7"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100060</string>
+	<string>0100070</string>
 	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
 	<true/>
 	<key>GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.0.7
- creates a new entry for next 1.0.8 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs