### PR TITLE
fix: Clear client on logout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -104,6 +104,17 @@ const WrappedApp = () => {
     handleClientInit()
   }, [])
 
+  useEffect(
+    function clearClientOnLogout() {
+      const resetRoute = () => setClient(null)
+
+      client?.on('logout', resetRoute)
+
+      return () => client?.removeListener('logout', resetRoute)
+    },
+    [client]
+  )
+
   if (client === null) return <Nav client={client} setClient={setClient} />
 
   if (client)


### PR DESCRIPTION
Today implementation doesn't clear the `cozy-client` on logout

On login, the `setClient` will trigger a switch in App.js that recreates the `<Nav />` component inside of `<CozyProvider />`. This re-trigger the `useAppBootstrap` hook and re-compute the `initialRoute` which now outputs the `home` screen (because we now have a logged-in cozy-client)

On logout, we navigate to the `welcome` screen without clearing the client. This does not re-trigger the `useAppBootstrap` hook which stays in the same state. This behaviour is not problematic

But if we login again, then the `useAppBootstrap` hook won't be re-triggered as it is designed to be run only one time (see `initialRoute === 'fetching'` condition). This behaviour is problematic because we are not redirected to the `home` screen anymore after the login scenario

To fix this we chose to clear the client when `logout` event is detected

The side effect is that each logout and re-login now re-trigger the `useAppBootstrat` hook

On logout this means that the `Linking.getInitialURL()` method is used again to compute the initial route. This would re-trigger an Onboarding scenario if the user opened the app with an universal link. But this is prevented by the fact that `localMethods.asyncLogout()` calls `RootNavigation.reset(routes.welcome...` which seems to have higher priority