### PR TITLE
fix: Do not change Home's uri on `blur` event if client is logged-out

### DIFF
--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -79,13 +79,13 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
   useEffect(() => {
     const unsubscribe = navigation.addListener('blur', () => {
       didBlurOnce.current = true
-      if (trackedWebviewInnerUri) {
+      if (trackedWebviewInnerUri && client.isLogged) {
         setUri(trackedWebviewInnerUri)
       }
     })
 
     return unsubscribe
-  }, [navigation, trackedWebviewInnerUri])
+  }, [navigation, trackedWebviewInnerUri, client])
 
   useFocusEffect(
     useCallback(() => {


### PR DESCRIPTION
When the user clicks on Home's logout button, the
`localMethods.asyncLogout()` method would logout the cozy-client and navigate to the `welcome` screen

The navigation would trigger the HomeView's blur event and then trigger the `setUri()` which would re-rerender the Home's CozyProxyWebView to load the new `uri`

Side effect is that the `updateCozyAppBundleInBackground()` method would be started and 10s later the bundle update process would start. Which should not happen as we are logged-out

To fix this we want to prevent the `setUri()` call if cozy-client is logged-out