### PR TITLE
feat: Improve transitions on MagicLink onboarding and on login 2FA

### DIFF
--- a/src/screens/login/CreateInstanceScreen.js
+++ b/src/screens/login/CreateInstanceScreen.js
@@ -40,7 +40,8 @@ export const CreateInstanceScreen = ({ route, navigation }) => {
     navigation.navigate(routes.onboarding, {
       registerToken,
       magicCode,
-      fqdn
+      fqdn,
+      backgroundColor
     })
   }
 

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -632,6 +632,7 @@ const LoginSteps = ({
     return (
       <TransitionToAuthorizeView
         setTransitionEnded={setTransitionToAuthorizeEnded}
+        backgroundColor={backgroundColor}
       />
     )
   }

--- a/src/screens/login/OnboardingScreen.js
+++ b/src/screens/login/OnboardingScreen.js
@@ -217,6 +217,7 @@ const OnboardingSteps = ({
         setKeys={setLoginData}
         setError={setError}
         readonly={state.stepReadonly}
+        setBackgroundColor={setBackgroundColor}
         setReadonly={setStepReadonly}
       />
     )

--- a/src/screens/login/components/CozyLogoScreen.tsx
+++ b/src/screens/login/components/CozyLogoScreen.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react'
+import { StyleSheet, View } from 'react-native'
+import { SvgXml } from 'react-native-svg'
+
+import { isLightBackground } from '/screens/login/components/functions/clouderyBackgroundFetcher'
+import { getColors } from '/ui/colors'
+
+const colors = getColors()
+
+interface CozyLogoScreenProps {
+  backgroundColor: string
+}
+
+export const CozyLogoScreen = ({
+  backgroundColor
+}: CozyLogoScreenProps): JSX.Element => {
+  const [foregroundColor, setForegroundColor] = useState(
+    colors.paperBackgroundColor
+  )
+
+  useEffect(() => {
+    const shouldUsePrimaryColor = isLightBackground(backgroundColor)
+
+    const color = shouldUsePrimaryColor
+      ? colors.primaryColor
+      : colors.paperBackgroundColor
+
+    setForegroundColor(color)
+  }, [backgroundColor])
+
+  return (
+    <View
+      style={[
+        styles.view,
+        {
+          backgroundColor: backgroundColor
+        }
+      ]}
+    >
+      <CozyLogo
+        foregroundColor={foregroundColor}
+        backgroundColor={backgroundColor}
+      />
+    </View>
+  )
+}
+
+interface CozyLogoProps {
+  backgroundColor: string
+  foregroundColor: string
+}
+
+const CozyLogo = ({
+  backgroundColor,
+  foregroundColor
+}: CozyLogoProps): JSX.Element => (
+  <SvgXml
+    xml={`
+      <svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path fill="${foregroundColor}"
+          d="M0 38.4C0 24.9587 0 18.2381 2.61584 13.1042C4.9168 8.58834 8.58834 4.9168 13.1042 2.61584C18.2381 0 24.9587 0 38.4 0H57.6C71.0413 0 77.7619 0 82.8958 2.61584C87.4117 4.9168 91.0832 8.58834 93.3842 13.1042C96 18.2381 96 24.9587 96 38.4V57.6C96 71.0413 96 77.7619 93.3842 82.8958C91.0832 87.4117 87.4117 91.0832 82.8958 93.3842C77.7619 96 71.0413 96 57.6 96H38.4C24.9587 96 18.2381 96 13.1042 93.3842C8.58834 91.0832 4.9168 87.4117 2.61584 82.8958C0 77.7619 0 71.0413 0 57.6V38.4Z" />
+        <path fill-rule="evenodd" clip-rule="evenodd"
+          d="M58.5253 57.7242C58.0177 58.5147 56.8923 58.7523 56.1169 58.2339C56.0499 58.1929 55.9851 58.1475 55.9246 58.1022C53.6631 59.8755 50.8789 60.8432 47.9845 60.8432C45.0965 60.8432 42.3188 59.8799 40.0616 58.113C40.0033 58.154 39.9449 58.1972 39.8845 58.2339C39.0853 58.7545 37.9772 58.5061 37.4739 57.7307C36.9641 56.9444 37.1866 55.8795 37.9685 55.3547C38.6468 54.9075 38.6943 54.0155 38.6943 54.0068C38.7116 53.5403 38.9146 53.0953 39.2537 52.7821C39.5907 52.4689 40.0141 52.2875 40.4806 52.3242C41.4159 52.3458 42.1762 53.132 42.1589 54.0781C42.1589 54.0911 42.1568 54.5641 41.9861 55.2207C45.4745 58.1173 50.5311 58.1065 54.0065 55.197C53.8791 54.6937 53.8467 54.2919 53.8381 54.1062C53.8294 53.6202 54.0022 53.1795 54.3284 52.8447C54.6481 52.5164 55.0801 52.3307 55.5401 52.322H55.5704C56.5057 52.322 57.2811 53.0759 57.3027 54.0133C57.3027 54.0133 57.3524 54.9097 58.0241 55.3525C58.8104 55.8709 59.035 56.9315 58.5253 57.7242ZM65.902 37.4938C65.4031 33.2731 63.5347 29.3722 60.5344 26.3568C57.0935 22.8986 52.5467 21 47.7343 21C42.9218 21 38.3771 22.8986 34.9363 26.359C31.9231 29.3851 30.0503 33.3077 29.5622 37.5521C25.4301 38.0532 21.6091 39.9778 18.6585 43.0687C15.2932 46.6003 13.4399 51.2681 13.4399 56.2102C13.4399 66.5717 21.6479 75 31.7416 75H64.2561C74.3455 75 82.5599 66.5717 82.5599 56.2102C82.5599 46.4189 75.2246 38.3513 65.902 37.4938Z"
+          fill="${backgroundColor}" />
+      </svg>
+    `}
+  />
+)
+
+const styles = StyleSheet.create({
+  view: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+})

--- a/src/screens/login/components/OnboardingPasswordView.js
+++ b/src/screens/login/components/OnboardingPasswordView.js
@@ -20,6 +20,7 @@ import { getColors } from '/ui/colors'
  * @param {Function} props.goBack - Function to call when the back button is clicked
  * @param {string} props.instance - The Cozy's url
  * @param {boolean} props.readonly - Specify if the form should be readonly
+ * @param {setBackgroundColor} props.setBackgroundColor - Set the LoginScreen's background color (used for overlay and navigation bars)
  * @param {setPasswordData} props.setPasswordData - Function to call to set the user's password
  * @param {setReadonly} props.setReadonly - Trigger change on the readonly state
  * @returns {import('react').ComponentClass}
@@ -29,6 +30,7 @@ const PasswordForm = ({
   instance,
   goBack,
   readonly,
+  setBackgroundColor,
   setPasswordData,
   setReadonly
 }) => {
@@ -70,6 +72,7 @@ const PasswordForm = ({
 
       if (message.message === 'loaded') {
         setLoading(false)
+        setBackgroundColor(colors.primaryColor)
       } else if (message.message === 'setPassphrase') {
         setPassword(message.passphrase, message.hint)
       } else if (message.message === 'backButton') {
@@ -116,6 +119,7 @@ const PasswordForm = ({
  * @param {string} props.instance - The Cozy's url
  * @param {number} [props.kdfIterations] - The number of KDF iterations to be used for hashing the password
  * @param {boolean} props.readonly - Specify if the form should be readonly
+ * @param {setBackgroundColor} props.setBackgroundColor - Set the LoginScreen's background color (used for overlay and navigation bars)
  * @param {setErrorCallback} props.setError - Function to call when an error is thrown by the component
  * @param {setLoginDataCallback} props.setKeys - Function to call to set the user's password and encryption keys
  * @param {setReadonly} props.setReadonly - Trigger change on the readonly state
@@ -128,6 +132,7 @@ export const OnboardingPasswordView = ({
   instance,
   kdfIterations,
   readonly,
+  setBackgroundColor,
   setError,
   setKeys,
   setReadonly
@@ -153,6 +158,7 @@ export const OnboardingPasswordView = ({
       fqdn={fqdn}
       goBack={goBack}
       instance={instance}
+      setBackgroundColor={setBackgroundColor}
       setPasswordData={setPasswordData}
       readonly={readonly}
       setReadonly={setReadonly}

--- a/src/screens/login/components/functions/clouderyBackgroundFetcher.ts
+++ b/src/screens/login/components/functions/clouderyBackgroundFetcher.ts
@@ -58,7 +58,7 @@ const isHexaCode = (value: string): boolean => {
  * @param backgroundColor - the background color to analyse
  * @returns true if it is a light background or false if it is a dark background
  */
-const isLightBackground = (backgroundColor: string): boolean => {
+export const isLightBackground = (backgroundColor: string): boolean => {
   let color = backgroundColor.startsWith('#')
     ? backgroundColor.substring(1)
     : backgroundColor

--- a/src/screens/login/components/transitions/TransitionToAuthorizeView.js
+++ b/src/screens/login/components/transitions/TransitionToAuthorizeView.js
@@ -18,10 +18,14 @@ import { getColors } from '/ui/colors'
  * Display a transition that should come before displaying the Authorize view
  *
  * @param {object} props
+ * @param {string} props.backgroundColor - The LoginScreen's background color (used for overlay and navigation bars)
  * @param {Function} props.setTransitionEnded - Function to call when the transition ends
  * @returns {import('react').ComponentClass}
  */
-export const TransitionToAuthorizeView = ({ setTransitionEnded }) => {
+export const TransitionToAuthorizeView = ({
+  backgroundColor,
+  setTransitionEnded
+}) => {
   const colors = getColors()
 
   const animationDelayInSecond = 400
@@ -87,7 +91,7 @@ export const TransitionToAuthorizeView = ({ setTransitionEnded }) => {
       style={[
         styles.background,
         {
-          backgroundColor: colors.primaryColor
+          backgroundColor: backgroundColor
         }
       ]}
     >


### PR DESCRIPTION
When doing MagicLink onboarding, we need to display a screen during the
HTTP requests processing

We chose to display a Cozy logo with a background based on the context

The context color is now passed as a route parameter from the Instance
creation screen (which did get the background color from the Cloudery
webview)

This new Cozy Logo view is now used as a loading screen on the
OnboardinScreen instead of the `showSplashscreen` that cannot be
customized with the context color

___

This PR also adapt the TransitionToAuthorizeView background on LoginScreen which is the cozy logo animation just before the Authorize screen in IAB

___

> **Warning**
> We still have to adapt the colour of the Splashscreen which seems impossible with the current react-native-bootsplash plugin, so we will have to find an other way to adapt the splash screen between the login and the home view