### PR TITLE
fix: Resolve setWorkerState only when webview reference is ready

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -20,6 +20,11 @@ const log = Minilog('ReactNativeLauncher')
 
 const SET_WORKER_STATE_TIMEOUT_MS = 30 * 1000
 
+export const ERRORS = {
+  SET_WORKER_STATE_TOO_LONG_TO_INIT:
+    'ReactNativeLauncher.setWorkerState took more than 30000 ms'
+}
+
 Minilog.enable()
 
 function LauncherEvent() {}
@@ -302,7 +307,7 @@ class ReactNativeLauncher extends Launcher {
         resolve()
       })
       timerId = setTimeout(() => {
-        reject('ReactNativeLauncher.setWorkerState took more than 30000 ms')
+        reject(ERRORS.SET_WORKER_STATE_TOO_LONG_TO_INIT)
       }, options?.timeout || SET_WORKER_STATE_TIMEOUT_MS)
     })
   }

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -583,8 +583,7 @@ class ReactNativeLauncher extends Launcher {
    */
   onPilotMessage(event) {
     if (this.pilot) {
-      const messenger = this.pilot.messenger
-      messenger.onMessage.bind(messenger)(event)
+      this.pilot.messenger.onMessage.apply(this.pilot.messenger, [event])
     }
   }
 
@@ -593,8 +592,7 @@ class ReactNativeLauncher extends Launcher {
    */
   onWorkerMessage(event) {
     if (this.worker) {
-      const messenger = this.worker.messenger
-      messenger.onMessage.bind(messenger)(event)
+      this.worker.messenger.onMessage.apply(this.worker.messenger, [event])
     }
   }
 

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -21,7 +21,10 @@ jest.mock('./keychain', () => {
 import CookieManager from '@react-native-cookies/cookies'
 import { waitFor } from '@testing-library/react-native'
 
-import ReactNativeLauncher, { launcherEvent } from './ReactNativeLauncher'
+import ReactNativeLauncher, {
+  launcherEvent,
+  ERRORS
+} from './ReactNativeLauncher'
 import {
   getCookie,
   saveCookie,
@@ -776,7 +779,7 @@ describe('ReactNativeLauncher', () => {
       const { launcher } = setup()
       await expect(() =>
         launcher.setWorkerState({ url: 'https://cozy.io', timeout: 1 })
-      ).rejects.toMatch('ReactNativeLauncher.setWorkerState took more')
+      ).rejects.toEqual(ERRORS.SET_WORKER_STATE_TOO_LONG_TO_INIT)
     })
   })
 })

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -765,4 +765,18 @@ describe('ReactNativeLauncher', () => {
       })
     })
   })
+  describe('setWorkerState', () => {
+    it('should resolve when the webview is ready if reloaded', async () => {
+      const { launcher } = setup()
+      const promise = launcher.setWorkerState({ url: 'https://cozy.io' })
+      launcher.emit('worker:webview:ready')
+      expect(await promise).toBe(undefined)
+    })
+    it('should throw after 30s if not resolved', async () => {
+      const { launcher } = setup()
+      await expect(() =>
+        launcher.setWorkerState({ url: 'https://cozy.io', timeout: 1 })
+      ).rejects.toMatch('ReactNativeLauncher.setWorkerState took more')
+    })
+  })
 })

