### PR TITLE
feat: Make field autofocus more generic in login and onboarding screens

### DIFF
--- a/src/libs/functions/keyboardHelper.ts
+++ b/src/libs/functions/keyboardHelper.ts
@@ -1,5 +1,5 @@
 import { NativeModules, Platform } from 'react-native'
-import type { WebView } from 'react-native-webview'
+import type { WebView, WebViewMessageEvent } from 'react-native-webview'
 
 import log from 'cozy-logger'
 
@@ -27,5 +27,54 @@ export const setFocusOnWebviewField = (
     }
   } catch {
     log('error', 'Error on opening the keyboard')
+  }
+}
+
+export const handleAutofocusFields = `
+  if (!window.cozy) window.cozy = {}
+  window.cozy.checkAutofocus = () => {
+    const autofocusField = document.querySelector("[autofocus]")
+
+    if (autofocusField) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({
+        message: 'queryKeyboard',
+        fieldId: autofocusField.id
+      }))
+    }
+  }
+  window.addEventListener("load", function(event) {
+    window.cozy.checkAutofocus()
+  })
+`
+
+export const triggerAutofocusFocusOnWebview = (webview: WebView): void => {
+  try {
+    if (Platform.OS === 'android') {
+      webview.injectJavaScript(`
+        window.cozy.checkAutofocus()
+      `)
+    }
+  } catch {
+    log('error', 'Error on trigger autofocus')
+  }
+}
+
+interface KeyboardMessage {
+  message: string
+  fieldId: string
+}
+
+export const tryProcessQueryKeyboardMessage = (
+  webview: WebView,
+  event: WebViewMessageEvent
+): void => {
+  try {
+    const message = JSON.parse(event.nativeEvent.data) as KeyboardMessage
+
+    if (message.message === 'queryKeyboard' && message.fieldId) {
+      setFocusOnWebviewField(webview, message.fieldId)
+    }
+  } catch {
+    log('error', 'Error on querying keyboard')
   }
 }

--- a/src/libs/functions/keyboardHelper.ts
+++ b/src/libs/functions/keyboardHelper.ts
@@ -1,10 +1,18 @@
 import { NativeModules, Platform } from 'react-native'
+import type { WebView } from 'react-native-webview'
 
 import log from 'cozy-logger'
 
-const Keyboard = NativeModules.Keyboard
+interface NativeKeyboard {
+  forceKeyboard: () => void
+}
 
