### PR TITLE
fix: move "hasRenderedOnce" into an useRef()

### DIFF
--- a/src/app/view/Lock/useLockScreen.ts
+++ b/src/app/view/Lock/useLockScreen.ts
@@ -21,6 +21,7 @@ import {
   tryUnlockWithPassword,
   validatePin
 } from '/app/domain/authorization/services/LockScreenService'
+import { devlog } from '/core/tools/env'
 
 export const useLockScreenProps = (props: LockScreenProps): LockViewProps => {
   const [biometryEnabled, setBiometryEnabled] = useState(false)
@@ -116,6 +117,7 @@ export const useLockScreenProps = (props: LockScreenProps): LockViewProps => {
   // but in case it didn't, we do it here as a fallback as it is critical.
   // We're using it last because might as well wait for the other hooks to be done.
   useEffect(() => {
+    devlog('🔓', 'useLockScreen', 'hiding splash screen')
     void hideSplashScreen()
   }, [])
 

--- a/src/app/view/Secure/hooks/usePasswordPrompt.ts
+++ b/src/app/view/Secure/hooks/usePasswordPrompt.ts
@@ -9,6 +9,7 @@ export const usePasswordPrompt = (onSuccess: () => void): (() => void) => {
   // The HomeView should have called hideSplashScreen() already,
   // but in case it didn't, we do it here as a fallback as it is critical
   useEffect(() => {
+    devlog('🔓', 'usePasswordPrompt', 'hiding splash screen')
     void hideSplashScreen()
   }, [])
 

--- a/src/app/view/Secure/hooks/usePinPrompt.ts
+++ b/src/app/view/Secure/hooks/usePinPrompt.ts
@@ -12,6 +12,7 @@ export const usePinPrompt = (
   // The HomeView should have called hideSplashScreen() already,
   // but in case it didn't, we do it here as a fallback as it is critical
   useEffect(() => {
+    devlog('🔓', 'usePinPrompt', 'hiding splash screen')
     void hideSplashScreen()
   }, [])
 

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -21,14 +21,13 @@ import { useSession } from '/hooks/useSession'
 import { useHomeStateContext } from '/screens/home/HomeStateProvider'
 import { launcherEvent } from '/libs/ReactNativeLauncher'
 import { determineSecurityFlow } from '/app/domain/authorization/services/SecurityService'
+import { devlog } from '/core/tools/env'
 
 const unzoomHomeView = webviewRef => {
   webviewRef?.injectJavaScript(
     'window.dispatchEvent(new Event("closeApp"));true;'
   )
 }
-
-let hasRenderedOnce = false
 
 /**
  * @typedef Props
@@ -60,6 +59,7 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
     route,
     navigation
   )
+  const hasRenderedOnce = useRef(false)
 
   useEffect(() => {
     const subscription = AppState.addEventListener(
@@ -185,6 +185,10 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
   }, [uri, client, route, mainAppFallbackURLInitialParam, navigation, session])
 
   useEffect(() => {
+    devlog(
+      `HomeView: determineSecurityFlowHook, hasRenderedOnce.current: "${hasRenderedOnce.current}"`
+    )
+
     async function handleSecurityFlowAndCozyAppFallback() {
       let navigationObject = null
 
@@ -214,8 +218,11 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
       }
 
       // If client exists and this is the first render, determine the security flow.
-      if (uri && client && !hasRenderedOnce) {
-        hasRenderedOnce = true
+      if (uri && client && !hasRenderedOnce.current) {
+        devlog(
+          `HomeView: setting hasRenderedOnce.current set to "true" and calling determineSecurityFlowHook()`
+        )
+        hasRenderedOnce.current = true
         await determineSecurityFlow(client, navigationObject)
       }
     }


### PR DESCRIPTION
It should handle better login/unlogin bad persistence
in "hasRenderedOnce" state.

There was a bug on onboarding where the home would never show up (seemingly),
or at least the phoneSecurity check was never called.
It is still unsure how this scenario arises but it's suspected it happens when creating
accounts in a row without leaving the application.
In that case, the scoped variable would stay to true, which is technically correct,
but functionally we prefer the home to think the app has rebooted since the 
last login.
By using this in an useRef(), we're hoping the blue screen issue will be fixed
since the home state should refresh itself more naturally than with
a hardcoded let value in the homeview file.