### PR TITLE
Feat/handle partners colors

### DIFF
--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -588,12 +588,12 @@ const LoginSteps = ({
   if (state.step === TWO_FACTOR_AUTHENTICATION_STEP) {
     return (
       <TwoFactorAuthenticationView
+        backgroundColor={backgroundColor}
         instance={state.instance}
         setTwoFactorCode={continueOAuth}
         goBack={cancelOauth}
         errorMessage={state.errorMessage2FA}
         readonly={state.stepReadonly}
-        setBackgroundColor={setBackgroundColor}
         setReadonly={setStepReadonly}
       />
     )

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -543,10 +543,11 @@ const LoginSteps = ({
   }
 
   if (state.step === PASSWORD_STEP) {
+    const enforcedCozyBlueBackground = colors.primaryColor
     return (
       <>
         <PasswordView
-          backgroundColor={backgroundColor}
+          backgroundColor={enforcedCozyBlueBackground}
           instance={state.instance}
           fqdn={state.fqdn}
           kdfIterations={state.kdfIterations}
@@ -563,7 +564,7 @@ const LoginSteps = ({
         />
         {state.waitForTransition && (
           <TransitionToPasswordView
-            backgroundColor={backgroundColor}
+            backgroundColor={enforcedCozyBlueBackground}
             setTransitionEnded={endTransitionToPassword}
             requestTransitionStart={state.requestTransitionStart}
             passwordAvatarPosition={state.passwordAvatarPosition}
@@ -602,10 +603,11 @@ const LoginSteps = ({
   }
 
   if (state.step === TWO_FACTOR_AUTHENTICATION_PASSWORD_STEP) {
+    const enforcedPartnerGreyBackground = '#4b4b4b'
     return (
       <>
         <PasswordView
-          backgroundColor={backgroundColor}
+          backgroundColor={enforcedPartnerGreyBackground}
           instance={state.instance}
           fqdn={state.fqdn}
           kdfIterations={state.kdfIterations}
@@ -622,7 +624,7 @@ const LoginSteps = ({
         />
         {state.waitForTransition && (
           <TransitionToPasswordView
-            backgroundColor={backgroundColor}
+            backgroundColor={enforcedPartnerGreyBackground}
             setTransitionEnded={endTransitionToPassword}
             requestTransitionStart={state.requestTransitionStart}
             passwordAvatarPosition={state.passwordAvatarPosition}

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -546,6 +546,7 @@ const LoginSteps = ({
     return (
       <>
         <PasswordView
+          backgroundColor={backgroundColor}
           instance={state.instance}
           fqdn={state.fqdn}
           kdfIterations={state.kdfIterations}
@@ -562,6 +563,7 @@ const LoginSteps = ({
         />
         {state.waitForTransition && (
           <TransitionToPasswordView
+            backgroundColor={backgroundColor}
             setTransitionEnded={endTransitionToPassword}
             requestTransitionStart={state.requestTransitionStart}
             passwordAvatarPosition={state.passwordAvatarPosition}
@@ -603,6 +605,7 @@ const LoginSteps = ({
     return (
       <>
         <PasswordView
+          backgroundColor={backgroundColor}
           instance={state.instance}
           fqdn={state.fqdn}
           kdfIterations={state.kdfIterations}
@@ -619,6 +622,7 @@ const LoginSteps = ({
         />
         {state.waitForTransition && (
           <TransitionToPasswordView
+            backgroundColor={backgroundColor}
             setTransitionEnded={endTransitionToPassword}
             requestTransitionStart={state.requestTransitionStart}
             passwordAvatarPosition={state.passwordAvatarPosition}

--- a/src/screens/login/components/PasswordView.js
+++ b/src/screens/login/components/PasswordView.js
@@ -8,14 +8,13 @@ import { openForgotPasswordLink } from '/libs/functions/openForgotPasswordLink'
 
 import { getHtml } from './assets/PasswordView/htmlPasswordInjection'
 
-import { getColors } from '/ui/colors'
-
 /**
  * Show a password form that asks the user their password
  * When the user validate their password, the password is sent back to parent
  * by calling `setPasswordData`
  *
  * @param {object} props
+ * @param {string} props.backgroundColor - The LoginScreen's background color (used for overlay and navigation bars)
  * @param {string} [props.errorMessage] - Error message to display if defined
  * @param {string} props.fqdn - The Cozy's fqdn
  * @param {Function} props.goBack - Function to call when the back button is clicked
@@ -29,6 +28,7 @@ import { getColors } from '/ui/colors'
  * @returns {import('react').ComponentClass}
  */
 const PasswordForm = ({
+  backgroundColor,
   errorMessage,
   fqdn,
   goBack,
@@ -43,7 +43,6 @@ const PasswordForm = ({
 }) => {
   const [loading, setLoading] = useState(true)
   const webviewRef = useRef()
-  const colors = getColors()
 
   useEffect(() => {
     if (webviewRef) {
@@ -75,7 +74,7 @@ const PasswordForm = ({
     }
   }, [webviewRef, errorMessage])
 
-  const html = getHtml(name, fqdn, instance)
+  const html = getHtml(name, fqdn, instance, backgroundColor)
 
   const setLoaded = avatarPosition => {
     setLoading(false)
@@ -95,7 +94,7 @@ const PasswordForm = ({
 
       if (message.message === 'loaded') {
         setLoaded(message.avatarPosition)
-        setBackgroundColor(colors.primaryColor)
+        setBackgroundColor(backgroundColor)
       } else if (message.message === 'setPassphrase') {
         setPassword(message.passphrase)
       } else if (message.message === 'forgotPassword') {
@@ -116,14 +115,14 @@ const PasswordForm = ({
         onMessage={processMessage}
         originWhitelist={['*']}
         source={{ html }}
-        style={{ backgroundColor: colors.primaryColor }}
+        style={{ backgroundColor: backgroundColor }}
       />
       {loading && (
         <View
           style={[
             styles.loadingOverlay,
             {
-              backgroundColor: colors.primaryColor
+              backgroundColor: backgroundColor
             }
           ]}
         />
@@ -139,6 +138,7 @@ const PasswordForm = ({
  * If an error occurs, then `setError` is called
  *
  * @param {object} props
+ * @param {string} props.backgroundColor - The LoginScreen's background color (used for overlay and navigation bars)
  * @param {string} [props.errorMessage] - Error message to display if defined
  * @param {string} props.fqdn - The Cozy's fqdn
  * @param {Function} props.goBack - Function to call when the back button is clicked
@@ -154,6 +154,7 @@ const PasswordForm = ({
  * @returns {import('react').ComponentClass}
  */
 export const PasswordView = ({
+  backgroundColor,
   errorMessage,
   fqdn,
   goBack,
@@ -185,6 +186,7 @@ export const PasswordView = ({
 
   return (
     <PasswordForm
+      backgroundColor={backgroundColor}
       errorMessage={errorMessage}
       fqdn={fqdn}
       goBack={goBack}

--- a/src/screens/login/components/PasswordView.spec.js
+++ b/src/screens/login/components/PasswordView.spec.js
@@ -32,7 +32,8 @@ describe('PasswordView', () => {
 
   it('should render component with webview and view', () => {
     const props = {
-      instance: 'http://cozy.192-168-1-102.nip.io:8080'
+      instance: 'http://cozy.192-168-1-102.nip.io:8080',
+      backgroundColor: '#4b4b4b'
     }
     // When
     const { toJSON } = render(<PasswordView {...props} />)

--- a/src/screens/login/components/TwoFactorAuthenticationView.js
+++ b/src/screens/login/components/TwoFactorAuthenticationView.js
@@ -4,35 +4,32 @@ import { KeyboardAvoidingView, Platform, View, StyleSheet } from 'react-native'
 import { getHtml } from './assets/TwoFactorAuthentication/htmlTwoFactorAuthentication'
 
 import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
-import { getColors } from '/ui/colors'
 import { setFocusOnWebviewField } from '/libs/functions/keyboardHelper'
 
 /**
  * Show a 2FA form that asks the user for their 2FA code received by email/authenticator
  *
  * @param {object} props
+ * @param {string} props.backgroundColor - The LoginScreen's background color (used for overlay and navigation bars)
  * @param {string} [props.errorMessage] - Error message to display if defined
  * @param {Function} props.goBack - Function to call when the back button is clicked
  * @param {string} props.instance - The Cozy's url
  * @param {boolean} props.readonly - Specify if the form should be readonly
  * @param {setReadonly} props.setReadonly - Trigger change on the readonly state
  * @param {setTwoFactorCode} props.setTwoFactorCode - Function to call to set the user's 2FA code
- * @param {setBackgroundColor} props.setBackgroundColor - Set the LoginScreen's background color (used for overlay and navigation bars)
  * @returns {import('react').ComponentClass}
  */
 export const TwoFactorAuthenticationView = ({
+  backgroundColor,
   errorMessage,
   goBack,
   instance,
   readonly,
-  setBackgroundColor,
   setReadonly,
   setTwoFactorCode
 }) => {
   const [loading, setLoading] = useState(true)
   const webviewRef = useRef()
-
-  const colors = getColors()
 
   useEffect(() => {
     if (webviewRef) {
@@ -47,16 +44,12 @@ export const TwoFactorAuthenticationView = ({
   }, [webviewRef, readonly])
 
   useEffect(() => {
-    setBackgroundColor(colors.primaryColor)
-  }, [setBackgroundColor, colors.primaryColor])
-
-  useEffect(() => {
     if (webviewRef && !loading) {
       setFocusOnWebviewField(webviewRef.current, 'two-factor-passcode')
     }
   }, [loading, webviewRef])
 
-  const html = getHtml(instance, errorMessage)
+  const html = getHtml(instance, backgroundColor, errorMessage)
 
   const processMessage = event => {
     if (event.nativeEvent && event.nativeEvent.data) {
@@ -88,7 +81,7 @@ export const TwoFactorAuthenticationView = ({
           style={[
             styles.loadingOverlay,
             {
-              backgroundColor: colors.primaryColor
+              backgroundColor: backgroundColor
             }
           ]}
         />

--- a/src/screens/login/components/__snapshots__/PasswordView.spec.js.snap
+++ b/src/screens/login/components/__snapshots__/PasswordView.spec.js.snap
@@ -23,7 +23,7 @@ exports[`PasswordView should render component with webview and view 1`] = `
           "top": 0,
         },
         {
-          "backgroundColor": "#297ef2",
+          "backgroundColor": "#4b4b4b",
         },
       ]
     }

--- a/src/screens/login/components/assets/PasswordView/htmlPasswordInjection.js
+++ b/src/screens/login/components/assets/PasswordView/htmlPasswordInjection.js
@@ -30,9 +30,10 @@ const locale = 'fr'
  * @param {string} title - The title of the page - for example the user's name as configured in the Cozy's settings
  * @param {string} fqdn - The subtitle of the page - for example the Cozy's fqdn
  * @param {string} instance - The Cozy's url, used to get avatar and fonts css
+ * @param {string} backgroundColor - The LoginScreen's background color (used for overlay and navigation bars)
  * @returns {Element} HTML of Password form to inject inside Webview
  */
-export const getHtml = (title, fqdn, instance) => {
+export const getHtml = (title, fqdn, instance, backgroundColor) => {
   const avatarUrl = new URL(instance)
   avatarUrl.pathname = 'public/avatar'
 
@@ -50,6 +51,22 @@ export const getHtml = (title, fqdn, instance) => {
     <style type="text/css">${cozyBsCss}</style>
     <style type="text/css">${themeCss}</style>
     <style type="text/css">${cirrusCss}</style>
+    <style type="text/css">
+    ${
+      backgroundColor === '#4b4b4b'
+        ? `
+        .theme-inverted {
+          --primaryColorDark: #eeeeee;
+          --primaryColorLightest: #626262;
+          --primaryTextContrastColor: #626262;
+          --secondaryColor: #a3a3a3;
+          --paperBackgroundColor: #4b4b4b;
+          --banner-color: #282828;
+          --btn-secondary-border-color: rgba(255, 255, 255, .48);
+        }`
+        : ''
+    }
+    </style>
   </head>
   <body class="theme-inverted">
     <form id="login-form" method="POST" action="#" class="d-contents">

--- a/src/screens/login/components/assets/TwoFactorAuthentication/htmlTwoFactorAuthentication.js
+++ b/src/screens/login/components/assets/TwoFactorAuthentication/htmlTwoFactorAuthentication.js
@@ -29,7 +29,11 @@ const getCredentialsErrorJs = credentialsErrorMsg =>
 
 const locale = 'fr'
 
-export const getHtml = (instance, credentialsErrorMsg = undefined) => `
+export const getHtml = (
+  instance,
+  backgroundColor,
+  credentialsErrorMsg = undefined
+) => `
 <!DOCTYPE html>
 <html lang="${locale}">
   <head>
@@ -40,6 +44,22 @@ export const getHtml = (instance, credentialsErrorMsg = undefined) => `
     <style type="text/css">${cozyBsCss}</style>
     <style type="text/css">${themeCss}</style>
     <style type="text/css">${cirrusCss}</style>
+    <style type="text/css">
+    ${
+      backgroundColor === '#4b4b4b'
+        ? `
+        .theme-inverted {
+          --primaryColorDark: #eeeeee;
+          --primaryColorLightest: #626262;
+          --primaryTextContrastColor: #626262;
+          --secondaryColor: #a3a3a3;
+          --paperBackgroundColor: #4b4b4b;
+          --banner-color: #282828;
+          --btn-secondary-border-color: rgba(255, 255, 255, .48);
+        }`
+        : ''
+    }
+    </style>
   </head>
   <body class="theme-inverted">
     <form id="two-factor-form" method="POST" action="#" class="d-contents">

--- a/src/screens/login/components/transitions/TransitionToPasswordView.js
+++ b/src/screens/login/components/transitions/TransitionToPasswordView.js
@@ -18,12 +18,14 @@ const webViewTopToNativeTop = top => top + getDimensions().statusBarHeight
  * correctly translate the Cozy logo to the avatar's position
  *
  * @param {object} props
+ * @param {string} props.backgroundColor - The LoginScreen's background color (used for overlay and navigation bars)
  * @param {TransitionPasswordAvatarPosition} props.passwordAvatarPosition - The password form's avatar position
  * @param {boolean} props.requestTransitionStart - Boolean that define if the transition should start
  * @param {Function} props.setTransitionEnded - Function to call when the transition ends
  * @returns {import('react').ComponentClass}
  */
 export const TransitionToPasswordView = ({
+  backgroundColor,
   passwordAvatarPosition,
   requestTransitionStart,
   setTransitionEnded
@@ -114,7 +116,7 @@ export const TransitionToPasswordView = ({
           styles.background,
           {
             opacity: animatedOpacity,
-            backgroundColor: colors.primaryColor
+            backgroundColor: backgroundColor
           }
         ]}
       />


### PR DESCRIPTION
**feat: Handle grey theme on TwoFactorAuthenticationView and PasswordView**

In some partner scenario we want the PasswordView and the TwoFactorAuthenticationView to fit the provided partner theme (which is grey)

For now we don't have a mechanism to retrieve all theme's colors from the cloudery WebView so we hard coded them if the corresponding grey `backgroundColor` is detected

In a later commit we should implement it in a more dynamic way

___

**feat: Enforce grey theme on PasswordView as 2FA**


The Password view can be displayed only in two distinct scenario

When login to a Blue Cozy, then we display the PasswordView which
should be blue

When login with a Partner Cozy with 2FA enabled, then the we display
the PasswordView for the 2FA step, which should use the Partner's theme

Today we don't have any way to detect the Partner's theme at this step
as no WebView should has been display prior this step (the first step
is top open the app from a link). So for now we enforce the hardcoded
`#4b4b4b` color until we find a better way