### PR TITLE
feat: delete existing accounts if needed

### DIFF
--- a/src/libs/Launcher.functions.spec.ts
+++ b/src/libs/Launcher.functions.spec.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import CozyClient from 'cozy-client'
+
+import { cleanExistingAccountsForKonnector } from './Launcher.functions'
+
+const client = {
+  query: jest.fn(),
+  destroy: jest.fn()
+} as Partial<CozyClient> as jest.Mocked<CozyClient>
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+it('should clean existing accounts for konnector', async () => {
+  const konnectorSlug = 'test'
+  const accounts = [
+    {
+      _id: '1',
+      _type: 'io.cozy.accounts',
+      accountType: konnectorSlug
+    },
+    {
+      _id: '2',
+      _type: 'io.cozy.accounts',
+      accountType: konnectorSlug
+    }
+  ]
+  client.query.mockResolvedValueOnce({ data: accounts })
+  await cleanExistingAccountsForKonnector(client, konnectorSlug)
+  expect(client.query).toHaveBeenCalledWith(
+    expect.objectContaining({
+      selector: {
+        accountType: konnectorSlug
+      }
+    })
+  )
+  expect(client.destroy).toHaveBeenCalledTimes(2)
+  expect(client.destroy).toHaveBeenCalledWith(accounts[0])
+  expect(client.destroy).toHaveBeenCalledWith(accounts[1])
+})
+
+it('should do nothing if no accounts', async () => {
+  const konnectorSlug = 'test'
+  client.query.mockResolvedValueOnce({ data: [] })
+  await cleanExistingAccountsForKonnector(client, konnectorSlug)
+  expect(client.query).toHaveBeenCalledWith(
+    expect.objectContaining({
+      selector: {
+        accountType: konnectorSlug
+      }
+    })
+  )
+  expect(client.destroy).not.toHaveBeenCalled()
+})

--- a/src/libs/Launcher.functions.ts
+++ b/src/libs/Launcher.functions.ts
@@ -1,0 +1,27 @@
+import CozyClient, { Q } from 'cozy-client'
+import type { CozyClientDocument } from 'cozy-client/types/types'
+
+export const cleanExistingAccountsForKonnector = async (
+  client: CozyClient,
+  konnectorSlug: string,
+  log?: MiniLogger
+): Promise<void> => {
+  const { data: accounts } = (await client.query(
+    Q('io.cozy.accounts').where({
+      accountType: konnectorSlug
+    })
+  )) as { data: CozyClientDocument[] }
+
+  if (accounts.length === 0) {
+    log?.info(`No existing accounts for "${konnectorSlug}"`)
+    return
+  }
+
+  log?.info(
+    `Deleting ${accounts.length} existing accounts for "${konnectorSlug}"`
+  )
+
+  for (const account of accounts) {
+    await client.destroy(account)
+  }
+}

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -6,6 +6,7 @@ import set from 'lodash/set'
 import { Q, models } from 'cozy-client'
 import { saveFiles, saveBills, saveIdentity } from 'cozy-clisk'
 
+import { cleanExistingAccountsForKonnector } from './Launcher.functions'
 import { ensureKonnectorFolder } from './folder'
 import { saveCredential, getCredential, removeCredential } from './keychain'
 import { dataURItoArrayBuffer } from './utils'
@@ -216,6 +217,9 @@ export default class Launcher {
       log.debug(
         `ensureAccountAndTriggerAndJob: found no account in start context. Creating one`
       )
+
+      await cleanExistingAccountsForKonnector(client, konnector.slug, log)
+
       const accountData = models.account.buildAccount(konnector, {})
       accountData._type = 'io.cozy.accounts'
       const accountResponse = await client.save(accountData)


### PR DESCRIPTION
## What does this do?

- When connecting a Konnector account, we check if any account is linked to this connector. If this is the case, we delete all of them. This avoids multi-account on a CCC.

## Why did you do this?

- For now, we don't want CCC to use the multiple account feature.

## Who/what does this impact?

- Every CCC

## How did you test this?

- Tested manually with accounts created in local CouchDB
- Added unit test for the new function
- The new function logs what it does for debugging purposes