### PR TITLE
fix: Add French localization support in Info.plist

### DIFF
--- a/ios/CozyReactNativeDev-Info.plist
+++ b/ios/CozyReactNativeDev-Info.plist
@@ -94,5 +94,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>fr</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request adds French localization support to the iOS app by updating the Info.plist file. It includes the 'fr' language in the CFBundleLocalizations key, which informs iOS that our app supports French localization. As a result, system-provided UI components will respect the device's language settings when set to French.

Please note that this change only affects build-time settings and does not allow for changing the app's language at runtime based on user settings. In the future, if we decide to support multiple languages and allow users to change the app's language at runtime, we can consider implementing a localization library such as react-i18next or react-native-localize. This would enable us to manage translations within the React Native code and update the displayed language based on user preferences.

For now, this pull request ensures that our app correctly supports French localization, as it is the only language currently supported in the app.