--- a/src/libs/bridge/ReactNativeLauncherMessenger.js
+++ b/src/libs/bridge/ReactNativeLauncherMessenger.js
@@ -16,7 +16,10 @@ export default class ReactNativeLauncherMessenger extends MessengerInterface {
 
   postMessage(message) {
     if (this.debug) {
-      this.log.debug('➡️ sending message', message)
+      let debugMessage = '➡️  sending message'
+      const { label, rest } = formatIds(message)
+      debugMessage += ' ' + label
+      this.log.debug(debugMessage, rest)
     }
     const script = `window.postMessage(${JSON.stringify(message)})`
     this.webViewRef.injectJavaScript(script)
@@ -38,9 +41,21 @@ export default class ReactNativeLauncherMessenger extends MessengerInterface {
    */
   onMessage(event) {
     const data = JSON.parse(event.nativeEvent.data)
-    if (this.debug) {
-      this.log.debug('⬅️ received message', data)
-    }
     this.listener({ data })
+    if (this.debug) {
+      let debugMessage = '⬅️  received message'
+      const { label, rest } = formatIds(data)
+      debugMessage += ' ' + label
+      this.log.debug(debugMessage, rest)
+    }
   }
+}
+
+function formatIds(message) {
+  const { sessionId, requestId, ...rest } = message
+  let label = 'sessionId=' + sessionId
+  if (requestId) {
+    label += ' requestId=' + requestId
+  }
+  return { label, rest }
 }

--- a/src/libs/konnectors/sendKonnectorsLogs.ts
+++ b/src/libs/konnectors/sendKonnectorsLogs.ts
@@ -17,7 +17,7 @@ export const sendKonnectorsLogs = async (client: CozyClient): Promise<void> => {
 
     const slugs = Object.keys(logs)
     for (const slug of slugs) {
-      log.debug(`Sending ${slug} logs batch`)
+      log.debug(`🐟 Sending ${slug} logs batch : ${logs[slug]?.length} items`)
       // Clean slug property in LogObj
 
       // Locally disable the rule because we delete the slug property with a destructuring assignment

--- a/src/libs/konnectors/sendKonnectorsLogs.ts
+++ b/src/libs/konnectors/sendKonnectorsLogs.ts
@@ -17,7 +17,9 @@ export const sendKonnectorsLogs = async (client: CozyClient): Promise<void> => {
 
     const slugs = Object.keys(logs)
     for (const slug of slugs) {
-      log.debug(`🐟 Sending ${slug} logs batch : ${logs[slug]?.length} items`)
+      log.debug(
+        `🐟 Sending ${slug} logs batch : ${logs[slug]?.length ?? 0} items`
+      )
       // Clean slug property in LogObj
 
       // Locally disable the rule because we delete the slug property with a destructuring assignment

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -170,6 +170,9 @@ class LauncherView extends Component {
         newUrl === this.state.worker.url && newUrl !== this.state.workerInnerUrl
       if (shouldForceWorkerReload) {
         this.setState({ workerKey: Date.now() })
+      } else {
+        // if we don't force worker reload, the reference to the worker webview won't change. Then we can resolve this promise directly.
+        this.launcher.emit('worker:webview:ready')
       }
       this.setState({
         worker: { ...this.state.worker, ...options }
@@ -259,7 +262,10 @@ class LauncherView extends Component {
               <WebView
                 key={this.state.workerKey}
                 mediaPlaybackRequiresUserAction={true}
-                ref={ref => (this.workerWebview = ref)}
+                ref={ref => {
+                  this.workerWebview = ref
+                  this.launcher.emit('worker:webview:ready')
+                }}
                 originWhitelist={['*']}
                 onLoad={this.onWorkerLoad}
                 useWebKit={true}

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -264,7 +264,9 @@ class LauncherView extends Component {
                 mediaPlaybackRequiresUserAction={true}
                 ref={ref => {
                   this.workerWebview = ref
-                  this.launcher.emit('worker:webview:ready')
+                  if (ref !== null) {
+                    this.launcher.emit('worker:webview:ready')
+                  }
                 }}
                 originWhitelist={['*']}
                 onLoad={this.onWorkerLoad}


### PR DESCRIPTION
In some cases, we still had the following message :
"nodeHandle expected to be non-null"

This was a regression after #751
In the case a webview reload was forced :

Ex : when the clisk konnector does :

```javascript
await this.goto(url)
await this.runInWorker('any  command')
```

The goto command resolved when the worker webview was not ready yet and
the launcher did not have a reference to the new webview yet.

Now, the goto command waits for the webview reference to be ready to be
resolved.

Also solve some minor issues I found during the debug

- fix: Resolve setWorkerState only when webview reference is ready
- fix: Do not create a new binded function on each message
- fix: Display the number of logs we try to send to the cozy stack
- feat: Format messenger debug message


#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

