### PR TITLE
fix: Intercept external links in OidcOnboardingView

### DIFF
--- a/src/screens/login/components/OidcOnboardingView.tsx
+++ b/src/screens/login/components/OidcOnboardingView.tsx
@@ -21,7 +21,14 @@ import {
   fetchBackgroundOnLoad,
   tryProcessClouderyBackgroundMessage
 } from '/screens/login/components/functions/clouderyBackgroundFetcher'
-import { parseOidcOnboardingFinishedUrl } from '/screens/login/components/functions/oidc'
+import {
+  interceptExternalLinksAndOpenInAppBrowser,
+  openWindowWithInAppBrowser
+} from '/screens/login/components/functions/interceptExternalLinks'
+import {
+  LOGIN_FLAGSHIP_URL,
+  parseOidcOnboardingFinishedUrl
+} from '/screens/login/components/functions/oidc'
 
 const log = Minilog('OidcOnboardingView')
 
@@ -98,12 +105,17 @@ export const OidcOnboardingView = ({
         source={{ uri: onboardUrl }}
         ref={webviewRef}
         injectedJavaScriptBeforeContentLoaded={fetchBackgroundOnLoad}
-        onShouldStartLoadWithRequest={handleNavigation}
+        onShouldStartLoadWithRequest={interceptExternalLinksAndOpenInAppBrowser(
+          onboardUrl,
+          [LOGIN_FLAGSHIP_URL],
+          handleNavigation
+        )}
         onLoadEnd={(): void => setLoading(false)}
         onMessage={processMessage}
         onNavigationStateChange={(event: WebViewNavigation): void => {
           setCanGoBack(event.canGoBack)
         }}
+        onOpenWindow={openWindowWithInAppBrowser}
         style={{
           backgroundColor: backgroundColor
         }}

--- a/src/screens/login/components/functions/interceptExternalLinks.ts
+++ b/src/screens/login/components/functions/interceptExternalLinks.ts
@@ -1,0 +1,34 @@
+import type { WebViewNavigation } from 'react-native-webview'
+import type { WebViewOpenWindowEvent } from 'react-native-webview/lib/WebViewTypes'
+
+import { showInAppBrowser } from '/libs/intents/InAppBrowser'
+
+type NavigationHandler = (request: WebViewNavigation) => boolean
+
+export const interceptExternalLinksAndOpenInAppBrowser = (
+  baseUri: string,
+  exceptionOrigins: string[],
+  parentHandleNavigation: NavigationHandler
+) => {
+  return (request: WebViewNavigation): boolean => {
+    const baseUrl = new URL(baseUri)
+    const targetUrl = new URL(request.url)
+
+    if (
+      baseUrl.origin !== targetUrl.origin &&
+      !exceptionOrigins.includes(targetUrl.origin)
+    ) {
+      void showInAppBrowser({ url: request.url })
+      return false
+    }
+
+    return parentHandleNavigation(request)
+  }
+}
+
+export const openWindowWithInAppBrowser = (
+  syntheticEvent: WebViewOpenWindowEvent
+): void => {
+  const { nativeEvent } = syntheticEvent
+  void showInAppBrowser({ url: nativeEvent.targetUrl })
+}

--- a/src/screens/login/components/functions/oidc.ts
+++ b/src/screens/login/components/functions/oidc.ts
@@ -19,6 +19,8 @@ const OIDC_ONBOARD_CALLBACK_URL_PARAM = 'redirect'
 const OIDC_ONBOARD_CALLBACK_URL =
   'https://loginflagship/oidc_onboarding_finished'
 
+export const LOGIN_FLAGSHIP_URL = 'https://loginflagship'
+
 interface OidcLoginCallback {
   code: string
   fqdn: string


### PR DESCRIPTION
Cloudery can display some external links in partners pages, so we should intercept them and display them in an InAppBrowser

Also some links would be open by the ClouderyView using `window.open()` method. This should be used for the "terms and condition" PDF that is stored on the Cloudery (and so we cannot detect URL.origin change)

By using `onOpenWindow` we would intercept those URLs

