### PR TITLE
feat: Send LOGIN_SUCCESS event via postMessage to the home application

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -151,23 +151,6 @@ export default class Launcher {
   }
 
   /**
-   * Updates the account to send the LOGIN_SUCCESS message to harvest
-   */
-  async sendLoginSuccess() {
-    const { account, client } = this.getStartContext()
-    if (!account?._id) {
-      throw new Error('sendLoginSuccess: not account to update')
-    }
-    const updatedAccount = await client.query(
-      Q('io.cozy.accounts').getById(account._id)
-    )
-    await client.save({
-      ...updatedAccount.data,
-      state: 'LOGIN_SUCCESS'
-    })
-  }
-
-  /**
    * Ensures that that the account has the proper account name which is the sourceAccountIdentifier fetched by the konnector
    *
    * @param {import('cozy-client/types/types').IOCozyAccount} account - cozy account

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -222,7 +222,8 @@ class ReactNativeLauncher extends Launcher {
       if (ensureResult.createdJob) {
         this.emit('CREATED_JOB', ensureResult.createdJob)
       }
-      await this.sendLoginSuccess()
+
+      launcherEvent.emit('loginSuccess', ensureResult.createdAccount?._id)
 
       const pilotContext = []
       // FIXME not used at the moment since the fetched file will not have the proper "createdByApp"

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -225,10 +225,6 @@ describe('ReactNativeLauncher', () => {
         })
       )
       expect(client.save).toHaveBeenNthCalledWith(3, {
-        _id: 'normal_account_id',
-        state: 'LOGIN_SUCCESS'
-      })
-      expect(client.save).toHaveBeenNthCalledWith(4, {
         _id: 'normal_job_id',
         attributes: {
           state: 'done'

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -61,6 +61,21 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
   }, [webviewRef])
 
   useEffect(() => {
+    const handleLoginSucess = accountId => {
+      const payload = JSON.stringify({
+        type: 'Clisk',
+        message: 'loginSuccess',
+        param: {
+          accountId
+        }
+      })
+      webviewRef?.postMessage(payload)
+    }
+    launcherEvent.on('loginSuccess', handleLoginSucess)
+    return () => launcherEvent.removeListener('loginSuccess', handleLoginSucess)
+  }, [webviewRef])
+
+  useEffect(() => {
     const handleLaunchResult = () => {
       const payload = JSON.stringify({
         type: 'Clisk',


### PR DESCRIPTION
This depends on https://github.com/cozy/cozy-libs/pull/2091 to be
deployed on home application to work completely

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

