### PR TITLE
feat: handle backpress in idle CCC

### DIFF
--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -1,6 +1,8 @@
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock'
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock.js'
+import mockBackHandler from 'react-native/Libraries/Utilities/__mocks__/BackHandler.js'
 import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock'
+
 import { mockRNFS } from '../__mocks__/react-native-fs-mock'
 
 jest.mock('react-native-device-info', () => mockRNDeviceInfo)
@@ -31,3 +33,4 @@ jest.mock('@react-native-firebase/messaging', () => ({
   requestPermission: jest.fn(() => Promise.resolve(true)),
   getToken: jest.fn(() => Promise.resolve('myMockToken'))
 }))
+jest.mock('react-native/Libraries/Utilities/BackHandler', () => mockBackHandler)

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -1,7 +1,5 @@
 import Minilog from '@cozy/minilog'
 
-import { withClient } from 'cozy-client'
-
 import {
   jsLogInterception,
   tryConsole
@@ -12,6 +10,10 @@ import get from 'lodash/get'
 import React, { Component } from 'react'
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native'
 import { WebView } from 'react-native-webview'
+
+import { handleBackPress, stopExecIfVisible } from './core/handleBackPress'
+
+import { withClient } from 'cozy-client'
 
 import { BackTo } from '/components/ui/icons/BackTo'
 import { getDimensions } from '/libs/dimensions'
@@ -174,6 +176,8 @@ class LauncherView extends Component {
       this.props.setLauncherContext({ state: 'default' })
     })
 
+    this.removeBackPress = handleBackPress(this, [stopExecIfVisible])
+
     await this.launcher.start({ initKonnectorError })
 
     stopTimeout()
@@ -182,6 +186,8 @@ class LauncherView extends Component {
   }
 
   componentWillUnmount() {
+    this.removeBackPress()
+
     if (this.launcher.removeAllListener) {
       this.launcher.removeAllListener()
     }

--- a/src/screens/konnectors/core/handleBackPress.spec.ts
+++ b/src/screens/konnectors/core/handleBackPress.spec.ts
@@ -1,0 +1,90 @@
+import { BackHandler } from 'react-native'
+
+import { stopExecIfVisible, handleBackPress } from './handleBackPress'
+
+const mockPlatform = {
+  OS: 'android'
+}
+
+jest.mock('react-native/Libraries/Utilities/Platform', () => mockPlatform)
+
+describe('stopExecIfVisible', () => {
+  it('should call onStopExecution if worker.visible is true', () => {
+    const launcherView = {
+      state: { worker: { visible: true } },
+      onStopExecution: jest.fn()
+    }
+
+    stopExecIfVisible(launcherView)
+
+    expect(launcherView.onStopExecution).toHaveBeenCalled()
+  })
+
+  it('should not call onStopExecution if worker.visible is false', () => {
+    const launcherView = {
+      state: { worker: { visible: false } },
+      onStopExecution: jest.fn()
+    }
+
+    stopExecIfVisible(launcherView)
+
+    expect(launcherView.onStopExecution).not.toHaveBeenCalled()
+  })
+
+  it('should return true', () => {
+    const result = stopExecIfVisible()
+
+    expect(result).toBe(true)
+  })
+})
+
+describe('handleBackPress', () => {
+  const launcherView = {
+    state: { worker: { visible: true } },
+    onStopExecution: jest.fn()
+  }
+
+  afterEach(() => {
+    launcherView.onStopExecution.mockClear()
+    mockPlatform.OS = 'android'
+  })
+
+  it('should not add event listeners if Platform.OS is not android', () => {
+    mockPlatform.OS = 'ios'
+
+    const removeListeners = handleBackPress(launcherView, [])
+    expect(jest.spyOn(BackHandler, 'addEventListener')).not.toHaveBeenCalled()
+    expect(removeListeners).toBeInstanceOf(Function)
+  })
+
+  it('should add event listeners with bound callbacks if Platform.OS is android', () => {
+    const callback1 = jest.fn()
+    const callback2 = jest.fn()
+
+    const removeListeners = handleBackPress(launcherView, [
+      callback1,
+      callback2
+    ])
+
+    expect(callback1).not.toHaveBeenCalled()
+    expect(callback2).not.toHaveBeenCalled()
+    expect(jest.spyOn(BackHandler, 'addEventListener')).toHaveBeenCalledTimes(2)
+    expect(
+      jest.spyOn(BackHandler, 'removeEventListener')
+    ).not.toHaveBeenCalled()
+
+    // Simulate hardware back press
+    // @ts-expect-error mockPressBack is defined in the mock but not in the types of the mock
+    BackHandler.mockPressBack() // eslint-disable-line @typescript-eslint/no-unsafe-call
+
+    expect(callback1).toHaveBeenCalledWith(launcherView)
+    expect(callback2).toHaveBeenCalledWith(launcherView)
+
+    // Call removeListeners to remove event listeners
+    removeListeners()
+
+    expect(
+      jest.spyOn(BackHandler, 'removeEventListener')
+    ).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/screens/konnectors/core/handleBackPress.ts
+++ b/src/screens/konnectors/core/handleBackPress.ts
@@ -1,0 +1,34 @@
+import { Platform, BackHandler } from 'react-native'
+
+interface LauncherView {
+  state: { worker: { visible?: boolean } }
+  onStopExecution: () => void
+}
+
+type Handler = (launcherView?: LauncherView) => boolean | null | undefined
+
+export const stopExecIfVisible: Handler = (launcherView?: LauncherView) => {
+  if (launcherView?.state.worker.visible) launcherView.onStopExecution()
+  return true
+}
+
+export const handleBackPress = (
+  launcherView: LauncherView,
+  callbacks: Handler[]
+): (() => void) => {
+  if (Platform.OS !== 'android') return (): void => undefined
+
+  const boundCallbacks = callbacks.map(callback =>
+    callback.bind(null, launcherView)
+  )
+
+  boundCallbacks.forEach(boundCallback => {
+    BackHandler.addEventListener('hardwareBackPress', boundCallback)
+  })
+
+  return (): void => {
+    boundCallbacks.forEach(boundCallback => {
+      BackHandler.removeEventListener('hardwareBackPress', boundCallback)
+    })
+  }
+}


### PR DESCRIPTION
This PR will allow users to backPress from their opened CCC to go back to the previous screen.
It uses the same callback as the "return to my Cozy" button.