### PR TITLE
fix: Target `<main>` instead of `<body>` for WebViews paddings injection

### DIFF
--- a/src/components/makeHTML.js
+++ b/src/components/makeHTML.js
@@ -23,8 +23,8 @@ const makeDOM = ({ body, isInverted }) => {
       <style type="text/css">${cirrusCss}</style>
     </head>
 
-    <body class="${theme}" style="padding-top: ${statusBarHeight}px; padding-bottom: ${navbarHeight}px;">
-      <main class="wrapper">
+    <body class="${theme}">
+      <main class="wrapper" style="padding-top: ${statusBarHeight}px; padding-bottom: ${navbarHeight}px;">
         ${body}
       </main>
     </body>

--- a/src/screens/login/components/functions/webViewPaddingInjection.ts
+++ b/src/screens/login/components/functions/webViewPaddingInjection.ts
@@ -4,15 +4,15 @@ const dimensions = getDimensions()
 
 export const jsPaddingInjection = `
   window.addEventListener("load", function(event) {
-    const body = document.getElementsByTagName('body')[0];
-    body.style.paddingTop = '${dimensions.statusBarHeight}px';
-    body.style.paddingBottom = '${dimensions.navbarHeight}px';
+    const main = document.getElementsByTagName('main')[0];
+    main.style.paddingTop = '${dimensions.statusBarHeight}px';
+    main.style.paddingBottom = '${dimensions.navbarHeight}px';
   });
 `
 
 export const cssPadding = `
-  body {
-    padding-top: ${dimensions.statusBarHeight}px;
-    padding-bottom: ${dimensions.navbarHeight}px;
+  main {
+    padding-top: ${dimensions.statusBarHeight}px !important;
+    padding-bottom: ${dimensions.navbarHeight}px !important;
   }
 `


### PR DESCRIPTION
If we apply a padding to `<body>`, the padding will be applied only if the screen's content is smaller than the screen's size

When the content takes nearly the same size as the screen, then the padding would disappear and UI would exceed the screen's safe area without any scroll bar displayed (which is the problem we initially tried to resolve)

When the content is longer than the screen's size, then the scroll bar appears, but when scrolling to the bottom then the UI would still be outside of the safe area

To prevent this, we can target the `<main>` container instead. By chance this container is present on all our Cloudery screens. But in some case it already contains a CSS class that targets paddings (i.e the 2FA view), so we want to enforce the safe area padding

