### PR TITLE
fix: Remove flickering between onboarding and secure prompt

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -12,6 +12,7 @@ import CliskDevView from '/screens/konnectors/CliskDevView'
 import { StatusBarStyle } from '/libs/intents/setFlagshipUI'
 import { useLauncherContext } from '/screens/home/hooks/useLauncherContext'
 import { shouldShowCliskDevMode } from '/core/tools/env'
+import { getColors } from '/ui/colors'
 
 import { styles } from '/screens/home/HomeScreen.styles'
 
@@ -36,9 +37,17 @@ export const HomeScreen = ({
     setLauncherContext,
     trySetLauncherContext
   } = useLauncherContext()
+  const colors = getColors()
 
   return (
-    <View style={styles.container}>
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.primaryColor
+        }
+      ]}
+    >
       <StatusBar barStyle={barStyle} />
 
       {shouldShowCliskDevMode() ? (

--- a/src/screens/login/OnboardingScreen.js
+++ b/src/screens/login/OnboardingScreen.js
@@ -13,6 +13,7 @@ import {
 import { resetKeychainAndSaveLoginData } from '/libs/functions/passwordHelpers'
 import { consumeRouteParameter } from '/libs/functions/routeHelpers'
 import { routes } from '/constants/routes'
+import { useSplashScreen } from '/hooks/useSplashScreen'
 import { getColors } from '/ui/colors'
 import { CozyLogoScreen } from '/screens/login/components/CozyLogoScreen'
 import { setStatusBarColorToMatchBackground } from '/screens/login/components/functions/clouderyBackgroundFetcher'
@@ -38,6 +39,7 @@ const OnboardingSteps = ({
   setClouderyTheme,
   setClient
 }) => {
+  const { showSplashScreen } = useSplashScreen()
   const [state, setState] = useState({
     step: LOADING_STEP
   })
@@ -177,6 +179,7 @@ const OnboardingSteps = ({
         registerToken
       })
 
+      showSplashScreen()
       await resetKeychainAndSaveLoginData(loginData)
       setClient(client)
     } catch (error) {
@@ -186,7 +189,7 @@ const OnboardingSteps = ({
         setError(error.message, error)
       }
     }
-  }, [setClient, setError, state, cancelOnboarding])
+  }, [setClient, setError, state, cancelOnboarding, showSplashScreen])
 
   const startMagicLinkOAuth = useCallback(async () => {
     try {
@@ -197,6 +200,7 @@ const OnboardingSteps = ({
         magicCode
       })
 
+      showSplashScreen()
       setClient(client)
     } catch (error) {
       if (error === OAUTH_USER_CANCELED_ERROR) {
@@ -205,7 +209,7 @@ const OnboardingSteps = ({
         setError(error.message, error)
       }
     }
-  }, [setClient, setError, state, cancelOnboarding])
+  }, [setClient, setError, state, cancelOnboarding, showSplashScreen])
 
   if (state.step === PASSWORD_STEP) {
     const { fqdn, instance } = state.onboardingData

--- a/src/screens/login/OnboardingScreen.js
+++ b/src/screens/login/OnboardingScreen.js
@@ -70,6 +70,11 @@ const OnboardingSteps = ({
     if (fqdn) {
       const instanceData = getInstanceDataFromFqdn(fqdn)
 
+      setState(oldState => ({
+        ...oldState,
+        step: LOADING_STEP
+      }))
+
       if (registerToken) {
         setOnboardingData({
           fqdn: instanceData.fqdn,


### PR DESCRIPTION
This PR tries to fix white screen flickering at the end of onboarding and before displaying the secure prompt

This adds a LOADING screen during the OAuth process, and then when everything is done it displays the SplashScreen until the secure prompt is displayed

I also added some blue background to HomeScreen so no white screen is displayed when the HomeView is not rendered (i.e. when waiting for a cozy-app fallback to be displayed)

This PR require the https://github.com/cozy/cozy-flagship-app/pull/806 to be merged to work correctly as I added some `showSplashScreen()` calls