### PR TITLE
fix: Set appMetadata for LauncherClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@sentry/integrations": "6.19.2",
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
-    "cozy-client": "^36.2.0",
+    "cozy-client": "^37.1.0",
     "cozy-clisk": "^0.9.4",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -173,7 +173,7 @@ export default class Launcher {
    * @returns {Promise<import('cozy-client/types/types').IOCozyAccount>}
    */
   async ensureAccountName(account) {
-    const { client, konnector } = this.getStartContext()
+    const { client } = this.getStartContext()
     const { sourceAccountIdentifier } = this.getUserData() || {}
     if (!account._id) {
       throw new Error('ensureAccountName: no account to check')
@@ -209,8 +209,15 @@ export default class Launcher {
   async ensureAccountTriggerAndLaunch() {
     const result = {}
     const startContext = this.getStartContext()
-    let { trigger, account, konnector, client, job, ...restOfContext } =
-      startContext
+    let {
+      trigger,
+      account,
+      konnector,
+      client,
+      job,
+      launcherClient,
+      ...restOfContext
+    } = startContext
 
     if (!account) {
       log.debug(
@@ -224,6 +231,11 @@ export default class Launcher {
       result.createdAccount = account
     }
     account = await this.ensureAccountName(account)
+    // since we know the account, let's set it to the client used by the
+    // konnector.
+    launcherClient.setAppMetadata({
+      sourceAccount: account._id
+    })
     const folder = await ensureKonnectorFolder(client, {
       konnector,
       account
@@ -260,6 +272,7 @@ export default class Launcher {
       trigger,
       job,
       konnector,
+      launcherClient,
       ...restOfContext
     })
     return result

--- a/src/libs/Launcher.spec.js
+++ b/src/libs/Launcher.spec.js
@@ -13,6 +13,9 @@ describe('Launcher', () => {
       const job = { _id: 'testjob' }
       const client = {}
       const konnector = {}
+      const launcherClient = {
+        setAppMetadata: () => null
+      }
       launcher.ensureAccountName = jest.fn().mockResolvedValue(account)
       launcher.setStartContext({
         client,
@@ -20,8 +23,10 @@ describe('Launcher', () => {
         account,
         trigger,
         job,
-        manifest: { name: 'konnector' }
+        manifest: { name: 'konnector' },
+        launcherClient
       })
+
       await launcher.ensureAccountTriggerAndLaunch()
       expect(launcher.getStartContext()).toStrictEqual({
         account,
@@ -29,7 +34,8 @@ describe('Launcher', () => {
         job,
         client,
         konnector,
-        manifest: { name: 'konnector' }
+        manifest: { name: 'konnector' },
+        launcherClient
       })
     })
   })

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -90,7 +90,10 @@ describe('ReactNativeLauncher', () => {
       const { launcher, client, launch } = setup()
       launcher.setStartContext({
         client,
-        konnector: { slug: 'konnectorslug', clientSide: true }
+        konnector: { slug: 'konnectorslug', clientSide: true },
+        launcherClient: {
+          setAppMetadata: () => null
+        }
       })
       launch.mockResolvedValue({ data: fixtures.job })
       client.query.mockResolvedValue({ data: fixtures.account })
@@ -148,7 +151,10 @@ describe('ReactNativeLauncher', () => {
         client,
         account: fixtures.account,
         trigger: fixtures.trigger,
-        konnector: { slug: 'konnectorslug', clientSide: true }
+        konnector: { slug: 'konnectorslug', clientSide: true },
+        launcherClient: {
+          setAppMetadata: () => null
+        }
       })
       launch.mockResolvedValue({ data: fixtures.job })
       client.query.mockResolvedValue({ data: fixtures.account })
@@ -168,7 +174,10 @@ describe('ReactNativeLauncher', () => {
         client,
         account: fixtures.account,
         trigger: fixtures.trigger,
-        konnector: { slug: 'konnectorslug', clientSide: true }
+        konnector: { slug: 'konnectorslug', clientSide: true },
+        launcherClient: {
+          setAppMetadata: () => null
+        }
       })
       client.query.mockResolvedValue({ data: fixtures.account })
       client.save.mockImplementation(async doc => ({ data: doc }))
@@ -249,6 +258,9 @@ describe('ReactNativeLauncher', () => {
         konnector: {
           slug: 'testkonnector',
           name: 'Test Konnector'
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       client.query.mockResolvedValue({ data: fixtures.account })
@@ -271,7 +283,10 @@ describe('ReactNativeLauncher', () => {
       const { launcher, client, launch } = setup()
       launcher.setStartContext({
         client,
-        konnector: { slug: 'konnectorslug', clientSide: true }
+        konnector: { slug: 'konnectorslug', clientSide: true },
+        launcherClient: {
+          setAppMetadata: () => null
+        }
       })
       launcher.pilot.call.mockImplementation(() => {
         return new Promise(() => {
@@ -319,6 +334,9 @@ describe('ReactNativeLauncher', () => {
         },
         manifest: {
           cookie_domains: ['.cozy.io']
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       const result = await launcher.getCookiesByDomain('.cozy.io')
@@ -332,7 +350,10 @@ describe('ReactNativeLauncher', () => {
         account: {
           id: 'cozyKonnector'
         },
-        manifest: {}
+        manifest: {},
+        launcherClient: {
+          setAppMetadata: () => null
+        }
       })
       await expect(launcher.getCookiesByDomain('.cozy.io')).rejects.toThrow(
         'getCookiesByDomain cannot be called without cookie_domains declared in manifest'
@@ -347,6 +368,9 @@ describe('ReactNativeLauncher', () => {
         },
         manifest: {
           cookie_domains: ['.somedomain']
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       await expect(launcher.getCookiesByDomain('.cozy.io')).rejects.toThrow(
@@ -362,6 +386,9 @@ describe('ReactNativeLauncher', () => {
         },
         manifest: {
           cookie_domains: ['apeculiarsite.com']
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       const result = await launcher.getCookiesByDomain('apeculiarsite.com')
@@ -381,6 +408,9 @@ describe('ReactNativeLauncher', () => {
         },
         manifest: {
           cookie_domains: ['.cozy.io']
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       const result = await launcher.getCookieByDomainAndName(
@@ -400,7 +430,10 @@ describe('ReactNativeLauncher', () => {
         account: {
           id: 'cozyKonnector'
         },
-        manifest: {}
+        manifest: {},
+        launcherClient: {
+          setAppMetadata: () => null
+        }
       })
       await expect(
         launcher.getCookieByDomainAndName('.cozy.io', 'SOME_COOKIE_NAME')
@@ -420,6 +453,9 @@ describe('ReactNativeLauncher', () => {
         },
         manifest: {
           cookie_domains: ['.somedomain']
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       await expect(
@@ -438,6 +474,9 @@ describe('ReactNativeLauncher', () => {
         },
         manifest: {
           cookie_domains: ['apeculiarsite.com']
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       const result = await launcher.getCookieByDomainAndName(
@@ -460,6 +499,9 @@ describe('ReactNativeLauncher', () => {
       launcher.setStartContext({
         account: {
           id: 'cozyKonnector'
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       const result = await launcher.getCookieFromKeychainByName('token')
@@ -481,6 +523,9 @@ describe('ReactNativeLauncher', () => {
       launcher.setStartContext({
         account: {
           id: 'cozyKonnector'
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       const result = await launcher.getCookieFromKeychainByName('token')
@@ -494,6 +539,9 @@ describe('ReactNativeLauncher', () => {
       launcher.setStartContext({
         account: {
           id: 'cozyKonnector'
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       await launcher.saveCookieToKeychain({
@@ -531,6 +579,9 @@ describe('ReactNativeLauncher', () => {
       launcher.setStartContext({
         account: {
           id: 'cozyKonnector'
+        },
+        launcherClient: {
+          setAppMetadata: () => null
         }
       })
       await launcher.saveCookieToKeychain({

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -1,19 +1,20 @@
+import Minilog from '@cozy/minilog'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
+import { getDeviceName } from 'react-native-device-info'
 
 import CozyClient from 'cozy-client'
 
-import AsyncStorage from '@react-native-async-storage/async-storage'
-import Minilog from '@cozy/minilog'
-import { getDeviceName } from 'react-native-device-info'
-
-import { queryResultToCrypto } from '../components/webviews/CryptoWebView/cryptoObservable/cryptoObservable'
 import { loginFlagship } from './clientHelpers/loginFlagship'
-import { normalizeFqdn } from './functions/stringHelpers'
 import { SOFTWARE_ID, SOFTWARE_NAME } from './constants'
+import { normalizeFqdn } from './functions/stringHelpers'
 
 import strings from '/constants/strings.json'
 import { androidSafetyNetApiKey } from '/constants/api-keys'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+import packageJSON from '../../package.json'
+import { queryResultToCrypto } from '../components/webviews/CryptoWebView/cryptoObservable/cryptoObservable'
 
 const log = Minilog('LoginScreen')
 
@@ -60,7 +61,11 @@ export const getClient = async () => {
   const client = new CozyClient({
     uri,
     oauth: { token },
-    oauthOptions
+    oauthOptions,
+    appMetadata: {
+      slug: 'flagship',
+      version: packageJSON.version
+    }
   })
   listenTokenRefresh(client)
   client.getStackClient().setOAuthOptions(oauthOptions)
@@ -196,6 +201,10 @@ export const createClient = async instance => {
       clientName: `${SOFTWARE_NAME} (${await getDeviceName()})`,
       shouldRequireFlagshipPermissions: true,
       certificationConfig: { androidSafetyNetApiKey }
+    },
+    appMetadata: {
+      slug: 'flagship',
+      version: packageJSON.version
     }
   }
 

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -77,19 +77,6 @@ export const getClient = async () => {
 }
 
 /**
- * Initialize a new CozyClient instance from the given uri with user interaction
- *
- * @param {String} uri : cozy uri
- * @returns {CozyClient}
- */
-export const initClient = async (uri, options) => {
-  const client = new CozyClient(options)
-  await client.register(uri)
-  await client.login()
-  return client
-}
-
-/**
  * Create the OAuth connection for the given Cozy instance
  *
  * @param {object} param

--- a/src/libs/client.spec.js
+++ b/src/libs/client.spec.js
@@ -4,6 +4,8 @@ import {
   removeNotificationDeviceToken
 } from '/libs/client'
 
+import packageJSON from '../../package.json'
+
 import CozyClient from 'cozy-client'
 
 jest.genMockFromModule('cozy-client')
@@ -49,7 +51,11 @@ describe('client', () => {
           shouldRequireFlagshipPermissions: true,
           softwareID: 'amiral'
         },
-        scope: ['*']
+        scope: ['*'],
+        appMetadata: {
+          slug: 'flagship',
+          version: packageJSON.version
+        }
       })
     })
 

--- a/src/libs/konnectors/models.ts
+++ b/src/libs/konnectors/models.ts
@@ -32,7 +32,7 @@ interface UpdatedByApp {
   slug?: string
 }
 
-interface Konnector {
+export interface Konnector {
   type: string
   id?: string
   attributes?: Konnector

--- a/src/screens/home/hooks/useLauncherClient.ts
+++ b/src/screens/home/hooks/useLauncherClient.ts
@@ -20,9 +20,14 @@ export const useLauncherClient = (
 
     const slug = launcherContextValue?.konnector.slug
 
-    if (slug) void getLauncherClient(client, slug, setLauncherClient)
+    if (slug)
+      void getLauncherClient(
+        client,
+        launcherContextValue.konnector,
+        setLauncherClient
+      )
     else setLauncherClient(undefined)
-  }, [client, launcherContextValue?.konnector.slug])
+  }, [client, launcherContextValue?.konnector])
 
   return { launcherClient }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6317,16 +6317,16 @@ cozy-client@^34.11.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^36.2.0:
-  version "36.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-36.2.0.tgz#662a659415dd9c7d8ae0d69e6c445bcbdaf1a935"
-  integrity sha512-CLom7iJ8b3cCPvA537BNxe7n1DGE6vM48P/xtjLB+Hl7ZKFWMiWSWKHgfQqxKwrDxwnNDD9XJ7VCxwlMBdqpWw==
+cozy-client@^37.1.0:
+  version "37.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-37.1.0.tgz#d8d583dd79a58c88de811649304763909799ee76"
+  integrity sha512-4HxFdnyIMR/Q1f34LsGmBKwMwF7IaMGDRQ4d1wiwqSyliwb16uhAecEYmhjAE4tyebmIm/dvZz68zlb+eFyyFg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^36.2.0"
+    cozy-stack-client "^37.0.0"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -6393,10 +6393,10 @@ cozy-stack-client@^34.11.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^36.2.0:
-  version "36.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-36.2.0.tgz#7e012279519128355c4886ac973cd062c7c4b2aa"
-  integrity sha512-E2eLDmCmYJQh/9WwR77mXs+/aoxB/dbRBxj2Q7LItr9ypTXSFaWZEjiTu7fiu83p04BwybAkzI26Zc4aBbpjRg==
+cozy-stack-client@^37.0.0:
+  version "37.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-37.0.0.tgz#3b516b5ad15eba5a19e833f524a37bee5dff507b"
+  integrity sha512-vpOCRvgqqJwdQ9lBHmbJHcViio32ULVKClXi/lkmBviEWC8ozcifcSQgAhrJPO2vbh5iz1wLOU1MOkPe/N+CKg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
The goal is to have an instanciated cozy-client with the right metadata. Before we had the right token, but the appMetadata was not right.

The createdByApp was right for the io.cozy.files since the stack doesn't read the value from the client, but for triggers or bills, the createdByApp was not right.

With this PR, we should have the right metadata now.

CozyClient is also able to take a `sourceAccount` appMetadata, but I think we don't have a `sourceAccount` at the first launch. So we should update it later, but I don't think cozy-client API allow this ATM.


I also added the appMetadata to the flagship client. 