### PR TITLE
fix: Query warning

### DIFF
--- a/src/libs/defaultRedirection/defaultRedirection.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.ts
@@ -31,7 +31,7 @@ export const fetchDefaultRedirectionUrl = async (
 
   try {
     const { data } = (await client.query(
-      Q('io.cozy.settings').getById('instance'),
+      Q('io.cozy.settings').getById('io.cozy.settings.instance'),
       {
         as: 'io.cozy.settings/instance'
       }


### PR DESCRIPTION
Since requesting just the end of the id is deprecated (since the latest upgrade of cozy-client), let's adapt the code to request the real id.
