### PR TITLE
feat: Allow to inject credentials in the flagship app

### DIFF
--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -3,6 +3,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
 
 import CozyClient from 'cozy-client'
+// @ts-ignore
+import flag from 'cozy-flags'
 
 import { normalizeFqdn } from './functions/stringHelpers'
 
@@ -58,6 +60,10 @@ export const getClient = async () => {
     uri,
     token
   })
+
+  await client.registerPlugin(flag.plugin)
+  await client.plugins.flags.initializing
+
   return client
 }
 

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -136,6 +136,16 @@ class LauncherView extends Component {
       })
       return new Error('UNKNOWN_ERROR.HANDSHAKE_FAILED')
     }
+
+    try {
+      await this.launcher.injectCredentials()
+    } catch (err) {
+      this.launcher.log({
+        level: 'error',
+        msg: 'launcherView.initKonnector.injectCredentials: ' + err.message
+      })
+      return new Error('UNKNOWN_ERROR.INJECT_CREDENTIALS')
+    }
   }
 
   async componentDidUpdate() {


### PR DESCRIPTION
The injection of credentials is needed when you want to test the
execution of a clisk konnector with an unauthenticated webview but with
saved credentials easily without having to wait for the end of website
session.

To do that you need to:

  - set the flag test.flagship.clisk.credentials.injecter to true
  - import the credentials in the doctype io.cozy.test.credentials with
  the following form :

```javascript
{
  "_id": "edf", // the slug of the targetted clisk konnector,
  "value": {
    "login": "login to import",
    "password": "password to import"
  }
}
```

Thi this setup, in the next run, the konnector will have the following
credentials available :

```javascript
{
  "login": "login to import",
  "password": "password to import"
}
```

When injected, the credentials will be removed from the database.

_Please explain what this PR does here._

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

