### PR TITLE
feat: Use `default_redirection` param to open default app on Login

### DIFF
--- a/src/screens/login/components/ClouderyView.js
+++ b/src/screens/login/components/ClouderyView.js
@@ -13,6 +13,7 @@ import { rootCozyUrl } from 'cozy-client'
 import strings from '/constants/strings.json'
 import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
+import { useHomeStateContext } from '/screens/home/HomeStateProvider'
 import { useClouderyUrl } from '/screens/login/cloudery-env/useClouderyUrl'
 import { ClouderyViewSwitch } from '/screens/login/components/ClouderyViewSwitch'
 import { getInstanceDataFromRequest } from '/screens/login/components/functions/getInstanceDataFromRequest'
@@ -59,6 +60,7 @@ export const ClouderyView = ({
   const [checkInstanceData, setCheckInstanceData] = useState()
   const webviewRef = useRef()
   const [canGoBack, setCanGoBack] = useState(false)
+  const { setOnboardedRedirection } = useHomeStateContext()
 
   const handleNavigation = request => {
     log.debug(`Navigation to ${request.url}`)
@@ -76,6 +78,7 @@ export const ClouderyView = ({
     if (isOidc) {
       processOIDC(request)
         .then(oidcResult => {
+          setOnboardedRedirection(oidcResult.defaultRedirection ?? '')
           if (oidcResult.fqdn) {
             startOidcOAuth(oidcResult.fqdn, oidcResult.code)
           } else if (oidcResult.onboardUrl) {


### PR DESCRIPTION
When login using OIDC, then the Cloudery redirects to the app with an URL containing a `default_redirection` parameter

This parameter is already parsed by the processOIDC method, but we did not propagate the value so the Flagship can display the correct cozy-app after the Login step

Related commit: 64b24f978aa4a0740b4920a9a9d09136ec9a1017
Related commit: f0f7bfebbad3f31dd171f70b94d3c9ab7c87aa0b
