### PR TITLE
fix: Resolve goto when the bridge is ready

### DIFF
--- a/src/constants/dev-config.ts
+++ b/src/constants/dev-config.ts
@@ -11,6 +11,7 @@ export const devConfig = {
   forceHideSplashScreen: false, // Hide react-native splash screen renders, useful for debugging in case of a webview crash
   forceOffline: false, // Force offline mode by overwriting the NetInfo module and returning a fake offline state,
   ignoreLogBox: false, // Hide react-native LogBox renders but still display logs to the console,
+  cliskKonnectorDevMode: false, // Do not show HomeView but just a special screen to run clisk konnectors
   forceInstallReferrer: false, // Enforce InstallReferrer with the 'enforcedInstallReferrer' string (strings.ONBOARDING_PARTNER_STORAGE_KEY must be clear to apply this value)
   enforcedInstallReferrer:
     'utm_source=SOME_PARTNER&utm_content=SOME_CONTEXT&utm_campaign=onboarding_partner&anid=admob'

--- a/src/core/tools/dev.ts
+++ b/src/core/tools/dev.ts
@@ -10,7 +10,7 @@ import { hideSplashScreen } from '/libs/services/SplashScreenService'
 export const initDev = async (isDev: boolean): Promise<void> => {
   if (!isDev) return
 
-  if (devConfig.forceHideSplashScreen) await hideSplashScreen()
+  if (hideSplashScreen) await hideSplashScreen()
 
   if (devConfig.forceOffline) {
     NetInfo.fetch = (): Promise<NetInfoState> =>

--- a/src/core/tools/env.ts
+++ b/src/core/tools/env.ts
@@ -52,6 +52,7 @@ try {
 const {
   disableGetIndex,
   enableLocalSentry,
+  cliskKonnectorDevMode,
   enableReduxLogger,
   enforcedInstallReferrer,
   forceInstallReferrer,
@@ -63,6 +64,8 @@ if (enableLocalSentry) toggleLocalSentry(true)
 export const isSentryDebugMode = (): boolean => enableLocalSentry
 
 export const shouldDisableGetIndex = (): boolean => disableGetIndex
+
+export const shouldShowCliskDevMode = (): boolean => cliskKonnectorDevMode
 
 export const shouldForceInstallReferrer = (): boolean => forceInstallReferrer
 export const getEnforcedInstallReferrer = (): string => enforcedInstallReferrer

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -298,7 +298,7 @@ class ReactNativeLauncher extends Launcher {
   setWorkerState(options) {
     return new Promise((resolve, reject) => {
       let timerId = null
-      this.emit('SET_WORKER_STATE', options)
+
       this.once('worker:webview:ready', () => {
         clearTimeout(timerId)
         if (options?.visible === true) {
@@ -309,6 +309,7 @@ class ReactNativeLauncher extends Launcher {
       timerId = setTimeout(() => {
         reject(ERRORS.SET_WORKER_STATE_TOO_LONG_TO_INIT)
       }, options?.timeout || SET_WORKER_STATE_TIMEOUT_MS)
+      this.emit('SET_WORKER_STATE', options)
     })
   }
 
@@ -410,6 +411,7 @@ class ReactNativeLauncher extends Launcher {
       throw new Error(`worker bridge restart init error: ${err.message}`)
     }
     this.emit('WORKER_RELOADED')
+    this.emit('worker:webview:ready')
   }
 
   /**

--- a/src/libs/bridge/ReactNativeLauncherMessenger.js
+++ b/src/libs/bridge/ReactNativeLauncherMessenger.js
@@ -60,7 +60,7 @@ function formatIds(message) {
   // eslint-disable-next-line no-unused-vars
   const { sessionId, requestId, type, ...rest } = message
   let label = 'sessionId=' + sessionId
-  if (requestId) {
+  if (requestId !== undefined) {
     label += ' requestId=' + requestId
   }
   return { label, rest }

--- a/src/libs/bridge/ReactNativeLauncherMessenger.js
+++ b/src/libs/bridge/ReactNativeLauncherMessenger.js
@@ -41,8 +41,13 @@ export default class ReactNativeLauncherMessenger extends MessengerInterface {
    */
   onMessage(event) {
     const data = JSON.parse(event.nativeEvent.data)
-    this.listener({ data })
-    if (this.debug && data.type === '@post-me') {
+    if (this.listener) {
+      // in scenarios where we watch the flagship app with hot reload I found this.listener to be null sometimes.
+      // As addMessageListener is directly called by post-me, I don't know why, it may be null but this avoids some headaches
+      // when developing on flagship app.
+      this.listener({ data })
+    }
+    if (this.debug && data.type === '@post-me' && data.eventName !== 'log') {
       let debugMessage = '⬅️  received message'
       const { label, rest } = formatIds(data)
       debugMessage += ' ' + label

--- a/src/libs/bridge/ReactNativeLauncherMessenger.js
+++ b/src/libs/bridge/ReactNativeLauncherMessenger.js
@@ -19,7 +19,11 @@ export default class ReactNativeLauncherMessenger extends MessengerInterface {
       let debugMessage = '➡️  sending message'
       const { label, rest } = formatIds(message)
       debugMessage += ' ' + label
-      this.log.debug(debugMessage, rest)
+      if (rest.action === 'handshake-request') {
+        this.log.debug(label, 'handshake request 👊')
+      } else {
+        this.log.debug(debugMessage, rest)
+      }
     }
     const script = `window.postMessage(${JSON.stringify(message)})`
     this.webViewRef.injectJavaScript(script)
@@ -51,7 +55,11 @@ export default class ReactNativeLauncherMessenger extends MessengerInterface {
       let debugMessage = '⬅️  received message'
       const { label, rest } = formatIds(data)
       debugMessage += ' ' + label
-      this.log.debug(debugMessage, rest)
+      if (rest.action === 'handshake-response') {
+        this.log.debug(label, 'handshake response 👊 ✅')
+      } else {
+        this.log.debug(debugMessage, rest)
+      }
     }
   }
 }

--- a/src/libs/bridge/ReactNativeLauncherMessenger.js
+++ b/src/libs/bridge/ReactNativeLauncherMessenger.js
@@ -15,7 +15,7 @@ export default class ReactNativeLauncherMessenger extends MessengerInterface {
   }
 
   postMessage(message) {
-    if (this.debug) {
+    if (this.debug && message.type === '@post-me') {
       let debugMessage = '➡️  sending message'
       const { label, rest } = formatIds(message)
       debugMessage += ' ' + label
@@ -42,7 +42,7 @@ export default class ReactNativeLauncherMessenger extends MessengerInterface {
   onMessage(event) {
     const data = JSON.parse(event.nativeEvent.data)
     this.listener({ data })
-    if (this.debug) {
+    if (this.debug && data.type === '@post-me') {
       let debugMessage = '⬅️  received message'
       const { label, rest } = formatIds(data)
       debugMessage += ' ' + label
@@ -52,7 +52,8 @@ export default class ReactNativeLauncherMessenger extends MessengerInterface {
 }
 
 function formatIds(message) {
-  const { sessionId, requestId, ...rest } = message
+  // eslint-disable-next-line no-unused-vars
+  const { sessionId, requestId, type, ...rest } = message
   let label = 'sessionId=' + sessionId
   if (requestId) {
     label += ' requestId=' + requestId

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -8,8 +8,10 @@ import { StatusBar, View } from 'react-native'
 
 import HomeView from '/screens/home/components/HomeView'
 import LauncherView from '/screens/konnectors/LauncherView'
+import CliskDevView from '/screens/konnectors/CliskDevView'
 import { StatusBarStyle } from '/libs/intents/setFlagshipUI'
 import { useLauncherContext } from '/screens/home/hooks/useLauncherContext'
+import { shouldShowCliskDevMode } from '/core/tools/env'
 
 import { styles } from '/screens/home/HomeScreen.styles'
 
@@ -39,12 +41,16 @@ export const HomeScreen = ({
     <View style={styles.container}>
       <StatusBar barStyle={barStyle} />
 
-      <HomeView
-        navigation={navigation}
-        route={route}
-        setBarStyle={setBarStyle}
-        setLauncherContext={trySetLauncherContext}
-      />
+      {shouldShowCliskDevMode() ? (
+        <CliskDevView setLauncherContext={trySetLauncherContext} />
+      ) : (
+        <HomeView
+          navigation={navigation}
+          route={route}
+          setBarStyle={setBarStyle}
+          setLauncherContext={trySetLauncherContext}
+        />
+      )}
 
       {canDisplayLauncher() && (
         <LauncherView

--- a/src/screens/konnectors/CliskDevView.jsx
+++ b/src/screens/konnectors/CliskDevView.jsx
@@ -8,52 +8,70 @@ const CliskDevView = ({ setLauncherContext }) => {
   const client = useClient()
 
   const [triggers, setTriggers] = useState([])
+  const [konnectors, setKonnectors] = useState([])
   const [selected, setSelected] = useState(null)
 
   const handleRun = async () => {
-    const triggerId = selected
-    const { data: trigger } = await client.query(
-      Q('io.cozy.triggers').getById(triggerId)
-    )
-    const slug = trigger?.message?.konnector
-    const { data: konnector } = await client.query(
-      Q('io.cozy.konnectors').getById('io.cozy.konnectors/' + slug)
-    )
-    const accountId = trigger?.message?.account
-    const { data: account } = await client.query(
-      Q('io.cozy.accounts').getById(accountId)
-    )
+    if (selected?._type === 'io.cozy.triggers') {
+      const triggerId = selected._id
+      const { data: trigger } = await client.query(
+        Q('io.cozy.triggers').getById(triggerId)
+      )
+      const slug = trigger?.message?.konnector
+      const { data: konnector } = await client.query(
+        Q('io.cozy.konnectors').getById('io.cozy.konnectors/' + slug)
+      )
+      const accountId = trigger?.message?.account
+      const { data: account } = await client.query(
+        Q('io.cozy.accounts').getById(accountId)
+      )
 
-    setLauncherContext({
-      state: 'launch',
-      value: { konnector, account, trigger: triggers[0], DEBUG: true }
-    })
+      setLauncherContext({
+        state: 'launch',
+        value: { konnector, account, trigger: triggers[0], DEBUG: true }
+      })
+    } else if (selected?._type === 'io.cozy.konnectors') {
+      setLauncherContext({
+        state: 'launch',
+        value: { konnector: selected, DEBUG: true }
+      })
+    }
   }
 
   useEffect(() => {
     const doEffect = async () => {
-      const { data } = await client.query(
+      const { data: clientTriggers } = await client.query(
         Q('io.cozy.triggers').where({
           type: '@client'
         })
       )
+      const triggerSlugs = clientTriggers.map(t => t.message.konnector)
+      const { data: clientKonnectors } = await client.query(
+        Q('io.cozy.konnectors').where({
+          clientSide: true
+        })
+      )
+      const filteredKonnectors = clientKonnectors.filter(
+        k => !triggerSlugs.includes(k.slug)
+      )
 
-      return data
+      return { clientTriggers, clientKonnectors: filteredKonnectors }
     }
     doEffect()
-      .then(data => {
-        return setTriggers(data)
+      .then(({ clientTriggers, clientKonnectors }) => {
+        setKonnectors(clientKonnectors)
+        return setTriggers(clientTriggers)
       })
       .catch(err => {
         console.error('doEffect error : ', err.message)
       })
   }, [client])
 
-  const Item = ({ trigger }) => {
-    const fontWeight = trigger._id === selected ? '800' : '400'
+  const TriggerItem = ({ trigger }) => {
+    const fontWeight = trigger._id === selected?._id ? '800' : '400'
     return (
       <TouchableOpacity
-        onPress={() => setSelected(trigger._id)}
+        onPress={() => setSelected(trigger)}
         style={{ padding: 10 }}
       >
         <Text style={{ fontSize: 20, fontWeight }}>
@@ -65,13 +83,31 @@ const CliskDevView = ({ setLauncherContext }) => {
     )
   }
 
-  // todo lancer l'item sé
+  const KonnectorItem = ({ konnector }) => {
+    const fontWeight = konnector._id === selected?._id ? '800' : '400'
+    return (
+      <TouchableOpacity
+        onPress={() => setSelected(konnector)}
+        style={{ padding: 10 }}
+      >
+        <Text style={{ fontSize: 20, fontWeight }}>
+          {konnector.slug + ': create'}
+        </Text>
+      </TouchableOpacity>
+    )
+  }
 
   return (
     <View style={{ padding: 20, backGroundColor: '#6e3b6e' }}>
       <FlatList
         data={triggers}
-        renderItem={({ item }) => <Item trigger={item} key={item._id} />}
+        renderItem={({ item }) => <TriggerItem trigger={item} key={item._id} />}
+      ></FlatList>
+      <FlatList
+        data={konnectors}
+        renderItem={({ item }) => (
+          <KonnectorItem konnector={item} key={item._id} />
+        )}
       ></FlatList>
       <Button title="run" onPress={handleRun} />
     </View>

--- a/src/screens/konnectors/CliskDevView.jsx
+++ b/src/screens/konnectors/CliskDevView.jsx
@@ -1,0 +1,56 @@
+/* eslint-disable no-console */
+import React, { useState } from 'react'
+import { Button, TextInput, View } from 'react-native'
+
+import { useClient, Q } from 'cozy-client'
+
+const CliskDevView = ({ setLauncherContext }) => {
+  const client = useClient()
+
+  const [slug, setSlug] = useState('')
+  const [accountId, setAccountId] = useState('')
+
+  const handleRun = async () => {
+    const { data: konnector } = await client.query(
+      Q('io.cozy.konnectors').getById('io.cozy.konnectors/' + slug)
+    )
+    const { data: account } = await client.query(
+      Q('io.cozy.accounts').getById(accountId)
+    )
+    const { data: triggers } = await client.query(
+      Q('io.cozy.triggers')
+        .where({
+          'message.account': accountId
+        })
+        .indexFields(['message.account'])
+    )
+
+    if (!konnector) return console.error('no konnector associated to ', slug)
+    if (!account) return console.error('no account associated to ', accountId)
+    if (!triggers || !triggers[0])
+      return console.error('no trigger associated to ', accountId)
+
+    setLauncherContext({
+      state: 'launch',
+      value: { konnector, account, trigger: triggers[0], DEBUG: true },
+    })
+  }
+
+  return (
+    <View style={{ padding: 20 }}>
+      <TextInput
+        style={{ fontSize: 30 }}
+        placeholder="slug"
+        onChangeText={setSlug}
+      />
+      <TextInput
+        placeholder="account id"
+        style={{ fontSize: 30 }}
+        onChangeText={setAccountId}
+      />
+      <Button title="run" onPress={handleRun} />
+    </View>
+  )
+}
+
+export default CliskDevView

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -267,9 +267,6 @@ class LauncherView extends Component {
                 mediaPlaybackRequiresUserAction={true}
                 ref={ref => {
                   this.workerWebview = ref
-                  if (ref !== null) {
-                    this.launcher.emit('worker:webview:ready')
-                  }
                 }}
                 originWhitelist={['*']}
                 onLoad={this.onWorkerLoad}

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -32,8 +32,6 @@ const log = Minilog('LauncherView')
 const colors = getColors()
 const { statusBarHeight } = getDimensions()
 
-const DEBUG = false
-
 class LauncherView extends Component {
   constructor(props) {
     super(props)
@@ -54,6 +52,7 @@ class LauncherView extends Component {
       worker: {},
       workerKey: 0
     }
+    this.DEBUG = false
   }
 
   /**
@@ -100,6 +99,8 @@ class LauncherView extends Component {
    */
   async initKonnector() {
     const { client, launcherContext } = this.props
+    const { DEBUG = false } = launcherContext
+    this.DEBUG = DEBUG
     const slug = launcherContext.konnector.slug
 
     try {
@@ -197,7 +198,9 @@ class LauncherView extends Component {
 
     stopTimeout()
 
-    this.props.setLauncherContext({ state: 'default' })
+    // in DEBUG mode, do not hide the worker in the end of the konnector execution
+    // this allows to make it easier to try pilot commands in web inspector
+    if (!this.DEBUG) this.props.setLauncherContext({ state: 'default' })
   }
 
   componentWillUnmount() {
@@ -211,7 +214,7 @@ class LauncherView extends Component {
 
   render() {
     const workerStyle =
-      this.state.worker.visible || DEBUG
+      this.state.worker.visible || this.DEBUG
         ? styles.workerVisible
         : styles.workerHidden
 


### PR DESCRIPTION
Before we resolved the goto when the webview was reload but but it fails
when running goto twice in a row for example (and also in other cases on
slow devices).

Also added some enhancements on post-me logs display
- feat: Do not log non post-me messages in messenger
- fix: Call the listener when non null
- fix: Show requestId even when = 0
- feat: Better display of handshake logs
- feat: Hide log events

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

