### PR TITLE
feat: Trigger quality_checks CI on all PRs

### DIFF
--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -3,8 +3,6 @@ name: React-Native CI
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
~~Current `quality_check` workflow is only triggered on PRs that target the `master` branch~~

~~We want to allow meta PRs to be checked by this workflow too~~

~~To make this happens, we should now name branches `feat/meta_pr_*`~~

Current `quality_check` workflow is only triggered on PRs that target
the `master` branch

We want all PRs to be checked by this workflow too

___

This PR is for https://github.com/cozy/cozy-flagship-app/pull/708 that is the target branch for all OIDC PRs and I noticed that all child PRs were not checked