### PR TITLE
fix: Correctly distinguish 401 and 403 errors on OIDC 2FA

### DIFF
--- a/src/libs/clientHelpers/oidc.ts
+++ b/src/libs/clientHelpers/oidc.ts
@@ -48,7 +48,7 @@ const loginOidc = async (
       throw e
     }
 
-    if (e.status === 401 || e.status === 403) {
+    if (e.status === 401) {
       if (e.reason?.two_factor_token) {
         return {
           two_factor_token: e.reason.two_factor_token
@@ -57,6 +57,10 @@ const loginOidc = async (
         return {
           invalidPassword: true
         }
+      }
+    } else if (e.status === 403 && twoFactorAuthenticationData) {
+      return {
+        two_factor_token: twoFactorAuthenticationData.token
       }
     } else {
       throw e


### PR DESCRIPTION
This reverts 770c27d1eafc6e70a06bb93b934837817aa1139b since the previous behaviour was a bug that has been fixed on cozy-stack side

Now the OIDC 2FA process correctly returns a 401 error on first attempt and then all attempts with a 2fa code would produce a 403 error

Related PR: cozy/cozy-stack#3895
Related commit: 770c27d1eafc6e70a06bb93b934837817aa1139b