### PR TITLE
feat: Rename app from `Cozy Cloud` to `Cloud Personnel`

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Cozy Cloud</string>
+    <string name="app_name">Cloud Personnel</string>
 </resources>

--- a/docs/how-to-retrieve-logs-in-release.md
+++ b/docs/how-to-retrieve-logs-in-release.md
@@ -55,7 +55,7 @@ Then in order to retrieve the log:
 - Run the app to generate logs
 - Plug the iPhone to your mac
 - In the mac's Finder, select the iPhone in the left pane
-- In the `Files` tab, open `Cozy Cloud` element and find `logs.txt`
+- In the `Files` tab, open `Cloud Personnel` element and find `logs.txt`
 - Drag&drop the `logs.txt` file into a local folder
 
 ![](/docs/images/finder_iphone_files.png)

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Cozy Cloud</string>
+	<string>Cloud Personnel</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/CozyReactNativeDev-Info.plist
+++ b/ios/CozyReactNativeDev-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Cozy Cloud</string>
+	<string>Cloud Personnel</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
We want to rename the app to better fit the "neutral" scenario we are implementing

Related PR: #708
