### PR TITLE
feat: Intercept handshake failed errors from clisk webviews

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -99,8 +99,30 @@ class LauncherView extends Component {
         })
       })
     } catch (err) {
-      log.error({ err })
-      return 'UNKNOWN_ERROR'
+      this.launcher.log({
+        level: 'error',
+        msg:
+          'launcherView.initKonnector.ensureKonnectorIsInstalled: ' +
+          err.message
+      })
+      return new Error('UNKNOWN_ERROR.KONNECTOR_INSTALL')
+    }
+    try {
+      if (this.state.konnector) {
+        await this.launcher.init({
+          bridgeOptions: {
+            pilotWebView: this.pilotWebView,
+            workerWebview: this.workerWebview
+          },
+          contentScript: get(this, 'state.konnector.content')
+        })
+      }
+    } catch (err) {
+      this.launcher.log({
+        level: 'error',
+        msg: 'launcherView.initKonnector.HANDSHAKE: ' + err.message
+      })
+      return new Error('UNKNOWN_ERROR.HANDSHAKE_FAILED')
     }
   }
 
@@ -143,16 +165,6 @@ class LauncherView extends Component {
     this.launcher.on('CREATED_ACCOUNT', this.onCreatedAccount)
     this.launcher.on('CREATED_JOB', this.onCreatedJob)
     this.launcher.on('STOPPED_JOB', this.onStoppedJob)
-
-    if (this.state.konnector) {
-      await this.launcher.init({
-        bridgeOptions: {
-          pilotWebView: this.pilotWebView,
-          workerWebview: this.workerWebview
-        },
-        contentScript: get(this, 'state.konnector.content')
-      })
-    }
 
     startTimeout(() => {
       this.launcher.stop({ message: TIMEOUT_KONNECTOR_ERROR })


### PR DESCRIPTION
Now the initialization of clisk view is done in the same method as
installation of the konnector.

Any error inside this method is intercepted, logged in the konnector
logs and passed the start method as UNKNOWN_ERROR

This way, it will be possible to get this error logged in production

_Please explain what this PR does here._

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

