### PR TITLE
fix: Show a loading screen after opening a MagicLink

### DIFF
--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -113,6 +113,11 @@ const LoginSteps = ({
         backgroundColor: colors.primaryColor
       })
 
+      setState(oldState => ({
+        ...oldState,
+        step: LOADING_STEP
+      }))
+
       if (magicCode) {
         startMagicLinkOAuth(instanceData.fqdn, magicCode)
       } else {


### PR DESCRIPTION
When login by MagicLink, the user receives an email

When the email's link is clicked, then the user is redirected to the Flagship app and then the login starts

During this phase, the App will do the login HTTP requests in background and then redirect the user to the home screen (or 2FA screen if needed)

During this phase the user will see the welcome screen (or sometimes the post code screen) until all login HTTP requests are done

Instead of this we want the user to see a loading screen