### PR TITLE
feat: Send clisk error message to harvest

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -205,7 +205,7 @@ export default class Launcher {
 
     if (!account) {
       log.debug(
-        `ensureAccountAndTriggerAndJob: found no account in start context. Creating one`
+        `ensureAccountAndTriggerAndLaunch: found no account in start context. Creating one`
       )
 
       await cleanExistingAccountsForKonnector(client, konnector.slug, log)

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -76,13 +76,11 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
   }, [webviewRef])
 
   useEffect(() => {
-    const handleLaunchResult = () => {
+    const handleLaunchResult = param => {
       const payload = JSON.stringify({
         type: 'Clisk',
         message: 'launchResult',
-        param: {
-          message: 'abort'
-        }
+        param
       })
       webviewRef?.postMessage(payload)
     }


### PR DESCRIPTION
When no account has been created yet.
This will allow harvest to display a non persistent message to
the user.

In draft waiting for the harvest side PR


#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

