### PR TITLE
feat: Bump app version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.11
+# 1.1.1
 
 ## ✨ Features
 
@@ -8,6 +8,22 @@
 
 ## 🔧 Tech
 
+
+# 1.1.0
+
+## ✨ Features
+
+* Improve login and onboarding screens theming capabilities for our partners ([PR #776](https://github.com/cozy/cozy-react-native/pull/776))
+* Logout locally configured Client Side Connectors when they are removed from another device ([PR #748](https://github.com/cozy/cozy-react-native/pull/748))
+
+## 🐛 Bug Fixes
+
+* Fix some scenario where the status bar was not displayed with the correct color ([PR #775](https://github.com/cozy/cozy-react-native/pull/775))
+
+## 🔧 Tech
+
+* Change OS icon for `mespapiers` app ([PR #778](https://github.com/cozy/cozy-react-native/pull/778))
+* Remove UINewsstandIcon from Info.plist ([PR #780](https://github.com/cozy/cozy-react-native/pull/780))
 
 # 1.0.10
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100101
-        versionName "1.0.10"
+        versionCode 101000
+        versionName "1.1.0"
         multiDexEnabled true
     }
     splits {

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -56,7 +56,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.10</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -75,7 +75,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0100101</string>
+	<string>0101001</string>
 	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
 	<true/>
 	<key>FirebaseDataCollectionDefaultEnabled</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR

- updates the App version to 1.1.0
- creates a new entry for next 1.1.1 release in the CHANGELOG
- improves the changelog by adding missing entries from previous days and add link to related PRs