### PR TITLE
fix: Use `trim()` on `tryProcessClouderyThemeMessage`

### DIFF
--- a/src/screens/login/components/CozyLogoScreen.tsx
+++ b/src/screens/login/components/CozyLogoScreen.tsx
@@ -1,9 +1,13 @@
+import Minilog from '@cozy/minilog'
 import React, { useEffect, useState } from 'react'
 import { StyleSheet, View } from 'react-native'
 import { SvgXml } from 'react-native-svg'
 
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
 import { isLightBackground } from '/screens/login/components/functions/clouderyBackgroundFetcher'
 import { getColors } from '/ui/colors'
+
+const log = Minilog('CozyLogoScreen')
 
 const colors = getColors()
 
@@ -19,13 +23,20 @@ export const CozyLogoScreen = ({
   )
 
   useEffect(() => {
-    const shouldUsePrimaryColor = isLightBackground(backgroundColor)
+    try {
+      const shouldUsePrimaryColor = isLightBackground(backgroundColor)
 
-    const color = shouldUsePrimaryColor
-      ? colors.primaryColor
-      : colors.paperBackgroundColor
+      const color = shouldUsePrimaryColor
+        ? colors.primaryColor
+        : colors.paperBackgroundColor
 
-    setForegroundColor(color)
+      setForegroundColor(color)
+    } catch (error) {
+      const errorMessage = getErrorMessage(error)
+      log.error(
+        `Something went wrong while trying to check if isLightBackground: ${errorMessage}`
+      )
+    }
   }, [backgroundColor])
 
   return (

--- a/src/screens/login/components/functions/clouderyThemeFetcher.ts
+++ b/src/screens/login/components/functions/clouderyThemeFetcher.ts
@@ -38,7 +38,7 @@ export const tryProcessClouderyThemeMessage = (
   if (message.message === 'setTheme' && message.color !== undefined) {
     setTheme({
       themeUrl: message.url,
-      backgroundColor: message.color
+      backgroundColor: message.color.trim()
     })
   }
 }

--- a/src/screens/login/components/transitions/TransitionToPasswordView.js
+++ b/src/screens/login/components/transitions/TransitionToPasswordView.js
@@ -1,14 +1,16 @@
+import Minilog from '@cozy/minilog'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Animated, Dimensions, Easing, StyleSheet, View } from 'react-native'
-
-import log from 'cozy-logger'
 
 import { getDimensions } from '/libs/dimensions'
 
 import { CozyIcon } from './transitions-icons/CozyIcon'
 
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
 import { isLightBackground } from '/screens/login/components/functions/clouderyBackgroundFetcher'
 import { getColors } from '/ui/colors'
+
+const log = Minilog('TransitionToPasswordView')
 
 const webViewTopToNativeTop = top => top + getDimensions().statusBarHeight
 
@@ -65,13 +67,20 @@ export const TransitionToPasswordView = ({
   ])
 
   useEffect(() => {
-    const shouldUsePrimaryColor = isLightBackground(backgroundColor)
+    try {
+      const shouldUsePrimaryColor = isLightBackground(backgroundColor)
 
-    const color = shouldUsePrimaryColor
-      ? colors.primaryColor
-      : colors.paperBackgroundColor
+      const color = shouldUsePrimaryColor
+        ? colors.primaryColor
+        : colors.paperBackgroundColor
 
-    setForegroundColor(color)
+      setForegroundColor(color)
+    } catch (error) {
+      const errorMessage = getErrorMessage(error)
+      log.error(
+        `Something went wrong while trying to check if isLightBackground: ${errorMessage}`
+      )
+    }
   }, [backgroundColor])
 
   const transitionToFinal = useCallback(


### PR DESCRIPTION
In some environments `getComputedStyle().getPropertyValue()` would return a result with a leading space

In this scenario we retrieve ` normal` instead of `normal`

So we want to `trim()` the result

Note that `getComputedStyle().getPropertyValue()` always return a string even if the property does not exist. In that cas the string is empty. So we don't need to check for nullity

We lost this security on feature rework when fetching Theme instead of Background