### PR TITLE
feat: Force worker webview reload when needed

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -51,7 +51,8 @@ class LauncherView extends Component {
       userAgent: undefined,
       konnector: null,
       workerInnerUrl: null,
-      worker: {}
+      worker: {},
+      workerKey: 0
     }
   }
 
@@ -163,7 +164,16 @@ class LauncherView extends Component {
     const initKonnectorError = await this.initKonnector()
 
     this.launcher.on('SET_WORKER_STATE', options => {
-      this.setState({ worker: { ...this.state.worker, ...options } })
+      // here we check the difference with worker inner url
+      const newUrl = options.url
+      const shouldForceWorkerReload =
+        newUrl === this.state.worker.url && newUrl !== this.state.workerInnerUrl
+      if (shouldForceWorkerReload) {
+        this.setState({ workerKey: Date.now() })
+      }
+      this.setState({
+        worker: { ...this.state.worker, ...options }
+      })
     })
 
     this.launcher.on('SET_USER_AGENT', userAgent => {
@@ -247,6 +257,7 @@ class LauncherView extends Component {
                 </TouchableOpacity>
               </View>
               <WebView
+                key={this.state.workerKey}
                 mediaPlaybackRequiresUserAction={true}
                 ref={ref => (this.workerWebview = ref)}
                 originWhitelist={['*']}

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -40,6 +40,7 @@ class LauncherView extends Component {
     this.onPilotMessage = this.onPilotMessage.bind(this)
     this.onWorkerMessage = this.onWorkerMessage.bind(this)
     this.onWorkerError = this.onWorkerError.bind(this)
+    this.onWorkerLoad = this.onWorkerLoad.bind(this)
     this.onStopExecution = this.onStopExecution.bind(this)
     this.onCreatedAccount = this.onCreatedAccount.bind(this)
     this.onCreatedJob = this.onCreatedJob.bind(this)
@@ -49,6 +50,7 @@ class LauncherView extends Component {
     this.state = {
       userAgent: undefined,
       konnector: null,
+      workerInnerUrl: null,
       worker: {}
     }
   }
@@ -248,6 +250,7 @@ class LauncherView extends Component {
                 mediaPlaybackRequiresUserAction={true}
                 ref={ref => (this.workerWebview = ref)}
                 originWhitelist={['*']}
+                onLoad={this.onWorkerLoad}
                 useWebKit={true}
                 javaScriptEnabled={true}
                 userAgent={this.state.userAgent}
@@ -264,6 +267,10 @@ class LauncherView extends Component {
         ) : null}
       </>
     )
+  }
+
+  onWorkerLoad(event) {
+    this.setState({ workerInnerUrl: event.nativeEvent.url })
   }
 
   /**
@@ -305,7 +312,7 @@ class LauncherView extends Component {
     if (event.nativeEvent && event.nativeEvent.data) {
       const msg = JSON.parse(event.nativeEvent.data)
       if (msg.message === 'NEW_WORKER_INITIALIZING') {
-        this.launcher.emit('NEW_WORKER_INITIALIZING')
+        this.launcher.emit('NEW_WORKER_INITIALIZING', this.workerWebview)
         return
       } else if (['load', 'DOMContentLoaded'].includes(msg.message)) {
         this.launcher.emit('worker:' + msg.message)


### PR DESCRIPTION
A worker webview rerender is needed when a worker url change is invoked by
the clisk konnector (goto) and the worker webview current url is already
the same url but the webview inner url is different.

By default in this case the react-native-webview component is not
rerendered if all the properties are the same.

Here we force the rerender with a change in the `key` attribute of the
webview.

Since in this case the reference to the webview is changed, we need to
update it in the launcher too.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

