### PR TITLE
fix: Disable ClouderyView tests that timeout

### DIFF
--- a/src/screens/login/components/ClouderyView.spec.js
+++ b/src/screens/login/components/ClouderyView.spec.js
@@ -73,7 +73,9 @@ jest.mock('/screens/login/cloudery-env/useClouderyUrl', () => {
   }
 })
 
-describe('ClouderyView', () => {
+// Those are flacky tests that often timeout on Github Action CI
+// We didn't find a way to stabilise them yet, so until a solution is found we want them to be disabled
+xdescribe('ClouderyView', () => {
   describe('on handleNavigation', () => {
     const props = {
       setInstanceData: jest.fn()


### PR DESCRIPTION
Those are flacky tests that often timeout on Github Action CI

We didn't find a way to stabilise them yet, so until a solution is found we want them to be disabled

Related commit: 3cb78493449dc5795ebb152c512502b702820440