### PR TITLE
feat: Add Magic Link support to Login and Onboarding scenario

### DIFF
--- a/src/hooks/useAppBootstrap.functions.ts
+++ b/src/hooks/useAppBootstrap.functions.ts
@@ -18,7 +18,11 @@ export const parseOnboardingURL = (
   url: string | null
 ): OnboardingParams | undefined => {
   try {
-    if (!url?.includes('onboarding') || url.includes('oidc_result')) {
+    if (
+      !url?.includes('onboarding') ||
+      url.includes('oidc_result') ||
+      url.includes('magic_code')
+    ) {
       return undefined
     }
 
@@ -80,5 +84,37 @@ export const parseFallbackURL = (url: string | null): FallbackUrl => {
       `Something went wrong while trying to parse fallback URL data: ${errorMessage}`
     )
     return defaultParse
+  }
+}
+
+interface MagicLinkUrl {
+  fqdn: string
+  magicCode: string
+}
+
+export const parseMagicLinkURL = (url: string | null): MagicLinkUrl | null => {
+  if (url === null) {
+    return null
+  }
+
+  try {
+    const makeURL = new URL(url)
+    const fqdn = makeURL.searchParams.get('fqdn')
+    const magicCode = makeURL.searchParams.get('magic_code')
+
+    if (!fqdn || !magicCode) {
+      return null
+    }
+
+    return {
+      fqdn,
+      magicCode
+    }
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error(
+      `Something went wrong while trying to parse magic link URL data: ${errorMessage}`
+    )
+    return null
   }
 }

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -11,6 +11,7 @@ import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
 import {
   parseFallbackURL,
+  parseMagicLinkURL,
   parseOnboardingURL
 } from '/hooks/useAppBootstrap.functions'
 import { useSplashScreen } from '/hooks/useSplashScreen'
@@ -174,6 +175,17 @@ export const useAppBootstrap = client => {
           navigate(routes.authenticate, { fqdn })
           return
         }
+      }
+
+      const magicLink = parseMagicLinkURL(url)
+
+      if (magicLink) {
+        const { fqdn, magicCode } = magicLink
+        log.debug(
+          `🔗 Redirect to authenticate screen for ${fqdn} with magicCode`
+        )
+        navigate(routes.authenticate, { fqdn, magicCode })
+        return
       }
 
       const { mainAppFallbackURL, cozyAppFallbackURL } = parseFallbackURL(url)

--- a/src/hooks/useAppBootstrap.spec.js
+++ b/src/hooks/useAppBootstrap.spec.js
@@ -480,3 +480,81 @@ it('Should handle WITH client WITH redirect URL', async () => {
     isLoading: false
   })
 })
+
+it('Should handle magic link from email', async () => {
+  const { result, waitForValueToChange } = renderHook(() =>
+    useAppBootstrap(null)
+  )
+
+  await waitForValueToChange(() => result.current.isLoading)
+
+  expect(result.current).toStrictEqual({
+    client: null,
+    initialRoute: {
+      route: routes.welcome
+    },
+    isLoading: false
+  })
+
+  act(() => {
+    Linking.emit('url', {
+      url: 'https://links.mycozy.cloud/flagship/onboarding?flagship=true&fqdn=SOME_FQDN&magic_code=SOME_MAGIC_CODE'
+    })
+  })
+
+  expect(navigate).toHaveBeenCalledWith(routes.authenticate, {
+    fqdn: 'SOME_FQDN',
+    magicCode: 'SOME_MAGIC_CODE'
+  })
+})
+
+it('Should handle link from OIDC instance creation email', async () => {
+  const { result, waitForValueToChange } = renderHook(() =>
+    useAppBootstrap(null)
+  )
+
+  await waitForValueToChange(() => result.current.isLoading)
+
+  expect(result.current).toStrictEqual({
+    client: null,
+    initialRoute: {
+      route: routes.welcome
+    },
+    isLoading: false
+  })
+
+  act(() => {
+    Linking.emit('url', {
+      url: 'https://links.mycozy.cloud/flagship/onboarding?flagship=true&onboard_url=https%3A%2F%2Fmanager.cozycloud.cc%2Fv2%2FSOME_PARTNER%2Fonboard%3Femail%3Dclaude2%2540cozycloud.cc%26skip_email_step%3Dtrue'
+    })
+  })
+
+  expect(navigate).toHaveBeenCalledWith(routes.instanceCreation, {
+    onboardUrl:
+      'https://manager.cozycloud.cc/v2/SOME_PARTNER/onboard?email=claude2%40cozycloud.cc&skip_email_step=true'
+  })
+})
+
+it(`Should not intercept OIDC result from ClouderyView's InAppBrowser`, async () => {
+  const { result, waitForValueToChange } = renderHook(() =>
+    useAppBootstrap(null)
+  )
+
+  await waitForValueToChange(() => result.current.isLoading)
+
+  expect(result.current).toStrictEqual({
+    client: null,
+    initialRoute: {
+      route: routes.welcome
+    },
+    isLoading: false
+  })
+
+  act(() => {
+    Linking.emit('url', {
+      url: 'https://links.mycozy.cloud/flagship/oidc_result?code=SOME_CODE&fqdn=SOME_FQDN&default_redirection'
+    })
+  })
+
+  expect(navigate).not.toHaveBeenCalled()
+})

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -509,3 +509,93 @@ export const connectOidcClient = async (client, oidcCode) => {
     state: STATE_CONNECTED
   }
 }
