### PR TITLE
Konnector/js interception

### DIFF
--- a/src/constants/dev-config.ts
+++ b/src/constants/dev-config.ts
@@ -7,7 +7,7 @@ export const devConfig = {
   disableGetIndex: false, // Bypass HTTPServer HTML generation which will fallback to local stack, useful for webpack-dev-server
   enableLocalSentry: false, // Be warned that it will send actual logs to Sentry on the "test" environment, use sparingly
   enableReduxLogger: false, // Outputs to console every Redux action with payload, prev and next state
-  enableKonnectorPostMeLogger: false, // Outputs every post-me exchanges between launcher and pilot and worker
+  enableKonnectorPostMeLogger: true, // Outputs every post-me exchanges between launcher and pilot and worker
   forceHideSplashScreen: false, // Hide react-native splash screen renders, useful for debugging in case of a webview crash
   forceOffline: false, // Force offline mode by overwriting the NetInfo module and returning a fake offline state,
   ignoreLogBox: false, // Hide react-native LogBox renders but still display logs to the console,

--- a/src/constants/dev-config.ts
+++ b/src/constants/dev-config.ts
@@ -7,7 +7,7 @@ export const devConfig = {
   disableGetIndex: false, // Bypass HTTPServer HTML generation which will fallback to local stack, useful for webpack-dev-server
   enableLocalSentry: false, // Be warned that it will send actual logs to Sentry on the "test" environment, use sparingly
   enableReduxLogger: false, // Outputs to console every Redux action with payload, prev and next state
-  enableKonnectorPostMeLogger: true, // Outputs every post-me exchanges between launcher and pilot and worker
+  enableKonnectorExtensiveLog: true, // Outputs every post-me exchanges between launcher, pilot and worker, but also every console.* coming from the webview
   forceHideSplashScreen: false, // Hide react-native splash screen renders, useful for debugging in case of a webview crash
   forceOffline: false, // Force offline mode by overwriting the NetInfo module and returning a fake offline state,
   ignoreLogBox: false, // Hide react-native LogBox renders but still display logs to the console,

--- a/src/core/tools/env.ts
+++ b/src/core/tools/env.ts
@@ -55,7 +55,7 @@ const {
   enableReduxLogger,
   enforcedInstallReferrer,
   forceInstallReferrer,
-  enableKonnectorPostMeLogger
+  enableKonnectorExtensiveLog
 } = getDevConfig(isDev())
 
 if (enableLocalSentry) toggleLocalSentry(true)
@@ -70,8 +70,8 @@ export const getEnforcedInstallReferrer = (): string => enforcedInstallReferrer
 export const shouldEnableReduxLogger = (): boolean =>
   enableReduxLogger && !isTest()
 
-export const shouldEnableKonnectorPostMeLogger = (): boolean =>
-  enableKonnectorPostMeLogger
+export const shouldEnableKonnectorExtensiveLog = (): boolean =>
+  enableKonnectorExtensiveLog
 
 export const EnvService = {
   name,

--- a/src/libs/bridge/ContentScriptBridge.js
+++ b/src/libs/bridge/ContentScriptBridge.js
@@ -2,7 +2,7 @@ import { ParentHandshake } from 'post-me'
 
 import { Bridge } from 'cozy-clisk'
 
-import { shouldEnableKonnectorPostMeLogger } from '/core/tools/env'
+import { shouldEnableKonnectorExtensiveLog } from '/core/tools/env'
 
 import ReactNativeLauncherMessenger from './ReactNativeLauncherMessenger'
 
@@ -20,7 +20,7 @@ export default class ContentScriptBridge extends Bridge {
     exposedMethodsNames = [],
     listenedEventsNames = [],
     webViewRef,
-    debug = shouldEnableKonnectorPostMeLogger()
+    debug = shouldEnableKonnectorExtensiveLog()
   } = {}) {
     if (root) {
       this.root = root

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -6,7 +6,7 @@ import {
   jsLogInterception,
   tryConsole
 } from '/components/webviews/jsInteractions/jsLogInterception'
-import { shouldEnableKonnectorPostMeLogger } from '/core/tools/env'
+import { shouldEnableKonnectorExtensiveLog } from '/core/tools/env'
 
 import debounce from 'lodash/debounce'
 import get from 'lodash/get'
@@ -197,7 +197,7 @@ class LauncherView extends Component {
         ? styles.workerVisible
         : styles.workerHidden
 
-    const debug = shouldEnableKonnectorPostMeLogger()
+    const debug = shouldEnableKonnectorExtensiveLog()
     const run = debug
       ? `
         (function() {


### PR DESCRIPTION
This PR adds the JS interception for console.* we have on other webviews to the konnectors ones. Like that, we can now see console.log() message from the pilote / worker in our flagship log. 
