### PR TITLE
Fix/handle default redirection error ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@sentry/integrations": "6.19.2",
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
-    "cozy-client": "^35.6.0",
+    "cozy-client": "^36.2.0",
     "cozy-clisk": "^0.9.4",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",

--- a/src/libs/defaultRedirection/defaultRedirection.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.ts
@@ -27,7 +27,7 @@ export type DefaultRedirectionUrl = string | null
 export const fetchDefaultRedirectionUrl = async (
   client: CozyClient
 ): Promise<DefaultRedirectionUrl> => {
-  let defaultRedirectionUrl
+  let defaultRedirectionUrl: DefaultRedirectionUrl
 
   try {
     const { data } = (await client.query(
@@ -68,7 +68,7 @@ export const fetchAndSetDefaultRedirectionUrl = async (
 ): Promise<DefaultRedirectionUrl> => {
   const newDefaultRedirectionUrl = await fetchDefaultRedirectionUrl(client)
 
-  if (!newDefaultRedirectionUrl) return null
+  if (newDefaultRedirectionUrl === null) return null
 
   await setDefaultRedirectionUrl(newDefaultRedirectionUrl)
 

--- a/src/libs/defaultRedirection/defaultRedirection.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.ts
@@ -27,7 +27,7 @@ export type DefaultRedirectionUrl = string | null
 export const fetchDefaultRedirectionUrl = async (
   client: CozyClient
 ): Promise<DefaultRedirectionUrl> => {
-  let defaultRedirectionUrl: DefaultRedirectionUrl
+  let defaultRedirectionUrl
 
   try {
     const { data } = (await client.query(

--- a/src/libs/functions/formatRedirectLink.spec.ts
+++ b/src/libs/functions/formatRedirectLink.spec.ts
@@ -10,15 +10,19 @@ describe('formatRedirectLink', () => {
     })
   } as CozyClient
 
-  it('should format onboarding redirection', () => {
+  it('should format redirect link with hash', () => {
     expect(formatRedirectLink('contacts/#/hash', client)).toStrictEqual(
       'http://contacts.mycozy.test/#/hash'
     )
   })
 
-  it('should format onboarding redirection', () => {
+  it('should format redirect link with path and hash', () => {
     expect(formatRedirectLink('contacts/path/#/hash', client)).toStrictEqual(
       'http://contacts.mycozy.test/path/#/hash'
     )
+  })
+
+  it('should return null when redirect link is invalid', () => {
+    expect(formatRedirectLink('http://home.mycozy.test', client)).toBe(null)
   })
 })

--- a/src/libs/functions/formatRedirectLink.ts
+++ b/src/libs/functions/formatRedirectLink.ts
@@ -1,25 +1,39 @@
+import Minilog from '@cozy/minilog'
+
 import CozyClient, {
   generateWebLink,
   deconstructRedirectLink
 } from 'cozy-client'
 
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+const log = Minilog('formatRedirectLink')
+
 export const formatRedirectLink = (
-  onboardingRedirection: string,
+  redirectLink: string,
   client: CozyClient
-): string => {
+): string | null => {
   const cozyUrl = client.getStackClient().uri
   const subDomainType = client.getInstanceOptions().capabilities.flat_subdomains
     ? 'flat'
     : 'nested'
 
-  const { slug, path, hash } = deconstructRedirectLink(onboardingRedirection)
+  try {
+    const { slug, pathname, hash } = deconstructRedirectLink(redirectLink)
 
-  return generateWebLink({
-    cozyUrl,
-    subDomainType,
-    slug,
-    pathname: path,
-    hash,
-    searchParams: []
-  })
+    return generateWebLink({
+      cozyUrl,
+      subDomainType,
+      slug,
+      pathname,
+      hash,
+      searchParams: []
+    })
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error(
+      `Something went wrong while trying to format redirect link: ${errorMessage}`
+    )
+    return null
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,21 +3820,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@5.36.0", "@typescript-eslint/eslint-plugin@^4.5.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.0.tgz#8f159c4cdb3084eb5d4b72619a2ded942aa109e5"
-  integrity sha512-X3In41twSDnYRES7hO2xna4ZC02SY05UN9sGW//eL1P5k4CKfvddsdC2hOq0O3+WU1wkCPQkiTY9mzSnXKkA0w==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.36.0"
-    "@typescript-eslint/type-utils" "5.36.0"
-    "@typescript-eslint/utils" "5.36.0"
-    debug "^4.3.4"
-    functional-red-black-tree "^1.0.1"
-    ignore "^5.2.0"
-    regexpp "^3.2.0"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
-
 "@typescript-eslint/eslint-plugin@5.54.0":
   version "5.54.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.0.tgz#2c821ad81b2c786d142279a8292090f77d1881f4"
@@ -3850,6 +3835,32 @@
     regexpp "^3.2.0"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/eslint-plugin@^4.5.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
+  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.33.0"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    debug "^4.3.1"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/experimental-utils@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
+  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/experimental-utils@^3.10.1":
   version "3.10.1"
@@ -3902,13 +3913,13 @@
     "@typescript-eslint/types" "4.26.0"
     "@typescript-eslint/visitor-keys" "4.26.0"
 
-"@typescript-eslint/scope-manager@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.36.0.tgz#f4f859913add160318c0a5daccd3a030d1311530"
-  integrity sha512-PZUC9sz0uCzRiuzbkh6BTec7FqgwXW03isumFVkuPw/Ug/6nbAqPUZaRy4w99WCOUuJTjhn3tMjsM94NtEj64g==
+"@typescript-eslint/scope-manager@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
+  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
   dependencies:
-    "@typescript-eslint/types" "5.36.0"
-    "@typescript-eslint/visitor-keys" "5.36.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
 
 "@typescript-eslint/scope-manager@5.54.0":
   version "5.54.0"
@@ -3917,16 +3928,6 @@
   dependencies:
     "@typescript-eslint/types" "5.54.0"
     "@typescript-eslint/visitor-keys" "5.54.0"
-
-"@typescript-eslint/type-utils@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.36.0.tgz#5d2f94a36a298ae240ceca54b3bc230be9a99f0a"
-  integrity sha512-W/E3yJFqRYsjPljJ2gy0YkoqLJyViWs2DC6xHkXcWyhkIbCDdaVnl7mPLeQphVI+dXtY05EcXFzWLXhq8Mm/lQ==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "5.36.0"
-    "@typescript-eslint/utils" "5.36.0"
-    debug "^4.3.4"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/type-utils@5.54.0":
   version "5.54.0"
@@ -3948,10 +3949,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.26.0.tgz#7c6732c0414f0a69595f4f846ebe12616243d546"
   integrity sha512-rADNgXl1kS/EKnDr3G+m7fB9yeJNnR9kF7xMiXL6mSIWpr3Wg5MhxyfEXy/IlYthsqwBqHOr22boFbf/u6O88A==
 
-"@typescript-eslint/types@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.36.0.tgz#cde7b94d1c09a4f074f46db99e7bd929fb0a5559"
-  integrity sha512-3JJuLL1r3ljRpFdRPeOtgi14Vmpx+2JcR6gryeORmW3gPBY7R1jNYoq4yBN1L//ONZjMlbJ7SCIwugOStucYiQ==
+"@typescript-eslint/types@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
+  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
 
 "@typescript-eslint/types@5.54.0":
   version "5.54.0"
@@ -3985,17 +3986,17 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.0.tgz#0acce61b4850bdb0e578f0884402726680608789"
-  integrity sha512-EW9wxi76delg/FS9+WV+fkPdwygYzRrzEucdqFVWXMQWPOjFy39mmNNEmxuO2jZHXzSQTXzhxiU1oH60AbIw9A==
+"@typescript-eslint/typescript-estree@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
+  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
   dependencies:
-    "@typescript-eslint/types" "5.36.0"
-    "@typescript-eslint/visitor-keys" "5.36.0"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    semver "^7.3.7"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
     tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@5.54.0":
@@ -4010,18 +4011,6 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
-
-"@typescript-eslint/utils@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.36.0.tgz#104c864ecc1448417606359275368bf3872bbabb"
-  integrity sha512-wAlNhXXYvAAUBbRmoJDywF/j2fhGLBP4gnreFvYvFbtlsmhMJ4qCKVh/Z8OP4SgGR3xbciX2nmG639JX0uw1OQ==
-  dependencies:
-    "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.36.0"
-    "@typescript-eslint/types" "5.36.0"
-    "@typescript-eslint/typescript-estree" "5.36.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
 
 "@typescript-eslint/utils@5.54.0", "@typescript-eslint/utils@^5.10.0":
   version "5.54.0"
@@ -4052,13 +4041,13 @@
     "@typescript-eslint/types" "4.26.0"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.0.tgz#565d35a5ca00d00a406a942397ead2cb190663ba"
-  integrity sha512-pdqSJwGKueOrpjYIex0T39xarDt1dn4p7XJ+6FqBWugNQwXlNGC5h62qayAIYZ/RPPtD+ButDWmpXT1eGtiaYg==
+"@typescript-eslint/visitor-keys@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
+  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
   dependencies:
-    "@typescript-eslint/types" "5.36.0"
-    eslint-visitor-keys "^3.3.0"
+    "@typescript-eslint/types" "4.33.0"
+    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@5.54.0":
   version "5.54.0"
@@ -6328,16 +6317,16 @@ cozy-client@^34.11.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^35.6.0:
-  version "35.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-35.6.0.tgz#f052a020f9f3bf19a85448d72c38d182c08e8da3"
-  integrity sha512-kDmUXWC9tV+vgqixhKigpnb8AmNUzZLgP6tF8SW5O50/TlORHLVvNlLg63m40ApDSMK1TaCFe+zSkYnF6/ojMQ==
+cozy-client@^36.2.0:
+  version "36.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-36.2.0.tgz#662a659415dd9c7d8ae0d69e6c445bcbdaf1a935"
+  integrity sha512-CLom7iJ8b3cCPvA537BNxe7n1DGE6vM48P/xtjLB+Hl7ZKFWMiWSWKHgfQqxKwrDxwnNDD9XJ7VCxwlMBdqpWw==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^35.6.0"
+    cozy-stack-client "^36.2.0"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -6404,10 +6393,10 @@ cozy-stack-client@^34.11.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^35.6.0:
-  version "35.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-35.6.0.tgz#9d650adc7f3661e2328780cacab87b7060f8ef4c"
-  integrity sha512-EVnRHemYHv9NXFeVP003QQ04OpHrcQIp8RQk4zAyS5Qm8dASagF5hZed4K6C+Fs4Z7qSYmP1GRM2zmqiqU3RfQ==
+cozy-stack-client@^36.2.0:
+  version "36.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-36.2.0.tgz#7e012279519128355c4886ac973cd062c7c4b2aa"
+  integrity sha512-E2eLDmCmYJQh/9WwR77mXs+/aoxB/dbRBxj2Q7LItr9ypTXSFaWZEjiTu7fiu83p04BwybAkzI26Zc4aBbpjRg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -9289,6 +9278,11 @@ ignore@^5.1.4, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
+ignore@^5.1.8:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 image-q@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
(duplicate PR to test CI)

Fix to avoid errors when a redirect link (default redirect, onboarding redirection) is invalid.

Now, it also allows to run app even if the stack has not been updated with the fix of invalid default redirection.
