### PR TITLE
fix: Remove default redirection url from AsyncStorage on logout

### DIFF
--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -12,6 +12,7 @@ export enum StorageKeys {
   BiometryActivated = '@cozy_AmiralApp_biometryActivated',
   Capabilities = '@cozy_AmiralApp_Capabilities',
   LastActivity = '@cozy_AmiralApp_lastActivity',
+  DefaultRedirectionUrl = '@cozy_AmiralAppDefaultRedirectionUrl',
   SessionCreatedFlag = 'SESSION_CREATED_FLAG'
 }
 


### PR DESCRIPTION
Avoid to redirect to the default redirection url of the previous logged in user.