### PR TITLE
feat: Rename app from `Cloud Personnel` to `Cozy`

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Cloud Personnel</string>
+    <string name="app_name">Cozy</string>
 </resources>

--- a/docs/how-to-retrieve-logs-in-release.md
+++ b/docs/how-to-retrieve-logs-in-release.md
@@ -55,7 +55,7 @@ Then in order to retrieve the log:
 - Run the app to generate logs
 - Plug the iPhone to your mac
 - In the mac's Finder, select the iPhone in the left pane
-- In the `Files` tab, open `Cloud Personnel` element and find `logs.txt`
+- In the `Files` tab, open `Cozy` element and find `logs.txt`
 - Drag&drop the `logs.txt` file into a local folder
 
 ![](/docs/images/finder_iphone_files.png)

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -51,7 +51,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Cloud Personnel</string>
+	<string>Cozy</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/CozyReactNativeDev-Info.plist
+++ b/ios/CozyReactNativeDev-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Cloud Personnel</string>
+	<string>Cozy</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
In previous PR we renamed the app to `Cloud Personnel` to better fit the "neutral" scenario we are implementing

But this new name was too long and would be truncated in some OS. For example iOS would truncate any app name between 11 and 13 characters based on the OS' font zoom setting. The Android rule can differ on each model/brand but we should be safe if choosing a name with less than 12 characters (based on unofficial answers on StackOverflow)

So we rename it again but this time we want to use `Cozy` name

Related PR: #735
