### PR TITLE
fix: Call correct method after receiving login and onboarding links

### DIFF
--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -35,6 +35,7 @@ import { NetService } from '/libs/services/NetService'
 import { routes } from '/constants/routes'
 import { setStatusBarColorToMatchBackground } from '/screens/login/components/functions/clouderyBackgroundFetcher'
 import { getInstanceFromFqdn } from '/screens/login/components/functions/getInstanceFromFqdn'
+import { getInstanceDataFromFqdn } from '/screens/login/components/functions/getInstanceDataFromRequest'
 
 const log = Minilog('LoginScreen')
 
@@ -105,22 +106,16 @@ const LoginSteps = ({
     const fqdn = consumeRouteParameter('fqdn', route, navigation)
     const magicCode = consumeRouteParameter('magicCode', route, navigation)
     if (fqdn) {
-      const url = getInstanceFromFqdn(fqdn)
-
-      const normalizedFqdn = url.host.toLowerCase()
-      const normalizedInstance = url.origin.toLowerCase()
+      const instanceData = getInstanceDataFromFqdn(fqdn)
 
       // when receiving fqdn from route parameter, we don't have access to partner context
       // so we enforce default Cozy color as background
       setBackgroundColor(colors.primaryColor)
 
       if (magicCode) {
-        startMagicLinkOAuth(normalizedFqdn, magicCode)
+        startMagicLinkOAuth(instanceData.fqdn, magicCode)
       } else {
-        setInstanceData({
-          fqdn: normalizedFqdn,
-          instance: normalizedInstance
-        })
+        setInstanceData(instanceData)
       }
     }
   }, [

--- a/src/screens/login/OnboardingScreen.js
+++ b/src/screens/login/OnboardingScreen.js
@@ -17,7 +17,7 @@ import { routes } from '/constants/routes'
 import { getColors } from '/ui/colors'
 import { CozyLogoScreen } from '/screens/login/components/CozyLogoScreen'
 import { setStatusBarColorToMatchBackground } from '/screens/login/components/functions/clouderyBackgroundFetcher'
-import { getInstanceFromFqdn } from '/screens/login/components/functions/getInstanceFromFqdn'
+import { getInstanceDataFromFqdn } from '/screens/login/components/functions/getInstanceDataFromRequest'
 
 const log = Minilog('OnboardingScreen')
 
@@ -69,18 +69,18 @@ const OnboardingSteps = ({
     const magicCode = consumeRouteParameter('magicCode', route, navigation)
 
     if (fqdn) {
-      const url = getInstanceFromFqdn(fqdn)
+      const instanceData = getInstanceDataFromFqdn(fqdn)
 
       if (registerToken) {
         setOnboardingData({
-          fqdn: url.host,
-          instance: url.origin,
+          fqdn: instanceData.fqdn,
+          instance: instanceData.instance,
           registerToken: registerToken
         })
       } else if (magicCode) {
         setMagicLinkOnboardingData({
-          fqdn: url.host,
-          instance: url.origin,
+          fqdn: instanceData.fqdn,
+          instance: instanceData.instance,
           magicCode: magicCode
         })
       }

--- a/src/screens/login/components/functions/getInstanceDataFromRequest.ts
+++ b/src/screens/login/components/functions/getInstanceDataFromRequest.ts
@@ -30,6 +30,12 @@ export const getInstanceDataFromRequest = (
     return null
   }
 
+  return getInstanceDataFromFqdn(fqdnParam)
+}
+
+export const getInstanceDataFromFqdn = (
+  fqdnParam: string
+): CozyFqndAndInstance | null => {
   const instance = getInstanceFromFqdn(fqdnParam)
 
   // since fqdnParam may contain a protocol, we use URL to remove it


### PR DESCRIPTION
`getInstanceFromFqdn` returns a strings containing the Cozy instance

As this is a string, the following lines would throw when calling `url.host` and `url.origin` from a string

New `getInstanceDataFromFqdn` method returns an object containing the Cozy FQDN and instance