### PR TITLE
feat: Logout clisk webview if some account removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "redux-logger": "3.0.6",
     "redux-persist": "^6.0.0",
     "rn-async-storage-flipper": "^0.0.10",
-    "rn-flipper-async-storage-advanced": "^1.0.4"
+    "rn-flipper-async-storage-advanced": "^1.0.4",
+    "semver": "^7.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.14.8",

--- a/src/libs/Launcher.spec.js
+++ b/src/libs/Launcher.spec.js
@@ -45,14 +45,21 @@ describe('Launcher', () => {
     it('should save credentials with proper attributes', async () => {
       const launcher = new Launcher()
       const konnector = { slug: 'testkonnectorslug' }
+      const client = {
+        getStackClient: () => ({
+          uri: 'http://cozy.localhost:8080'
+        })
+      }
       launcher.setStartContext({
-        konnector
+        konnector,
+        client
       })
       await launcher.saveCredentials({
         login: 'testlogin',
         password: 'testpassword'
       })
       expect(saveCredential).toHaveBeenCalledWith(
+        'cozy.localhost_8080',
         expect.objectContaining({
           credentials: {
             login: 'testlogin',
@@ -69,6 +76,9 @@ describe('Launcher', () => {
       const launcher = new Launcher()
       const konnector = { slug: 'testkonnectorslug' }
       const client = {
+        getStackClient: () => ({
+          uri: 'http://cozy.localhost:8080'
+        }),
         query: jest.fn().mockResolvedValueOnce({
           data: [
             { _id: 'testaccountid1' },
@@ -89,7 +99,10 @@ describe('Launcher', () => {
       const result = await launcher.cleanCredentialsAccounts('testslug1')
 
       expect(result).toBe(true)
-      expect(getSlugAccountIds).toHaveBeenCalledWith('testslug1')
+      expect(getSlugAccountIds).toHaveBeenCalledWith(
+        'cozy.localhost_8080',
+        'testslug1'
+      )
       expect(client.query).toHaveBeenCalledWith(
         expect.objectContaining({ ids: ['testaccountid1', 'testaccountid3'] })
       )
@@ -98,7 +111,10 @@ describe('Launcher', () => {
       const launcher = new Launcher()
       const konnector = { slug: 'testkonnectorslug' }
       const client = {
-        query: jest.fn()
+        query: jest.fn(),
+        getStackClient: () => ({
+          uri: 'http://cozy.localhost:8080'
+        })
       }
       getSlugAccountIds.mockResolvedValueOnce([])
       launcher.setStartContext({
@@ -109,7 +125,10 @@ describe('Launcher', () => {
       const result = await launcher.cleanCredentialsAccounts('testslug1')
 
       expect(result).toBe(false)
-      expect(getSlugAccountIds).toHaveBeenCalledWith('testslug1')
+      expect(getSlugAccountIds).toHaveBeenCalledWith(
+        'cozy.localhost_8080',
+        'testslug1'
+      )
       expect(client.query).not.toHaveBeenCalled()
     })
   })

--- a/src/libs/Launcher.spec.js
+++ b/src/libs/Launcher.spec.js
@@ -1,6 +1,8 @@
 import Launcher from './Launcher'
+import { saveCredential, getSlugAccountIds } from './keychain'
 
 jest.mock('./folder')
+jest.mock('./keychain')
 
 describe('Launcher', () => {
   describe('ensureAccountTriggerAndLaunch', () => {
@@ -37,6 +39,78 @@ describe('Launcher', () => {
         manifest: { name: 'konnector' },
         launcherClient
       })
+    })
+  })
+  describe('saveCredentials', () => {
+    it('should save credentials with proper attributes', async () => {
+      const launcher = new Launcher()
+      const konnector = { slug: 'testkonnectorslug' }
+      launcher.setStartContext({
+        konnector
+      })
+      await launcher.saveCredentials({
+        login: 'testlogin',
+        password: 'testpassword'
+      })
+      expect(saveCredential).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentials: {
+            login: 'testlogin',
+            password: 'testpassword'
+          },
+          slug: 'testkonnectorslug',
+          version: 1
+        })
+      )
+    })
+  })
+  describe('cleanCredentialsAccounts', () => {
+    it('should clean credentials accounts associated to non existing accounts', async () => {
+      const launcher = new Launcher()
+      const konnector = { slug: 'testkonnectorslug' }
+      const client = {
+        query: jest.fn().mockResolvedValueOnce({
+          data: [
+            { _id: 'testaccountid1' },
+            { _id: 'testaccountid2' },
+            { _id: 'testaccountid3' }
+          ]
+        })
+      }
+      getSlugAccountIds.mockResolvedValueOnce([
+        'testaccountid1',
+        'testaccountid3'
+      ])
+      launcher.setStartContext({
+        konnector,
+        client
+      })
+
+      const result = await launcher.cleanCredentialsAccounts('testslug1')
+
+      expect(result).toBe(true)
+      expect(getSlugAccountIds).toHaveBeenCalledWith('testslug1')
+      expect(client.query).toHaveBeenCalledWith(
+        expect.objectContaining({ ids: ['testaccountid1', 'testaccountid3'] })
+      )
+    })
+    it('should return false if nothing was cleaned', async () => {
+      const launcher = new Launcher()
+      const konnector = { slug: 'testkonnectorslug' }
+      const client = {
+        query: jest.fn()
+      }
+      getSlugAccountIds.mockResolvedValueOnce([])
+      launcher.setStartContext({
+        konnector,
+        client
+      })
+
+      const result = await launcher.cleanCredentialsAccounts('testslug1')
+
+      expect(result).toBe(false)
+      expect(getSlugAccountIds).toHaveBeenCalledWith('testslug1')
+      expect(client.query).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -69,6 +69,9 @@ describe('ReactNativeLauncher', () => {
       create: jest.fn(),
       query: jest.fn(),
       destroy: jest.fn(),
+      getStackClient: () => ({
+        uri: 'http://cozy.localhost:8080'
+      }),
       collection: () => ({
         launch,
         findReferencedBy,

--- a/src/libs/keychain.js
+++ b/src/libs/keychain.js
@@ -98,6 +98,25 @@ export async function removeCredential(account) {
 }
 
 /**
+ * Get account ids associated to the given slug in keychain
+ *
+ * @param {String} slug - konnector slug
+ * @returns {Promise<Array<String>>} - list of account ids associated to the given slug
+ */
+export async function getSlugAccountIds(slug) {
+  const password = await getDecodedGenericPasswords()
+  const credentials = password[CREDENTIALS_SCOPE] || {}
+  const result = []
+  for (const accountId in credentials) {
+    const account = credentials[accountId]
+    if (account.slug === slug) {
+      result.push(accountId)
+    }
+  }
+  return result
+}
+
+/**
  *
  * @param {String} key
  * @param {String|Object} value

--- a/src/libs/keychain.spec.js
+++ b/src/libs/keychain.spec.js
@@ -5,6 +5,7 @@ import * as Keychain from 'react-native-keychain'
 import {
   saveCredential,
   getCredential,
+  getSlugAccountIds,
   GLOBAL_KEY,
   saveVaultInformation,
   getVaultInformation,
@@ -29,6 +30,28 @@ describe('keychain test suite', () => {
     console.log = jest.fn() // eslint-disable-line no-console
   })
   describe('credentials API', () => {
+    describe('getSlugAccountIds', () => {
+      it('should get the account ids associated to a given slug', async () => {
+        jest.spyOn(Keychain, 'getGenericPassword').mockResolvedValueOnce({
+          username: GLOBAL_KEY,
+          password: JSON.stringify({
+            CSC_ACCOUNTS: {
+              0: {
+                slug: 'testslug1'
+              },
+              1: {
+                slug: 'testslug2'
+              },
+              2: {
+                slug: 'testslug1'
+              }
+            }
+          })
+        })
+        const accountIds = await getSlugAccountIds('testslug1')
+        expect(accountIds).toStrictEqual(['0', '2'])
+      })
+    })
     it('test get credentials methods', async () => {
       jest.spyOn(Keychain, 'getGenericPassword').mockResolvedValueOnce(false)
       const cred = await getCredential(account)


### PR DESCRIPTION
Now, when running a clisk konnector, we first check that the accounts
associated to its credentials still exist in cozy database.

If some accounts in credentials do not exist, it  means that the
associated accounts have been removed from cozy database and then we can
clean the corresponding credentials.

To make this possible, credentials are now saved with the following
format :

```
{
  version: 1, // to make future migrations easier
  createdByAppVersion: '0.1.0-9999',
  createdAt: '2023-04-18T16:20:46.103Z',
  slug: 'konnectorslug', // to find credentials associated to a given konnector slug
  credentials: {
    // any object given to saveCredentials
  }
}
```

With this new credentials format, old format credentials are now
ignored.

If some credentials have been removed, it means that we must logout from
the target website of the konnector, to avoid wrong account
associations.

Konnectors must now implement a `ensureNotAuthenticated` method,
callable by the launcher. This method will be called when the some
credentials have been removed and if cozy-clisk package version is
equal greater than 0.10.0.

The launcher checks if the ensureNotAuthenticated method should be
available with the `getCliskVersion` method. In this case, the
getCliskVersion method has been merged just after the
`ensureAuthenticated` method but this is a proof of concept for the
`getCliskVersion` method.