### PR TITLE
fix: Do not create new folder on error before login success

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -107,7 +107,7 @@ export default class Launcher {
         }
       })
     } else {
-      log.info('Konnector execution stopped by user, no job to stop')
+      log.info('Error before login success, no job to stop')
     }
   }
 
@@ -183,7 +183,10 @@ export default class Launcher {
     let { data: accountGetResult } = await client.query(
       Q('io.cozy.accounts').getById(account._id)
     )
-    if (accountGetResult?.auth?.accountName !== sourceAccountIdentifier) {
+    if (
+      sourceAccountIdentifier &&
+      accountGetResult?.auth?.accountName !== sourceAccountIdentifier
+    ) {
       log.debug('Will update account accountName to ', sourceAccountIdentifier)
       const { data: accountSaveResult } = await client.save({
         ...accountGetResult,
@@ -240,10 +243,12 @@ export default class Launcher {
     launcherClient.setAppMetadata({
       sourceAccount: account._id
     })
-    const folder = await ensureKonnectorFolder(client, {
-      konnector,
-      account
-    })
+    const folder = models.accounts.getAccountName(account)
+      ? await ensureKonnectorFolder(client, {
+          konnector,
+          account
+        })
+      : null
     if (!trigger) {
       log.debug(
         `ensureAccountAndTriggerAndJob: found no trigger in start context. Creating one`


### PR DESCRIPTION
When an error was thrown in ensureAuthenticated, a folder with the name
of the account was created. This was due to the fact that no
sourceAccountIdentifier was yet fetched by the connector (and the name
of the folder is the sourceAccountIdentifier.

Now no folder is created when no sourceAccountIdentifier is available

In this case, the accountName in the account was also  rewritten to
undefined and this is also now canceled

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

