### PR TITLE
fix: Do not change the user agent on pilot webview 

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -255,7 +255,6 @@ class LauncherView extends Component {
                 }}
                 useWebKit={true}
                 javaScriptEnabled={true}
-                userAgent={this.state.userAgent}
                 sharedCookiesEnabled={true}
                 onMessage={this.onPilotMessage}
                 onError={this.onPilotError}


### PR DESCRIPTION
When a clisk konnector called the `setUserAgent` function, it changed
the user agent on worker and pilot webviews.

It seems that this change of user agent on the pilot webview is causing
the pilot to loose the course of it's execution, making it wait forever.

Since now we do not download any file from the pilot itself, I think
removing the user agent from the pilot webview has no impact.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

