### PR TITLE
fix: Run Debug on real Device

### DIFF
--- a/ios/CozyReactNative.xcodeproj/project.pbxproj
+++ b/ios/CozyReactNative.xcodeproj/project.pbxproj
@@ -791,6 +791,7 @@
 				CODE_SIGN_ENTITLEMENTS = CozyReactNative/CozyReactNative.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 3AKXFMV43J;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3AKXFMV43J;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = CozyReactNative/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -804,6 +805,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.cozy.flagship.mobile;
 				PRODUCT_NAME = CozyReactNative;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "amiral-dev-profile";
 				SWIFT_OBJC_BRIDGING_HEADER = "CozyReactNative-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
I was not able to run the debug build on my real iphone because the profil & cert were not for debug purpose.

So we added a new provisioning profile "amiral-dev-profile". You can add a new device to this profile by going to the developper apple website.

And since we added a profile for dev purpose we needed to create a dev certificat. This certificate is available in the password store 
