### PR TITLE
fix: Return to WelcomeScreen when canceling MagicLink login

### DIFF
--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -172,7 +172,7 @@ const LoginSteps = ({
 
   const cancelOauth = useCallback(() => {
     setState(oldState => {
-      if (oldState.isOidc) {
+      if (oldState.isOidc || oldState.isMagicLink) {
         return {
           step: CLOUDERY_STEP
         }
@@ -264,6 +264,7 @@ const LoginSteps = ({
           setState(oldState => ({
             ...oldState,
             step: TWO_FACTOR_AUTHENTICATION_PASSWORD_STEP,
+            isMagicLink: true,
             client: result.client,
             fqdn: fqdn,
             instance: instance,
@@ -278,6 +279,7 @@ const LoginSteps = ({
           setState(oldState => ({
             ...oldState,
             step: AUTHORIZE_TRANSITION_STEP,
+            isMagicLink: true,
             waitForTransition: true,
             client: result.client,
             sessionCode: result.sessionCode


### PR DESCRIPTION
With previous implementation we would return to the PasswordView when canceling the MagicLink authorization and 2FA steps

This should not be possible because PasswordView should never appears in the MagicLink scenario, so we want to return to the WelcomeScreen instead