### PR TITLE
fix: use setParams instead of navigate in LauncherView

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -22,7 +22,7 @@ import {
   startTimeout,
   stopTimeout
 } from '/screens/konnectors/core/handleTimeout'
-import { navigate } from '/libs/RootNavigation'
+import { navigationRef } from '/libs/RootNavigation'
 import { TIMEOUT_KONNECTOR_ERROR } from '/libs/Launcher'
 
 const log = Minilog('LauncherView')
@@ -79,10 +79,13 @@ class LauncherView extends Component {
    *
    * @param {import('cozy-client/types/types').IOCozyAccount} - cozy account object
    */
-  onCreatedAccount(account) {
-    const { launcherContext } = this.props
-    const konnector = launcherContext.konnector.slug
-    navigate('default', { konnector, account: account._id })
+  onCreatedAccount({ _id: account }) {
+    const konnector = this.props.launcherContext.konnector.slug
+
+    // We already are in the Home Screen if we reach this point, so we just need to set params, no need to navigate.
+    // It will trigger a re-render of the Home Screen and the Homeview uri will be updated
+    // with the new account id and the konnector slug, making Harvest function properly.
+    navigationRef.setParams({ account, konnector })
   }
 
   /**


### PR DESCRIPTION
## What does this do?

- When connecting a Konnector account, onCreatedAccount() will use the setParams() API instead of the navigate() API (react-navigation). This makes it possible to navigate to the Harvest logged in view while connecting for the first time.

## Why did you do this?

- Navigating to 'default' or to 'home' could not work correctly as it was already the current page. It had unexpected behaviours and resulted in various cryptic navigation state update bugs. By using setParams() we are modifying the current route, and therefore homeview behaves correctly and gives the correct uri to cozy-home and harvest.

## Who/what does this impact?

- When connecting an account to a CCC

## How did you test this?

- Only test manually and on local environment. Unit testing would be very hard at this point in time (but needed) and integration close to impossible