### PR TITLE
feat: Bump app version to 1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.0.11
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+
+
+## 🔧 Tech
+
+
 # 1.0.10
 
 ## ✨ Features
@@ -5,6 +16,8 @@
 
 ## 🐛 Bug Fixes
 
+* Fix a bug that prevented a Connector to be opened from cozy-store ([PR #766](https://github.com/cozy/cozy-react-native/pull/766))
+* Fix a bug that would re-send a new 2FA email every time the user enters the wrong 2FA code on OIDC login ([PR #767](https://github.com/cozy/cozy-react-native/pull/767))
 
 ## 🔧 Tech
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100091
-        versionName "1.0.9"
+        versionCode 100101
+        versionName "1.0.10"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -63,7 +63,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.9</string>
+	<string>1.0.10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -82,7 +82,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100091</string>
+	<string>0100101</string>
   <key>FirebaseDataCollectionDefaultEnabled</key>
   <false/>
 	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.0.10
- creates a new entry for next 1.0.11 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs