### PR TITLE
fix: Android Universal Link

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,13 +50,13 @@
           <category android:name="android.intent.category.BROWSABLE" />
           <data android:scheme="cozy" />
         </intent-filter>
-        <intent-filter>
+        <intent-filter android:autoVerify="true">
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-          <data android:scheme="https"
-            android:host="links.mycozy.cloud"
-            android:pathPrefix="/flagship" />
+          <data android:scheme="https" />
+          <data android:host="links.mycozy.cloud" />
+          <data android:pathPrefix="/flagship" />
         </intent-filter>
       </activity>
       <activity


### PR DESCRIPTION
UL was not working because I forgot to add the
android:autoVerify="true" tag for the intent...

Adding it, makes the UL work.

I also converted the old definition to the new one, see https://stackoverflow.com/questions/68144323/app-links-legacy-failure-verification-error-on-android-12 for more information.

UL tested:
```
adb shell am start -W -a android.intent.action.VIEW -d "https://links.mycozy.cloud/flagship/\?fallback\=https%3A%2F%2Ffoo-home.mycozy.cloud%2F%23%2Fconnected%2Falan%2Faccounts%2F123456789\#/connected/alan/accounts/123456789"
```