-export const setFocusOnWebviewField = (webview, fieldId) => {
+const Keyboard = NativeModules.Keyboard as NativeKeyboard
+
+export const setFocusOnWebviewField = (
+  webview: WebView,
+  fieldId: string
+): void => {
   try {
     if (Platform.OS === 'android') {
       webview.requestFocus()

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -48,7 +48,7 @@ const colors = getColors()
 const LoginSteps = ({
   backgroundColor,
   clouderyMode,
-  disabledFocus,
+  disableAutofocus,
   goBack,
   navigation,
   route,
@@ -406,7 +406,7 @@ const LoginSteps = ({
       <ClouderyView
         backgroundColor={backgroundColor}
         clouderyMode={clouderyMode}
-        disabledFocus={disabledFocus}
+        disableAutofocus={disableAutofocus}
         setBackgroundColor={setBackgroundColor}
         setInstanceData={setInstanceData}
         startOidcOAuth={startOidcOAuth}
@@ -499,7 +499,7 @@ const LoginSteps = ({
 
 export const LoginScreen = ({
   clouderyMode,
-  disabledFocus,
+  disableAutofocus,
   goBack,
   navigation,
   route,
@@ -530,7 +530,7 @@ export const LoginScreen = ({
         route={route}
         setBackgroundColor={setBackgroundAndStatusBarColor}
         setClient={setClient}
-        disabledFocus={disabledFocus}
+        disableAutofocus={disableAutofocus}
         goBack={goBack}
       />
       <View

--- a/src/screens/login/components/ClouderyCreateInstanceView.js
+++ b/src/screens/login/components/ClouderyCreateInstanceView.js
@@ -1,9 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { KeyboardAvoidingView, Platform, StyleSheet, View } from 'react-native'
 import Minilog from '@cozy/minilog'
 
 import { getOnboardingDataFromRequest } from '/libs/functions/getOnboardingDataFromRequest'
-import { setFocusOnWebviewField } from '/libs/functions/keyboardHelper'
+import {
+  handleAutofocusFields,
+  tryProcessQueryKeyboardMessage
+} from '/libs/functions/keyboardHelper'
 import { NetService } from '/libs/services/NetService'
 import { jsCozyGlobal } from '/components/webviews/jsInteractions/jsCozyInjection'
 import { jsLogInterception } from '/components/webviews/jsInteractions/jsLogInterception'
@@ -25,6 +28,8 @@ const run = `
     ${jsLogInterception}
 
     ${fetchBackgroundOnLoad}
+    
+    ${handleAutofocusFields}
 
     return true;
   })();
@@ -76,13 +81,8 @@ export const ClouderyCreateInstanceView = ({
     return true
   }
 
-  useEffect(() => {
-    if (webviewRef && !loading) {
-      setFocusOnWebviewField(webviewRef.current, 'slug')
-    }
-  }, [loading, webviewRef])
-
   const processMessage = event => {
+    tryProcessQueryKeyboardMessage(webviewRef.current, event)
     tryProcessClouderyBackgroundMessage(event, setBackgroundColor)
   }
 

--- a/src/screens/login/components/ClouderyCreateInstanceView.js
+++ b/src/screens/login/components/ClouderyCreateInstanceView.js
@@ -18,16 +18,17 @@ import { useHomeStateContext } from '/screens/home/HomeStateProvider'
 
 const log = Minilog('ClouderyCreateInstanceView')
 
-const run =
-  `
-    (function() {
-      ${jsCozyGlobal()}
+const run = `
+  (function() {
+    ${jsCozyGlobal()}
 
-      ${jsLogInterception}
+    ${jsLogInterception}
 
-      return true;
-    })();
-  ` + fetchBackgroundOnLoad
+    ${fetchBackgroundOnLoad}
+
+    return true;
+  })();
+`
 
 /**
  * Displays the Cloudery web page where the user can onboard a new cozy from an onboarding email

--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -34,7 +34,7 @@ import {
  * @param {string} props.backgroundColor - The LoginScreen's background color (used for overlay and navigation bars)
  * @param {'CLOUDERY_MODE_LOGIN'|'CLOUDERY_MODE_SIGNING'} props.clouderyMode
  * @param {setInstanceData} props.setInstanceData - Set instance data (fqdn and origin) to start the Login process
- * @param {boolean} props.disabledFocus - Boolean stating if the Webview can get focus (used to trigger auto-focus on email field)
+ * @param {boolean} props.disableAutofocus - Boolean stating if the Webview can get focus (used to trigger auto-focus on email field)
  * @param {setBackgroundColor} props.setBackgroundColor - Set the LoginScreen's background color (used for overlay and navigation bars)
  * @param {setErrorCallback} props.setError - Display the given error
  * @param {startOidcOAuth} props.startOidcOAuth - Start the OIDC Oauth process
@@ -45,7 +45,7 @@ export const ClouderyView = ({
   backgroundColor,
   clouderyMode,
   setInstanceData,
-  disabledFocus,
+  disableAutofocus,
   setBackgroundColor,
   setError,
   startOidcOAuth,
@@ -108,24 +108,6 @@ export const ClouderyView = ({
     checkInstanceData && asyncCore()
   }, [checkInstanceData, setInstanceData])
 
-  useEffect(() => {
-    // add a parameter
-    if (
-      webviewRef &&
-      !loading &&
-      !disabledFocus &&
-      !urls?.isOnboardingPartner
-    ) {
-      webviewRef.current.setFocusOnField()
-    }
-  }, [
-    clouderyMode,
-    loading,
-    webviewRef,
-    disabledFocus,
-    urls?.isOnboardingPartner
-  ])
-
   const handleBackPress = useCallback(() => {
     if (!canGoBack) {
       return false
@@ -166,6 +148,7 @@ export const ClouderyView = ({
           urls={urls}
           backgroundColor={backgroundColor}
           setBackgroundColor={setBackgroundColor}
+          disableAutofocus={disableAutofocus}
         />
       )}
       {displayOverlay && (

--- a/src/screens/login/components/ClouderyViewSwitch.tsx
+++ b/src/screens/login/components/ClouderyViewSwitch.tsx
@@ -207,16 +207,17 @@ const ClouderyWebView = forwardRef(
 )
 ClouderyWebView.displayName = 'WebView'
 
-const run =
-  `
-    (function() {
-      ${jsCozyGlobal()}
+const run = `
+  (function() {
+    ${jsCozyGlobal()}
 
-      ${jsLogInterception}
+    ${jsLogInterception}
 
-      return true;
-    })();
-  ` + fetchBackgroundOnLoad
+    ${fetchBackgroundOnLoad}
+
+    return true;
+  })();
+`
 
 const handleError = async (webviewErrorEvent: unknown): Promise<void> => {
   try {

--- a/src/screens/login/components/OidcOnboardingView.tsx
+++ b/src/screens/login/components/OidcOnboardingView.tsx
@@ -98,7 +98,7 @@ export const OidcOnboardingView = ({
       <SupervisedWebView
         source={{ uri: onboardUrl }}
         ref={webviewRef}
-        injectedJavaScriptBeforeContentLoaded={fetchBackgroundOnLoad}
+        injectedJavaScriptBeforeContentLoaded={run}
         onShouldStartLoadWithRequest={handleNavigation}
         onLoadEnd={(): void => setLoading(false)}
         onMessage={processMessage}
@@ -125,6 +125,14 @@ export const OidcOnboardingView = ({
     </Wrapper>
   )
 }
+
+const run = `
+  (function() {
+    ${fetchBackgroundOnLoad}
+
+    return true;
+  })();
+`
 
 const handleError = async (webviewErrorEvent: unknown): Promise<void> => {
   try {

--- a/src/screens/login/components/functions/clouderyBackgroundFetcher.ts
+++ b/src/screens/login/components/functions/clouderyBackgroundFetcher.ts
@@ -14,7 +14,6 @@ interface ClouderyMessage {
 type SetBackgroundColorCallback = (color: string) => void
 
 export const fetchBackgroundOnLoad = `
-(function() {
   window.addEventListener("load", function(event) {
     const color = getComputedStyle(
       document.getElementsByTagName("main")[0]
@@ -25,7 +24,6 @@ export const fetchBackgroundOnLoad = `
       color: color
     }))
   })
-})();
 `
 
 export const tryProcessClouderyBackgroundMessage = (

--- a/src/screens/welcome/WelcomeScreen.jsx
+++ b/src/screens/welcome/WelcomeScreen.jsx
@@ -65,7 +65,7 @@ export const WelcomeScreen = ({ navigation, route, setClient }) => {
       <LoginScreen
         clouderyMode={clouderyMode}
         style={styles.view}
-        disabledFocus={isWelcomeModalDisplayed}
+        disableAutofocus={isWelcomeModalDisplayed}
         navigation={navigation}
         route={route}
         setClient={setClient}


### PR DESCRIPTION
In previous implementations, we handled field autofocus from the react-native components by predicting which field would be displayed

Those fields were easily predictable as only a few login and onboarding scenario were implemented

Now that we implemented OIDC scenario, it is harder to predict those fields. For example, the link from email onboarding can now redirect to the Cloudery's FQDN choice page, or the ToS page

The new implementation allow to focus whatever DOM field that has `autofocus` prop. If no `autofocus` field is present, then no focus is triggered. This would prevent the keyboard to appear on the ToS page

Also as this mechanism is triggered from the HTML page and on page's load event, then the keyboard focus is handled on every navigation, which would make the autofocus experience more robust and homogenous

> **Note**
> OnboardingPasswordView, PasswordView and TwoFactorAuthenticationView all use the old autofocus mechanism. I didn't adapt them as those are locally handled pages (html is injected) so I don't feel the need to adapt them
> However I may change my mind based on how (and if) we will fix the missing autofocus feature on iOS