### PR TITLE
feat: scanDocument return last scan instead of first

### DIFF
--- a/src/app/domain/scanner/services/scanner.ts
+++ b/src/app/domain/scanner/services/scanner.ts
@@ -12,7 +12,11 @@ export const scanDocument = async (): Promise<Base64 | undefined> => {
       maxNumDocuments: 1
     })
 
-    return scannedImages?.[0]
+    if (scannedImages) {
+      return scannedImages[scannedImages.length - 1]
+    } else {
+      return undefined
+    }
   } catch {
     return undefined
   }


### PR DESCRIPTION
On iOS, we can not limit the number of scan and we prefer choosing the last one instead of the first one.