### PR TITLE
Refactor: Extract Nav and Router components into their own components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -59,26 +59,10 @@ const App = ({ setClient }) => {
   return <RootNavigator initialRoute={initialRoute} setClient={setClient} />
 }
 
-const WrappedApp = () => {
-  const [client, setClient] = useState(undefined)
+const Nav = ({ client, setClient }) => {
+  const colors = getColors()
 
-  useEffect(() => {
-    const handleClientInit = async () => {
-      try {
-        const existingClient = await getClient()
-        if (existingClient) {
-          cleanKonnectorsOnBootInBackground(existingClient)
-        }
-        setClient(existingClient || null)
-      } catch {
-        setClient(null)
-      }
-    }
-
-    handleClientInit()
-  }, [])
-
-  const Nav = () => (
+  return (
     <NavigationContainer ref={RootNavigation.navigationRef}>
       <NativeIntentProvider localMethods={localMethods(client)}>
         <View
@@ -99,13 +83,33 @@ const WrappedApp = () => {
       </NativeIntentProvider>
     </NavigationContainer>
   )
+}
 
-  if (client === null) return <Nav />
+const WrappedApp = () => {
+  const [client, setClient] = useState(undefined)
+
+  useEffect(() => {
+    const handleClientInit = async () => {
+      try {
+        const existingClient = await getClient()
+        if (existingClient) {
+          cleanKonnectorsOnBootInBackground(existingClient)
+        }
+        setClient(existingClient || null)
+      } catch {
+        setClient(null)
+      }
+    }
+
+    handleClientInit()
+  }, [])
+
+  if (client === null) return <Nav client={client} setClient={setClient} />
 
   if (client)
     return (
       <CozyProvider client={client}>
-        <Nav />
+        <Nav client={client} setClient={setClient} />
       </CozyProvider>
     )
 

--- a/src/App.js
+++ b/src/App.js
@@ -6,32 +6,23 @@ import { NavigationContainer } from '@react-navigation/native'
 import { PersistGate } from 'redux-persist/integration/react'
 import { Provider } from 'react-redux'
 import { StatusBar, StyleSheet, View } from 'react-native'
-import { createStackNavigator } from '@react-navigation/stack'
 import { decode, encode } from 'base-64'
 
 import { CozyProvider, useClient } from 'cozy-client'
 import { NativeIntentProvider } from 'cozy-intent'
 
+import { RootNavigator } from '/AppRouter'
 import * as RootNavigation from '/libs/RootNavigation'
 import NetStatusBoundary from '/libs/services/NetStatusBoundary'
-import { CozyAppScreen } from '/screens/cozy-app/CozyAppScreen'
-import { CreateInstanceScreen } from '/screens/login/CreateInstanceScreen'
 import { CryptoWebView } from '/components/webviews/CryptoWebView/CryptoWebView'
-import { ErrorScreen } from '/screens/error/ErrorScreen'
-import { HomeScreen } from '/screens/home/HomeScreen'
 import { HomeStateProvider } from '/screens/home/HomeStateProvider'
 import { HttpServerProvider } from '/libs/httpserver/httpServerProvider'
-import { LockScreen } from '/screens/lock/LockScreen'
-import { LoginScreen } from '/screens/login/LoginScreen'
-import { OnboardingScreen } from '/screens/login/OnboardingScreen'
 import { SplashScreenProvider } from '/components/providers/SplashScreenProvider'
-import { WelcomeScreen } from '/screens/welcome/WelcomeScreen'
 import { cleanKonnectorsOnBootInBackground } from '/libs/konnectors/cleanKonnectorsOnBoot'
 import { getClient } from '/libs/client'
 import { getColors } from '/ui/colors'
 import { localMethods } from '/libs/intents/localMethods'
 import { persistor, store } from '/redux/store'
-import { routes } from '/constants/routes.js'
 import { useAppBootstrap } from '/hooks/useAppBootstrap.js'
 import { useGlobalAppState } from '/hooks/useGlobalAppState'
 import { useCookieResyncOnResume } from '/hooks/useCookieResyncOnResume'
@@ -39,9 +30,6 @@ import { useCozyEnvironmentOverride } from '/hooks/useCozyEnvironmentOverride'
 import { useNotifications } from '/hooks/useNotifications'
 import { useNetService } from '/libs/services/NetService'
 import { withSentry } from '/libs/monitoring/Sentry'
-
-const Root = createStackNavigator()
-const Stack = createStackNavigator()
 
 // Polyfill needed for cozy-client connection
 if (!global.btoa) {
@@ -68,92 +56,10 @@ const App = ({ setClient }) => {
     return null
   }
 
-  const MainAppNavigator = () => (
-    <Root.Navigator
-      initialRouteName={routes.default}
-      screenOptions={{ headerShown: false }}
-    >
-      <Stack.Screen
-        name={routes.default}
-        component={HomeScreen}
-        initialParams={initialRoute.params}
-      />
-    </Root.Navigator>
-  )
-
-  const RootNavigator = () => (
-    <Root.Navigator
-      initialRouteName={initialRoute.route}
-      screenOptions={{ headerShown: false }}
-    >
-      {/*
-      We embed routes.home into its own Navigator so we prevent initialParams
-      to be re-applied when calling goBack() from the CozyApp route
-      i.e:
-       - We open the app with a deeplink https://links.mycozy.cloud/flagship/drive/?fallback=http://drive.cozy.tools:8080/
-       - routes.home is called with {initialParams:{cozyAppFallbackURL: 'http://drive.cozy.tools:8080/'}}
-       - routes.home reads initialParams and redirects to routes.cozyapp
-       - user press the back button so the app redirects to routes.home
-       - routes.home SHOULD NOT read initialParams and SHOULD NOT redirect to routes.cozyapp
-      */}
-      <Root.Screen name={routes.home} component={MainAppNavigator} />
-
-      <Stack.Screen
-        name={routes.authenticate}
-        initialParams={initialRoute.params}
-      >
-        {params => <LoginScreen setClient={setClient} {...params} />}
-      </Stack.Screen>
-
-      <Stack.Screen
-        name={routes.onboarding}
-        initialParams={initialRoute.params}
-      >
-        {params => <OnboardingScreen setClient={setClient} {...params} />}
-      </Stack.Screen>
-
-      <Stack.Screen
-        name={routes.instanceCreation}
-        initialParams={initialRoute.params}
-      >
-        {params => <CreateInstanceScreen {...params} />}
-      </Stack.Screen>
-
-      <Stack.Screen name={routes.welcome}>
-        {params => <WelcomeScreen setClient={setClient} {...params} />}
-      </Stack.Screen>
-
-      <Root.Screen
-        name={routes.error}
-        component={ErrorScreen}
-        initialParams={{ type: initialRoute.root }}
-      />
-
-      <Root.Screen
-        name={routes.cozyapp}
-        component={CozyAppScreen}
-        options={{
-          presentation: 'transparentModal',
-          animationEnabled: false
-        }}
-      />
-
-      <Root.Screen
-        name={routes.lock}
-        component={LockScreen}
-        options={{
-          presentation: 'transparentModal',
-          animationEnabled: false
-        }}
-      />
-    </Root.Navigator>
-  )
-
-  return <RootNavigator />
+  return <RootNavigator initialRoute={initialRoute} setClient={setClient} />
 }
 
 const WrappedApp = () => {
-  const colors = getColors()
   const [client, setClient] = useState(undefined)
 
   useEffect(() => {

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { createStackNavigator } from '@react-navigation/stack'
+
+import { CozyAppScreen } from '/screens/cozy-app/CozyAppScreen'
+import { CreateInstanceScreen } from '/screens/login/CreateInstanceScreen'
+import { ErrorScreen } from '/screens/error/ErrorScreen'
+import { HomeScreen } from '/screens/home/HomeScreen'
+import { LockScreen } from '/screens/lock/LockScreen'
+import { LoginScreen } from '/screens/login/LoginScreen'
+import { OnboardingScreen } from '/screens/login/OnboardingScreen'
+import { WelcomeScreen } from '/screens/welcome/WelcomeScreen'
+import { routes } from '/constants/routes.js'
+
+const Root = createStackNavigator()
+const Stack = createStackNavigator()
+
+const MainAppNavigator = ({ initialRoute }) => (
+  <Root.Navigator
+    initialRouteName={routes.default}
+    screenOptions={{ headerShown: false }}
+  >
+    <Stack.Screen
+      name={routes.default}
+      component={HomeScreen}
+      initialParams={initialRoute.params}
+    />
+  </Root.Navigator>
+)
+
+export const RootNavigator = ({ initialRoute, setClient }) => (
+  <Root.Navigator
+    initialRouteName={initialRoute.route}
+    screenOptions={{ headerShown: false }}
+  >
+    {/*
+    We embed routes.home into its own Navigator so we prevent initialParams
+    to be re-applied when calling goBack() from the CozyApp route
+    i.e:
+    - We open the app with a deeplink https://links.mycozy.cloud/flagship/drive/?fallback=http://drive.cozy.tools:8080/
+    - routes.home is called with {initialParams:{cozyAppFallbackURL: 'http://drive.cozy.tools:8080/'}}
+    - routes.home reads initialParams and redirects to routes.cozyapp
+    - user press the back button so the app redirects to routes.home
+    - routes.home SHOULD NOT read initialParams and SHOULD NOT redirect to routes.cozyapp
+    */}
+    <Root.Screen name={routes.home}>
+      {params => <MainAppNavigator initialRoute={initialRoute} {...params} />}
+    </Root.Screen>
+
+    <Stack.Screen
+      name={routes.authenticate}
+      initialParams={initialRoute.params}
+    >
+      {params => <LoginScreen setClient={setClient} {...params} />}
+    </Stack.Screen>
+
+    <Stack.Screen name={routes.onboarding} initialParams={initialRoute.params}>
+      {params => <OnboardingScreen setClient={setClient} {...params} />}
+    </Stack.Screen>
+
+    <Stack.Screen
+      name={routes.instanceCreation}
+      initialParams={initialRoute.params}
+    >
+      {params => <CreateInstanceScreen {...params} />}
+    </Stack.Screen>
+
+    <Stack.Screen name={routes.welcome}>
+      {params => <WelcomeScreen setClient={setClient} {...params} />}
+    </Stack.Screen>
+
+    <Root.Screen
+      name={routes.error}
+      component={ErrorScreen}
+      initialParams={{ type: initialRoute.root }}
+    />
+
+    <Root.Screen
+      name={routes.cozyapp}
+      component={CozyAppScreen}
+      options={{
+        presentation: 'transparentModal',
+        animationEnabled: false
+      }}
+    />
+
+    <Root.Screen
+      name={routes.lock}
+      component={LockScreen}
+      options={{
+        presentation: 'transparentModal',
+        animationEnabled: false
+      }}
+    />
+  </Root.Navigator>
+)


### PR DESCRIPTION
`MainAppNavigator`, `RootNavigator` and `Nav` were declared inside of `App` and `WrappedApp` functional components

This would produce unintended re-render, or worst, unintended re-mount of the entire router if `App` or `WrappedApp` would have to re-render due to changes on upper context

Extracting those component from `App` and `WrappedApp` would stabilize the component tree

___

This PR is needed for https://github.com/cozy/cozy-flagship-app/pull/700