### PR TITLE
fix: Firebase was still sending log related request on iOS

### DIFF
--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -37,6 +37,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>0100070</string>
+  <key>FirebaseDataCollectionDefaultEnabled</key>
+  <false/>
 	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
 	<true/>
 	<key>GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED</key>


### PR DESCRIPTION
We saw at startup a request to firebaselogging-pa.googleapis.com. I added another key in Info.plist which solves the issue.