### PR TITLE
fix: Saving and getting credentials

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -125,14 +125,15 @@ export default class Launcher {
    * @returns {Promise<void>}
    */
   async saveCredentials(credentials) {
-    const { konnector, client } = this.getStartContext()
+    const { konnector, client, account } = this.getStartContext()
     const existingCredentials = await this.getCredentials()
     if (existingCredentials) {
       await this.removeCredentials()
     }
     const result = {
       version: 1,
-      createdByAppVersion: getVersion() + '-' + (await getBuildId()), // récupérer build number de l'app amirale
+      _id: account._id,
+      createdByAppVersion: getVersion() + '-' + (await getBuildId()),
       createdAt: new Date().toJSON(),
       slug: konnector.slug,
       credentials
@@ -188,7 +189,7 @@ export default class Launcher {
     )
     let didRemoveAccountCredential = false
     for (const accountId of accountIds) {
-      if (!existingAccountIds.includes(accountIds)) {
+      if (!existingAccountIds.includes(accountId)) {
         await removeCredential(fqdn, { _id: accountId })
         didRemoveAccountCredential = true
       }

--- a/src/libs/Launcher.spec.js
+++ b/src/libs/Launcher.spec.js
@@ -45,6 +45,9 @@ describe('Launcher', () => {
     it('should save credentials with proper attributes', async () => {
       const launcher = new Launcher()
       const konnector = { slug: 'testkonnectorslug' }
+      const account = {
+        _id: 'testaccountid'
+      }
       const client = {
         getStackClient: () => ({
           uri: 'http://cozy.localhost:8080'
@@ -52,7 +55,8 @@ describe('Launcher', () => {
       }
       launcher.setStartContext({
         konnector,
-        client
+        client,
+        account
       })
       await launcher.saveCredentials({
         login: 'testlogin',
@@ -61,6 +65,7 @@ describe('Launcher', () => {
       expect(saveCredential).toHaveBeenCalledWith(
         'cozy.localhost_8080',
         expect.objectContaining({
+          _id: 'testaccountid',
           credentials: {
             login: 'testlogin',
             password: 'testpassword'
@@ -80,15 +85,12 @@ describe('Launcher', () => {
           uri: 'http://cozy.localhost:8080'
         }),
         query: jest.fn().mockResolvedValueOnce({
-          data: [
-            { _id: 'testaccountid1' },
-            { _id: 'testaccountid2' },
-            { _id: 'testaccountid3' }
-          ]
+          data: [{ _id: 'testaccountid1' }, { _id: 'testaccountid3' }]
         })
       }
       getSlugAccountIds.mockResolvedValueOnce([
         'testaccountid1',
+        'testaccountid2',
         'testaccountid3'
       ])
       launcher.setStartContext({
@@ -104,7 +106,9 @@ describe('Launcher', () => {
         'testslug1'
       )
       expect(client.query).toHaveBeenCalledWith(
-        expect.objectContaining({ ids: ['testaccountid1', 'testaccountid3'] })
+        expect.objectContaining({
+          ids: ['testaccountid1', 'testaccountid2', 'testaccountid3']
+        })
       )
     })
     it('should return false if nothing was cleaned', async () => {


### PR DESCRIPTION
Credentials were always removed before running the clisk konnectors


2 problems fixed :

- The id of the account was not saved in the credentials
- Typo in the check of existence of account + wrong linked unit test



#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

