### PR TITLE
fix: Force konnector log messages as string

### DIFF
--- a/src/redux/KonnectorState/KonnectorLogsSlice.ts
+++ b/src/redux/KonnectorState/KonnectorLogsSlice.ts
@@ -29,10 +29,15 @@ export const konnectorLogsSlice = createSlice({
   initialState,
   reducers: {
     addLog: (state, action: PayloadAction<LogObj>) => {
-      if (state.logs[action.payload.slug] === undefined) {
-        state.logs[action.payload.slug] = []
+      const log = { ...action.payload }
+      if (state.logs[log.slug] === undefined) {
+        state.logs[log.slug] = []
       }
-      state.logs[action.payload.slug]?.push(action.payload)
+      if (typeof log.msg !== 'string') {
+        log.msg = JSON.stringify(log.msg)
+      }
+
+      state.logs[log.slug]?.push(log)
     },
     removeLogs: (state, action: PayloadAction<removeLogInfo>) => {
       const result = state.logs[action.payload.slug]?.slice(


### PR DESCRIPTION
Since the stack expects them to be strings.
    
Or else when for example you log an int in a clisk konnector,
No logs will be sent to the stack anymore and the logs stored in the
flagship app will grow indefinitely.


#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

