### PR TITLE
feat: Handle password based 2FA on Magic Link login scenario

### DIFF
--- a/src/libs/clientHelpers/connectClient.ts
+++ b/src/libs/clientHelpers/connectClient.ts
@@ -8,6 +8,7 @@ import {
 import {
   CozyClientCreationContext,
   is2faNeededResult,
+  is2faPasswordNeededResult,
   isFlagshipVerificationNeededResult,
   isInvalidPasswordResult,
   STATE_2FA_NEEDED,
@@ -59,6 +60,12 @@ export const connectClient = async ({
       state: STATE_2FA_NEEDED,
       twoFactorToken: result.two_factor_token
     }
+  }
+
+  if (is2faPasswordNeededResult(result)) {
+    throw new Error(
+      'Login should never return is2faPasswordNeededResult result (reserved for MagicLink scenario)'
+    )
   }
 
   if (isFlagshipVerificationNeededResult(result)) {

--- a/src/libs/clientHelpers/magicLink.ts
+++ b/src/libs/clientHelpers/magicLink.ts
@@ -1,5 +1,4 @@
 import type CozyClient from 'cozy-client'
-import type { LoginFlagshipResult } from 'cozy-client'
 
 import { authorizeClient } from '/libs/clientHelpers/authorizeClient'
 import { createClient } from '/libs/clientHelpers/createClient'
@@ -10,38 +9,93 @@ import {
 import {
   CozyClientCreationContext,
   is2faNeededResult,
+  is2faPasswordNeededResult,
   isAccessToken,
+  isFetchError,
   isFlagshipVerificationNeededResult,
-  STATE_2FA_NEEDED,
+  isInvalidPasswordResult,
+  LoginFlagshipResult,
+  STATE_2FA_PASSWORD_NEEDED,
   STATE_AUTHORIZE_NEEDED,
-  STATE_CONNECTED
+  STATE_CONNECTED,
+  STATE_INVALID_PASSWORD
 } from '/libs/clientHelpers/types'
+import { translation } from '/locales'
+
+const ERROR_2FA_PASSWORD_NEEDED =
+  'passphrase is required as second authentication factor'
+
+const ERROR_INVALID_MAGIC_CODE = 'invalid magic code'
+
+const loginMagicLink = async (
+  client: CozyClient,
+  magicCode: string,
+  passwordHash?: string
+): Promise<LoginFlagshipResult> => {
+  const stackClient = client.getStackClient()
+
+  try {
+    const oauthOptions = stackClient.oauthOptions
+    const data = {
+      magic_code: magicCode,
+      passphrase: passwordHash,
+      client_id: oauthOptions.clientID,
+      client_secret: oauthOptions.clientSecret,
+      scope: '*'
+    }
+
+    const loginResult = await stackClient.fetchJSON<LoginFlagshipResult>(
+      'POST',
+      '/auth/magic_link/flagship',
+      data
+    )
+
+    return loginResult
+  } catch (e: unknown) {
+    if (!isFetchError(e)) {
+      throw e
+    }
+
+    if (e.status === 401) {
+      if (e.reason?.error === ERROR_2FA_PASSWORD_NEEDED) {
+        return {
+          twoFactorPasswordNeeded: true
+        }
+      } else if (e.reason?.error === ERROR_INVALID_MAGIC_CODE) {
+        throw new Error(translation.screens.login.invalidMagicCode, e)
+      } else {
+        throw new Error('Error while calling loginMagicLink', e)
+      }
+    } else {
+      throw e
+    }
+  }
+}
 
 export const connectMagicLinkClient = async (
   client: CozyClient,
-  magicCode: string
+  magicCode: string,
+  passwordHash?: string
 ): Promise<CozyClientCreationContext> => {
   const stackClient = client.getStackClient()
 
-  const oauthOptions = stackClient.oauthOptions
-  const data = {
-    magic_code: magicCode,
-    client_id: oauthOptions.clientID,
-    client_secret: oauthOptions.clientSecret,
-    scope: '*'
-  }
+  const result = await loginMagicLink(client, magicCode, passwordHash)
 
-  const result = await stackClient.fetchJSON<LoginFlagshipResult>(
-    'POST',
-    '/auth/magic_link/flagship',
-    data
-  )
-
-  if (is2faNeededResult(result)) {
+  if (isInvalidPasswordResult(result)) {
     return {
       client,
-      state: STATE_2FA_NEEDED,
-      twoFactorToken: result.two_factor_token
+      state: STATE_INVALID_PASSWORD
+    }
+  }
+
+  if (is2faNeededResult(result)) {
+    throw new Error('Magic login should never return is2faNeededResult result')
+  }
+
+  if (is2faPasswordNeededResult(result)) {
+    return {
+      client,
+      state: STATE_2FA_PASSWORD_NEEDED
     }
   }
 

--- a/src/libs/clientHelpers/magicLink.ts
+++ b/src/libs/clientHelpers/magicLink.ts
@@ -40,8 +40,7 @@ const loginMagicLink = async (
       magic_code: magicCode,
       passphrase: passwordHash,
       client_id: oauthOptions.clientID,
-      client_secret: oauthOptions.clientSecret,
-      scope: '*'
+      client_secret: oauthOptions.clientSecret
     }
 
     const loginResult = await stackClient.fetchJSON<LoginFlagshipResult>(
@@ -133,8 +132,7 @@ export const callMagicLinkOnboardingInitClient = async ({
   const data = {
     magic_code: magicCode,
     client_id: oauthOptions.clientID,
-    client_secret: oauthOptions.clientSecret,
-    scope: '*'
+    client_secret: oauthOptions.clientSecret
   }
 
   const result = await stackClient.fetchJSON<LoginFlagshipResult>(

--- a/src/libs/clientHelpers/types.ts
+++ b/src/libs/clientHelpers/types.ts
@@ -10,6 +10,7 @@ import type {
 export const STATE_CONNECTED = 'STATE_CONNECTED'
 export const STATE_AUTHORIZE_NEEDED = 'STATE_AUTHORIZE_NEEDED'
 export const STATE_2FA_NEEDED = 'STATE_2FA_NEEDED'
+export const STATE_2FA_PASSWORD_NEEDED = 'STATE_2FA_PASSWORD_NEEDED'
 export const STATE_INVALID_PASSWORD = 'STATE_INVALID_PASSWORD'
 
 export interface CozyClientCreationContext {
@@ -18,6 +19,7 @@ export interface CozyClientCreationContext {
     | 'STATE_CONNECTED'
     | 'STATE_AUTHORIZE_NEEDED'
     | 'STATE_2FA_NEEDED'
+    | 'STATE_2FA_PASSWORD_NEEDED'
     | 'STATE_INVALID_PASSWORD'
   twoFactorToken?: string
   sessionCode?: string
@@ -30,6 +32,7 @@ interface FetchError extends Error {
   status: number
   reason?: {
     two_factor_token?: string
+    error?: string
   }
 }
 
@@ -46,9 +49,14 @@ interface LoginFlagshipInvalidPasswordResult {
   invalidPassword: true
 }
 
+interface LoginFlagship2faPasswordNeededResult {
+  twoFactorPasswordNeeded: true
+}
+
 export type LoginFlagshipResult =
   | CozyClientLoginFlagshipResult
   | LoginFlagshipInvalidPasswordResult
+  | LoginFlagship2faPasswordNeededResult
 
 export const isInvalidPasswordResult = (
   result: LoginFlagshipResult
@@ -60,6 +68,12 @@ export const is2faNeededResult = (
   result: LoginFlagshipResult
 ): result is LoginFlagship2faNeededResult => {
   return 'two_factor_token' in result && !!result.two_factor_token
+}
+
+export const is2faPasswordNeededResult = (
+  result: LoginFlagshipResult
+): result is LoginFlagship2faPasswordNeededResult => {
+  return 'twoFactorPasswordNeeded' in result
 }
 
 export const isFlagshipVerificationNeededResult = (

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -32,6 +32,9 @@
       "promptTitle": "S'authentifier",
       "title": "Entrez votre mot de passe"
     },
+    "login": {
+      "invalidMagicCode": "Le lien pour accéder à votre Cozy est tronqué ou a expiré"
+    },
     "offline": {
       "body": "Vérifier votre connexion internet pour accéder à votre Cozy.",
       "title": "Pas de connexion internet"


### PR DESCRIPTION
On Magic Link scenario, if the user enabled 2FA, then then 2FA should be done using the user's password instead of the usual code sent by email

This choice has been made because the Magic Link scenario already uses the email channel, so a 2FA code sent through the same channel would add no benefits to security. So instead we ask to the user for their password

To make this possible, we will have to modify cozy-settings so the 2FA feature requires a password to be set on the Cozy

> **Note**
> I'm not happy with the complexity I added on the LoginScreen with this PR but also with the OIDC one. We now have a lot of similar methods (`startOAuth`, `continueOAuth`, `startOidcOAuth`, `startMagicLinkOAuth`, `continueMagicLinkOAuth`) but with enough difference to make it difficult to factorize them. I expect to rework on this after the delivery deadline.