+
+export const connectMagicLinkClient = async (client, magicCode) => {
+  const stackClient = client.getStackClient()
+
+  let oauthOptions = stackClient.oauthOptions
+  const data = {
+    magic_code: magicCode,
+    client_id: oauthOptions.clientID,
+    client_secret: oauthOptions.clientSecret,
+    scope: '*'
+  }
+
+  const {
+    two_factor_token: twoFactorToken,
+    session_code: sessionCode,
+    ...token
+  } = await stackClient.fetchJSON('POST', '/auth/magic_link/flagship', data)
+
+  const need2FA = twoFactorToken !== undefined
+
+  if (need2FA) {
+    return {
+      client,
+      state: STATE_2FA_NEEDED,
+      twoFactorToken: twoFactorToken
+    }
+  }
+
+  const needFlagshipVerification = sessionCode !== undefined
+
+  if (needFlagshipVerification) {
+    return {
+      client: client,
+      state: STATE_AUTHORIZE_NEEDED,
+      sessionCode: sessionCode
+    }
+  }
+
+  stackClient.setToken(token)
+
+  return {
+    client: client,
+    state: STATE_CONNECTED
+  }
+}
+
+export const callMagicLinkOnboardingInitClient = async ({
+  instance,
+  magicCode
+}) => {
+  const client = await createClient(instance)
+  const stackClient = client.getStackClient()
+
+  await client.certifyFlagship()
+
+  let oauthOptions = stackClient.oauthOptions
+  const data = {
+    magic_code: magicCode,
+    client_id: oauthOptions.clientID,
+    client_secret: oauthOptions.clientSecret,
+    scope: '*'
+  }
+
+  const result = await stackClient.fetchJSON(
+    'POST',
+    '/auth/magic_link/flagship',
+    data
+  )
+
+  if (result.access_token) {
+    stackClient.setToken(result)
+  } else if (result.session_code) {
+    const { session_code } = result
+    const { codeVerifier, codeChallenge } = await createPKCE()
+
+    await client.authorize({
+      sessionCode: session_code,
+      pkceCodes: {
+        codeVerifier,
+        codeChallenge
+      }
+    })
+  }
+
+  await client.login()
+  await saveClient(client)
+  listenTokenRefresh(client)
+
+  return client
+}

--- a/src/libs/functions/getOnboardingDataFromRequest.js
+++ b/src/libs/functions/getOnboardingDataFromRequest.js
@@ -13,12 +13,14 @@ const getInstanceAndRegisterToken = uri => {
 
   const registerToken = url.searchParams.get(strings.registerToken)
   const onboardedRedirection = url.searchParams.get('redirection')
+  const magicCode = url.searchParams.get('magic_code')
 
   const fqdn = url.host
 
   return {
     fqdn,
     registerToken,
+    magicCode,
     onboardedRedirection
   }
 }

--- a/src/libs/functions/getOnboardingDataFromRequest.spec.js
+++ b/src/libs/functions/getOnboardingDataFromRequest.spec.js
@@ -8,6 +8,7 @@ describe('getOnboardingDataFromRequest', () => {
       })
     ).toStrictEqual({
       fqdn: 'claude.mycozy.cloud',
+      magicCode: null,
       onboardedRedirection: 'mespapiers',
       registerToken: 'SOME_TOKEN'
     })
@@ -19,5 +20,18 @@ describe('getOnboardingDataFromRequest', () => {
         url: 'http://claude.mycozy.cloud/?redirection=mespapiers&registerToken=SOME_REGISTER_TOKEN'
       })
     ).toBeNull()
+  })
+
+  it(`should correctly parse an URL with a magic_code (instance created from magic link email)`, () => {
+    expect(
+      getOnboardingDataFromRequest({
+        url: 'https://claude.mycozy.cloud/?onboarding=true&redirection=mespapiers&magic_code=SOME_MAGIC_CODE'
+      })
+    ).toStrictEqual({
+      fqdn: 'claude.mycozy.cloud',
+      magicCode: 'SOME_MAGIC_CODE',
+      onboardedRedirection: 'mespapiers',
+      registerToken: null
+    })
   })
 })

--- a/src/screens/login/CreateInstanceScreen.js
+++ b/src/screens/login/CreateInstanceScreen.js
@@ -35,10 +35,11 @@ export const CreateInstanceScreen = ({ route, navigation }) => {
   }
 
   const startOnboarding = onboardingData => {
-    const { fqdn, registerToken } = onboardingData
+    const { fqdn, registerToken, magicCode } = onboardingData
 
     navigation.navigate(routes.onboarding, {
       registerToken,
+      magicCode,
       fqdn
     })
   }

--- a/src/screens/login/components/ClouderyCreateInstanceView.js
+++ b/src/screens/login/components/ClouderyCreateInstanceView.js
@@ -65,14 +65,16 @@ export const ClouderyCreateInstanceView = ({
 
     if (request.loading) {
       if (createdInstance) {
-        const { fqdn, registerToken, onboardedRedirection } = createdInstance
+        const { fqdn, registerToken, onboardedRedirection, magicCode } =
+          createdInstance
         log.debug(`Intercept onboarding's password URL on ${fqdn}`)
         const normalizedFqdn = fqdn.toLowerCase()
 
         setOnboardedRedirection(onboardedRedirection ?? '')
         startOnboarding({
           fqdn: normalizedFqdn,
-          registerToken
+          magicCode: magicCode,
+          registerToken: registerToken
         })
 
         return false


### PR DESCRIPTION
We want the user to be able to create and login to their Cozy using passwordless authentication

To make this possible, when the user onboard to a partner context by entering their email, then the sent email contains a `magic link` that allows to complete the onboarding without entering any password

Then with this account type, the user can login using the same principle. After entering their email or their instance url, the Cloudery send a `magic link` by email and this magic link would allow to login without the password step

Related PR: cozy/cozy-stack#3872

> **Note**
> This PR adds more complexity to client.js, so I added another PR to refactor it: #734