### PR TITLE
Hotfix: Race Condition on SplashScreen Hide

### DIFF
--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -47,7 +47,8 @@ export const determineSecurityFlow = async (
     navigation: NavigationContainerRef<Record<string, unknown>>
     href: string
     slug: string
-  }
+  },
+  isCallerHandlingSplashscreen?: boolean
 ): Promise<void> => {
   const callbackNav = async (): Promise<void> => {
     try {
@@ -72,7 +73,24 @@ export const determineSecurityFlow = async (
     devlog('🔒', 'No security action taken')
 
     if (navigationObject) await navigateToApp(navigationObject)
-    void hideSplashScreen() // This might be redundant but some cases require a hideSplashScreen() failsafe
+
+    // This might be redundant but some cases require a hideSplashScreen() failsafe
+    // @TODO: should be refactored into a proper app-wide splashscreen handling service
+    if (isCallerHandlingSplashscreen) {
+      devlog(
+        '🔏',
+        'determineSecurityFlow received Splashscreen instruction from its caller, therefore will not hide it'
+      )
+    }
+
+    if (!isCallerHandlingSplashscreen) {
+      devlog(
+        '🔏',
+        "determineSecurityFlow didn't receive Splashscreen instruction from its caller, defaulting to hiding it"
+      )
+
+      void hideSplashScreen()
+    }
   } else {
     devlog('🔓', 'Application does not have autolock activated')
     devlog('🔓', 'Device is unsecured')

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -223,7 +223,7 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
           `HomeView: setting hasRenderedOnce.current set to "true" and calling determineSecurityFlowHook()`
         )
         hasRenderedOnce.current = true
-        await determineSecurityFlow(client, navigationObject)
+        await determineSecurityFlow(client, navigationObject, true)
       }
     }
 


### PR DESCRIPTION
This PR addresses a race condition that was causing the splash screen to be hidden prematurely, leading to a partially loaded view being briefly visible to the user.

Changes:

1. Adds an optional parameter `isCallerHandlingSplashscreen` to the `determineSecurityFlow` function in the `SecurityService`. When this parameter is `true`, `determineSecurityFlow` will not hide the splash screen, leaving this responsibility to the calling component.

2. Modifies `HomeView` to pass `true` for the `isCallerHandlingSplashscreen` parameter when it calls `determineSecurityFlow`. This ensures that the splash screen is not hidden until `HomeView`'s WebView event listener receives the `hideSplashScreen` message.

This is a temporary hotfix to mitigate the immediate issue. A more comprehensive solution involving centralizing splash screen handling logic will be implemented in a future PR.

Note: This change assumes proper usage of the `isCallerHandlingSplashscreen` flag in all places where `determineSecurityFlow` is called. Misuse could potentially reintroduce the same race condition this fix is intended to prevent. The upcoming refactor will address this concern.

![image](https://github.com/cozy/cozy-flagship-app/assets/12577784/1d2fb000-cd3a-442f-a9cd-309767f351f7)
