### PR TITLE
feat: Add logs for Cloudery views navigations and URL interception

### DIFF
--- a/src/screens/login/components/ClouderyCreateInstanceView.js
+++ b/src/screens/login/components/ClouderyCreateInstanceView.js
@@ -54,6 +54,7 @@ export const ClouderyCreateInstanceView = ({
   const { setOnboardedRedirection } = useHomeStateContext()
 
   const handleNavigation = request => {
+    log.debug(`Navigation to ${request.url}`)
     const createdInstance = getOnboardingDataFromRequest(request)
 
     NetService.isOffline()

--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -1,3 +1,4 @@
+import Minilog from '@cozy/minilog'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   BackHandler,
@@ -19,6 +20,8 @@ import {
   isOidcNavigationRequest,
   processOIDC
 } from '/screens/login/components/functions/oidc'
+
+const log = Minilog('ClouderyView')
 
 /**
  * Displays the Cloudery web page where the user can log to their Cozy instance by specifying
@@ -58,6 +61,7 @@ export const ClouderyView = ({
   const [canGoBack, setCanGoBack] = useState(false)
 
   const handleNavigation = request => {
+    log.debug(`Navigation to ${request.url}`)
     if (request.loading) {
       const instance = getUriFromRequest(request)
 

--- a/src/screens/login/components/OidcOnboardingView.tsx
+++ b/src/screens/login/components/OidcOnboardingView.tsx
@@ -52,6 +52,7 @@ export const OidcOnboardingView = ({
   const { setOnboardedRedirection } = useHomeStateContext()
 
   const handleNavigation = (request: WebViewNavigation): boolean => {
+    log.debug(`Navigation to ${request.url}`)
     const createdInstance = getOnboardingDataFromRequest(request)
     if (createdInstance) {
       setOnboardedRedirection(createdInstance.onboardedRedirection ?? '')


### PR DESCRIPTION
Due to the increasing number of login and onboarding scenario it becomes necessary to add logs on Cloudery views so we can track what state is triggered by useAppBootstrap and which URLs are intercepted by the app (from Cloudery webviews navigation and from universal links)

So this PR add some logs to track those scenario from the react-native console