### PR TITLE
fix: Handle email onboarding scenario

### DIFF
--- a/src/screens/login/CreateInstanceScreen.js
+++ b/src/screens/login/CreateInstanceScreen.js
@@ -6,10 +6,13 @@ import { routes } from '/constants/routes'
 import { useDimensions } from '/libs/dimensions'
 import { consumeRouteParameter } from '/libs/functions/routeHelpers'
 import { getColors } from '/ui/colors'
+import { setStatusBarColorToMatchBackground } from '/screens/login/components/functions/clouderyBackgroundFetcher'
 
 import { ClouderyCreateInstanceView } from './components/ClouderyCreateInstanceView'
 
 const log = Minilog('CreateInstanceScreen')
+
+const colors = getColors()
 
 /**
  * Screen that should be displayed when openning an onboarding link from email
@@ -24,6 +27,12 @@ const log = Minilog('CreateInstanceScreen')
  */
 export const CreateInstanceScreen = ({ route, navigation }) => {
   const [clouderyUrl, setClouderyUrl] = useState()
+  const [backgroundColor, setBackgroundColor] = useState(colors.primaryColor)
+
+  const setBackgroundAndStatusBarColor = backgroundColor => {
+    setStatusBarColorToMatchBackground(backgroundColor)
+    setBackgroundColor(backgroundColor)
+  }
 
   const startOnboarding = onboardingData => {
     const { fqdn, registerToken } = onboardingData
@@ -45,12 +54,19 @@ export const CreateInstanceScreen = ({ route, navigation }) => {
   }, [navigation, route, setClouderyUrl])
   const dimensions = useDimensions()
   return (
-    <View style={styles.view}>
+    <View
+      style={{
+        ...styles.view,
+        backgroundColor: backgroundColor
+      }}
+    >
       <View style={{ height: dimensions.statusBarHeight }} />
       {clouderyUrl && (
         <ClouderyCreateInstanceView
           clouderyUrl={clouderyUrl}
           startOnboarding={startOnboarding}
+          backgroundColor={backgroundColor}
+          setBackgroundColor={setBackgroundAndStatusBarColor}
         />
       )}
       <View
@@ -64,7 +80,6 @@ export const CreateInstanceScreen = ({ route, navigation }) => {
 
 const styles = StyleSheet.create({
   view: {
-    flex: 1,
-    backgroundColor: getColors().primaryColor
+    flex: 1
   }
 })

--- a/src/screens/login/components/ClouderyCreateInstanceView.js
+++ b/src/screens/login/components/ClouderyCreateInstanceView.js
@@ -13,6 +13,7 @@ import {
   fetchBackgroundOnLoad,
   tryProcessClouderyBackgroundMessage
 } from '/screens/login/components/functions/clouderyBackgroundFetcher'
+import { openWindowWithInAppBrowser } from '/screens/login/components/functions/interceptExternalLinks'
 import { parseOnboardedRedirectionForEmailScenario } from '/screens/login/components/functions/oidc'
 
 const log = Minilog('ClouderyCreateInstanceView')
@@ -97,6 +98,7 @@ export const ClouderyCreateInstanceView = ({
         onShouldStartLoadWithRequest={handleNavigation}
         onLoadEnd={() => setLoading(false)}
         onMessage={processMessage}
+        onOpenWindow={openWindowWithInAppBrowser}
         injectedJavaScriptBeforeContentLoaded={run}
         style={{
           backgroundColor: backgroundColor


### PR DESCRIPTION
This PR adapt screens colors and external links interception in CreateInstanceScreen. This screen is used in the Onboarding from email scenario. So we apply the same mechanisms that we implemented for the LoginScreen.

> **Note**
> We may want to mutualize the WebView code between ClouderyCreateInstanceView and ClouderyView, but I prefer to wait to have a better idea about what this implies. Also this is not mandatory for the tomorrow's deadline