### PR TITLE
fix: update immersiveRoutes

### DIFF
--- a/src/components/webviews/jsInteractions/jsCozyInjection.js
+++ b/src/components/webviews/jsInteractions/jsCozyInjection.js
@@ -4,7 +4,8 @@ import { version } from '../../../../package.json'
 
 import { getDimensions } from '/libs/dimensions'
 
-const immersiveRoutes = ['home']
+// This will have the effect of reverting OS icons to white when closing UI modals
+const immersiveRoutes = ['home', 'default']
 
 const makeMetadata = routeName => {
   const { navbarHeight, statusBarHeight } = getDimensions()


### PR DESCRIPTION
This PR addresses an issue with the immersive behavior when closing UI modals in the webview. The change consists of updating the `immersiveRoutes` array in `jsCozyInjection.js` to include both `home` and `default` routes.

The issue was caused by the name of the "home" route being changed to "default". By updating the `immersiveRoutes` array to contain both the old (`home`) and the new (`default`) route names, we ensure that the immersive behavior is maintained for both routes. This fix will revert the Operating System icons to white when closing UI modals, providing a consistent user experience.