### PR TITLE
fix: Prevent initial route params to be reused on HomeView

### DIFF
--- a/src/libs/functions/routeHelpers.ts
+++ b/src/libs/functions/routeHelpers.ts
@@ -1,9 +1,13 @@
+import Minilog from '@cozy/minilog'
 import {
   NavigationProp,
   ParamListBase,
   RouteProp
 } from '@react-navigation/native'
 import { get } from 'lodash'
+import { useEffect, useState } from 'react'
+
+const log = Minilog('routeHelpers')
 
 /**
  * Retrieve the specified route parameter and remove it from the navigation state
@@ -24,4 +28,55 @@ export const consumeRouteParameter = <T>(
   }
 
   return param
+}
+
+interface UseClouderyUrlHook<T> {
+  consume: () => T | undefined
+}
+
+/**
+ * Hook that return the specified route parameter and ensure it is read only one single time
+ *
+ * @param paramName - Name of the parameter to retrieve
+ * @param route - Application's route
+ * @param navigation - Application's navigation
+ * @returns an initial parameter to be `.consume()`
+ */
+export const useInitialParam = <T>(
+  paramName: string,
+  route: RouteProp<ParamListBase>,
+  navigation: NavigationProp<ParamListBase>
+): UseClouderyUrlHook<T> => {
+  const [paramValue, setParamValue] = useState<T | undefined>(undefined)
+  const [handledInitialParams, setHandledInitialParams] = useState(false)
+
+  const consume = (): T | undefined => {
+    const value = paramValue
+
+    setParamValue(undefined)
+
+    return value
+  }
+
+  useEffect(
+    function checkInitialParam() {
+      const value = consumeRouteParameter<T>(paramName, route, navigation)
+
+      if (handledInitialParams) {
+        if (value) {
+          log.warn(
+            `🚨 useInitialParam detected new value for already consumed ${paramName} param, this should not happens, please verify your Router initialization`
+          )
+        }
+        return
+      }
+
+      setParamValue(value)
+
+      setHandledInitialParams(true)
+    },
+    [handledInitialParams, navigation, paramName, paramValue, route]
+  )
+
+  return { consume }
 }

--- a/src/libs/functions/routeHelpers.ts
+++ b/src/libs/functions/routeHelpers.ts
@@ -1,3 +1,8 @@
+import {
+  NavigationProp,
+  ParamListBase,
+  RouteProp
+} from '@react-navigation/native'
 import { get } from 'lodash'
 
 /**
@@ -7,8 +12,12 @@ import { get } from 'lodash'
  * @param {*} navigation - Application's navigation
  * @returns the route parameter's value
  */
-export const consumeRouteParameter = (paramName, route, navigation) => {
-  const param = get(route, `params.${paramName}`)
+export const consumeRouteParameter = <T>(
+  paramName: string,
+  route: RouteProp<ParamListBase>,
+  navigation: NavigationProp<ParamListBase>
+): T | undefined => {
+  const param = get(route, `params.${paramName}`) as T | undefined
 
   if (param !== undefined) {
     navigation.setParams({ [paramName]: undefined })

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -13,7 +13,10 @@ import { AppState } from 'react-native'
 
 import { CozyProxyWebView } from '/components/webviews/CozyProxyWebView'
 import { navigateToApp } from '/libs/functions/openApp'
-import { consumeRouteParameter } from '/libs/functions/routeHelpers'
+import {
+  consumeRouteParameter,
+  useInitialParam
+} from '/libs/functions/routeHelpers'
 import { resetUIState } from '/libs/intents/setFlagshipUI'
 import { useSession } from '/hooks/useSession'
 import { routes } from '/constants/routes'
@@ -50,6 +53,16 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
   const session = useSession()
   const didBlurOnce = useRef(false)
   const [webviewRef, setParentRef] = useState()
+  const mainAppFallbackURLInitialParam = useInitialParam(
+    'mainAppFallbackURL',
+    route,
+    navigation
+  )
+  const cozyAppFallbackURLInitialParam = useInitialParam(
+    'cozyAppFallbackURL',
+    route,
+    navigation
+  )
 
   useEffect(() => {
     const subscription = AppState.addEventListener(
@@ -140,11 +153,7 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
 
   useEffect(() => {
     const href = consumeRouteParameter('href', route, navigation)
-    const mainAppFallbackURL = consumeRouteParameter(
-      'mainAppFallbackURL',
-      route,
-      navigation
-    )
+    const mainAppFallbackURL = mainAppFallbackURLInitialParam.consume()
     const deepLink = href || mainAppFallbackURL
 
     if (deepLink) {
@@ -176,16 +185,12 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
     if (!uri && session.subDomainType) {
       getHomeUri()
     }
-  }, [uri, client, route, navigation, session])
+  }, [uri, client, route, mainAppFallbackURLInitialParam, navigation, session])
 
   useEffect(
     function handleCozyAppFallback() {
       if (uri) {
-        const cozyAppFallbackURL = consumeRouteParameter(
-          'cozyAppFallbackURL',
-          route,
-          navigation
-        )
+        const cozyAppFallbackURL = cozyAppFallbackURLInitialParam.consume()
 
         if (cozyAppFallbackURL) {
           setShouldWaitCozyApp(true)
@@ -207,7 +212,14 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
         }
       }
     },
-    [uri, client, route, navigation, setShouldWaitCozyApp, shouldWaitCozyApp]
+    [
+      client,
+      cozyAppFallbackURLInitialParam,
+      navigation,
+      setShouldWaitCozyApp,
+      shouldWaitCozyApp,
+      uri
+    ]
   )
 
   useEffect(() => {


### PR DESCRIPTION
> **Warning**
> This PR does not fix the root issue, but as we want to fix it fast before next release and because we don't know yet why this happens, then this PR fixes the issue symptoms

When opening a konnector from cozy-store, we want the HomeView to open the expected konnector

Current router implementation has a navigation bug that re-apply the route's initial params every time we navigate to `routes.home`

This would prevent the queried konnector to be displayed because in that scenario the HomeView initial param would override the konnector's URI with the cozy-home initial URI

Until we fix this navigation bug, we want to secure the way HomeView handle initial params so they would never be re-applied again after first handling

If the param re-appear on the router params, then we want a warning to be displayed on the debug terminal to remind us to fix the root issue