### PR TITLE
fix: add hideSplashScreen fallbacks

### DIFF
--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -53,3 +53,8 @@ jest.mock('@react-native-cookies/cookies', () => {
     get: jest.fn()
   }
 })
+
+jest.mock('react-native-bootsplash', () => ({
+  hide: jest.fn(),
+  show: jest.fn()
+}))

--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -27,7 +27,6 @@ import { safePromise } from '/utils/safePromise'
 import { navigateToApp } from '/libs/functions/openApp'
 
 // Can use mock functions in dev environment
-// async (): Promise<boolean> => Promise.resolve(false)
 const fns = getDevModeFunctions(
   {
     isDeviceSecured,
@@ -35,9 +34,9 @@ const fns = getDevModeFunctions(
     hasDefinedPassword
   },
   {
-    isDeviceSecured: undefined,
-    isAutoLockEnabled: undefined,
-    hasDefinedPassword: undefined
+    isDeviceSecured: undefined, // async (): Promise<boolean> => Promise.resolve(false),
+    isAutoLockEnabled: undefined, // async (): Promise<boolean> => Promise.resolve(false),
+    hasDefinedPassword: undefined // async (): Promise<boolean> => Promise.resolve(false)
   }
 )
 
@@ -128,7 +127,7 @@ export const savePinCode = async (
   }
 }
 
-export const startPinCode = async (): Promise<void> => {
+export const doPinCodeAutoLock = async (): Promise<void> => {
   try {
     const autoLockStatus = await ensureAutoLockIsEnabled()
     devlog('🔓', `AutoLock status is ${String(autoLockStatus)}`)
@@ -145,6 +144,7 @@ async function safeSetKeysAsync(
     devlog('🔓', 'Saving password', keys)
 
     await savePassword(client, keys)
+
     navigate(routes.promptPin)
   } catch (error) {
     devlog('🔓', 'Error saving password')

--- a/src/app/view/Lock/useLockScreen.ts
+++ b/src/app/view/Lock/useLockScreen.ts
@@ -8,8 +8,9 @@ import { LockScreenProps, LockViewProps } from '/app/view/Lock/LockScreenTypes'
 import { getData, StorageKeys } from '/libs/localStore/storage'
 import { getInstanceAndFqdnFromClient } from '/libs/client'
 import { getVaultInformation } from '/libs/keychain'
-import { reset } from '/libs/RootNavigation'
+import { hideSplashScreen } from '/libs/services/SplashScreenService'
 import { openForgotPasswordLink } from '/libs/functions/openForgotPasswordLink'
+import { reset } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
 import { translation } from '/locales'
 import {
@@ -110,6 +111,13 @@ export const useLockScreenProps = (props: LockScreenProps): LockViewProps => {
         ))(),
     [biometryEnabled]
   )
+
+  // The HomeView should have called hideSplashScreen() already,
+  // but in case it didn't, we do it here as a fallback as it is critical.
+  // We're using it last because might as well wait for the other hooks to be done.
+  useEffect(() => {
+    void hideSplashScreen()
+  }, [])
 
   const handleInput = (text: string): void => {
     resetError()

--- a/src/app/view/Secure/PinPrompt.tsx
+++ b/src/app/view/Secure/PinPrompt.tsx
@@ -1,9 +1,8 @@
 import { RouteProp } from '@react-navigation/native'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { PromptingPage } from '/components/templates/PromptingPage'
 import { translation } from '/locales'
-import { startPinCode } from '/app/domain/authorization/services/SecurityService'
 import { usePinPrompt } from '/app/view/Secure/hooks/usePinPrompt'
 
 type RootStackParamList = Record<string, undefined | { onSuccess: () => void }>
@@ -16,10 +15,6 @@ export const PinPrompt = (props: PinPromptProps): JSX.Element => {
   const { handleSetPinCode, handleIgnorePinCode } = usePinPrompt(
     props.route.params?.onSuccess
   )
-
-  useEffect(() => {
-    void startPinCode()
-  }, [])
 
   return (
     <PromptingPage

--- a/src/app/view/Secure/SetPinView.spec.tsx
+++ b/src/app/view/Secure/SetPinView.spec.tsx
@@ -5,7 +5,7 @@ import { SetPinView } from '/app/view/Secure/SetPinView'
 
 jest.mock('/app/domain/authorization/services/SecurityService', () => ({
   savePinCode: jest.fn(),
-  startPinCode: jest.fn()
+  doPinCodeAutoLock: jest.fn()
 }))
 
 jest.mock('/locales', () => ({

--- a/src/app/view/Secure/hooks/usePasswordPrompt.ts
+++ b/src/app/view/Secure/hooks/usePasswordPrompt.ts
@@ -1,8 +1,17 @@
+import { useEffect } from 'react'
+
 import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
 import { devlog } from '/core/tools/env'
+import { hideSplashScreen } from '/libs/services/SplashScreenService'
 
 export const usePasswordPrompt = (onSuccess: () => void): (() => void) => {
+  // The HomeView should have called hideSplashScreen() already,
+  // but in case it didn't, we do it here as a fallback as it is critical
+  useEffect(() => {
+    void hideSplashScreen()
+  }, [])
+
   const handleSetPassword = (): void => {
     try {
       // It should be impossible according to the typings for onSuccess to be undefined,


### PR DESCRIPTION
Calling hideSplashScreen everywhere since it seems the HomeView fails to do it in some unknown scenarios.

Not a good long-term solution, but we need it now. Especially as it can't create side effects even if the home view hides the splash screen.

Some additional minor refactor/improvements that do not touch user/data flow have been added 