### PR TITLE
Improve App Security with Back Button and AppState Listeners

### DIFF
--- a/src/@types/BackHandler.d.ts
+++ b/src/@types/BackHandler.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-native/Libraries/Utilities/__mocks__/BackHandler'

--- a/src/app/domain/authentication/models/User.ts
+++ b/src/app/domain/authentication/models/User.ts
@@ -118,7 +118,7 @@ export const savePassword = async (
 
   await resetKeychainAndSaveLoginData(keys)
 
-  devlog('🔑', 'Password saved')
+  devlog('🔏', 'Password saved')
 }
 
 export interface SetKeys {

--- a/src/app/domain/authorization/services/SecurityNavigationService.spec.ts
+++ b/src/app/domain/authorization/services/SecurityNavigationService.spec.ts
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { BackHandler, AppState } from 'react-native'
+import * as MockBackHandler from 'react-native/Libraries/Utilities/__mocks__/BackHandler'
+
+import { routes } from '/constants/routes'
+import { navigationRef } from '/libs/RootNavigation'
+
+import { SecurityNavigationService } from './SecurityNavigationService'
+
+// Mock BackHandler and AppState
+jest.mock('react-native', () => ({
+  BackHandler: {
+    ...MockBackHandler,
+    exitApp: jest.fn(),
+    addEventListener: jest.fn().mockReturnThis(),
+    remove: jest.fn()
+  },
+  AppState: {
+    currentState: 'active',
+    addEventListener: jest.fn().mockReturnThis(),
+    remove: jest.fn()
+  }
+}))
+
+describe('SecurityNavigationService', () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    jest.clearAllMocks()
+    SecurityNavigationService.stopListening()
+  })
+
+  it('starts and stops listening correctly', () => {
+    // Mock navigationRef
+    navigationRef.current = {
+      getCurrentRoute: jest.fn().mockReturnValue({ name: routes.lock })
+    } as any
+
+    SecurityNavigationService.startListening()
+
+    expect(BackHandler.addEventListener).toHaveBeenCalledWith(
+      'hardwareBackPress',
+      expect.any(Function)
+    )
+
+    expect(AppState.addEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function)
+    )
+
+    SecurityNavigationService.stopListening()
+
+    // @ts-expect-error: Mocked function
+    expect(BackHandler.remove).toHaveBeenCalled()
+    // @ts-expect-error: Mocked function
+    expect(AppState.remove).toHaveBeenCalled()
+  })
+
+  it('exits the app when back button is pressed on exit routes', () => {
+    // Mock navigationRef
+    navigationRef.current = {
+      getCurrentRoute: jest.fn().mockReturnValue({ name: routes.lock })
+    } as any
+
+    SecurityNavigationService.startListening()
+
+    // Simulate back button press
+    // @ts-expect-error: Mocked function
+    const backPressHandler = BackHandler.addEventListener.mock.calls[0][1]
+    backPressHandler()
+
+    expect(BackHandler.exitApp).toHaveBeenCalled()
+  })
+
+  it('does not exit the app when back button is pressed on non-exit routes', () => {
+    // Mock a non-exit route
+    navigationRef.current = {
+      getCurrentRoute: jest.fn().mockReturnValue({ name: routes.home })
+    } as any
+
+    SecurityNavigationService.startListening()
+
+    // Simulate back button press
+    // @ts-expect-error: Mocked function
+    const backPressHandler = BackHandler.addEventListener.mock.calls[0][1]
+    backPressHandler()
+
+    expect(MockBackHandler.exitApp).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/domain/authorization/services/SecurityNavigationService.ts
+++ b/src/app/domain/authorization/services/SecurityNavigationService.ts
@@ -1,0 +1,109 @@
+import {
+  BackHandler,
+  NativeEventSubscription,
+  AppState,
+  AppStateStatus
+} from 'react-native'
+
+import { routes } from '/constants/routes'
+import { devlog } from '/core/tools/env'
+import { navigationRef } from '/libs/RootNavigation'
+
+let backHandler: NativeEventSubscription | null = null
+let appState = AppState.currentState
+let appStateSubscription: NativeEventSubscription | null = null
+
+// Define the routes that should trigger an app exit when the back button is pressed
+const exitRoutes = [routes.lock, routes.promptPin, routes.promptPassword]
+
+/**
+ * Handle back button press
+ * If the current route is one of the defined exit routes, the app will be exited.
+ * Otherwise, the back button press event is ignored, and the event will propagate
+ * to the other listeners (if any).
+ */
+const handleBackPress = (): boolean => {
+  devlog('🔏', 'BackHandler listener triggered in SecurityNavigationService')
+
+  const currentRouteName = navigationRef.current?.getCurrentRoute()?.name
+
+  if (currentRouteName && exitRoutes.includes(currentRouteName)) {
+    devlog('🔏', `BackHandler will exit app for route "${currentRouteName}`)
+
+    BackHandler.exitApp()
+
+    return true
+  }
+
+  devlog(
+    '🔏',
+    `BackHandler listener in SecurityNavigationService will allow back naviation`
+  )
+
+  return false
+}
+
+/**
+ * Handle app state changes
+ * When the app comes to the foreground, start listening to back button presses
+ * When the app goes to the background, stop listening to avoid leaks
+ */
+const handleAppStateChange = (nextAppState: AppStateStatus): void => {
+  devlog('🔏', `Handling new app state with value: "${nextAppState}"`)
+
+  if (appState.match(/inactive|background/) && nextAppState === 'active') {
+    devlog('🔏', 'App has come to the foreground')
+
+    startListening()
+  } else {
+    devlog('🔏', 'App is going to the background')
+
+    stopListening()
+  }
+  appState = nextAppState
+}
+
+/**
+ * Start listening to back button presses and app state changes
+ * This function is idempotent, so it's safe to call multiple times.
+ */
+const startListening = (): void => {
+  devlog('🔏', 'BackHandler listener started in SecurityNavigationService')
+
+  if (!backHandler) {
+    backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      handleBackPress
+    )
+  }
+
+  if (!appStateSubscription) {
+    appStateSubscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange
+    )
+  }
+}
+
+/**
+ * Stop listening to back button presses and app state changes
+ * This function is idempotent, so it's safe to call multiple times.
+ */
+const stopListening = (): void => {
+  devlog('🔏', 'BackHandler listener stopped in SecurityNavigationService')
+
+  if (backHandler) {
+    backHandler.remove()
+    backHandler = null
+  }
+
+  if (appStateSubscription) {
+    appStateSubscription.remove()
+    appStateSubscription = null
+  }
+}
+
+export const SecurityNavigationService = {
+  startListening,
+  stopListening
+}

--- a/src/app/view/Secure/hooks/usePasswordPrompt.ts
+++ b/src/app/view/Secure/hooks/usePasswordPrompt.ts
@@ -9,7 +9,7 @@ export const usePasswordPrompt = (onSuccess: () => void): (() => void) => {
   // The HomeView should have called hideSplashScreen() already,
   // but in case it didn't, we do it here as a fallback as it is critical
   useEffect(() => {
-    devlog('🔓', 'usePasswordPrompt', 'hiding splash screen')
+    devlog('🔏', 'usePasswordPrompt', 'hiding splash screen')
     void hideSplashScreen()
   }, [])
 

--- a/src/app/view/Secure/hooks/usePinPrompt.ts
+++ b/src/app/view/Secure/hooks/usePinPrompt.ts
@@ -12,7 +12,7 @@ export const usePinPrompt = (
   // The HomeView should have called hideSplashScreen() already,
   // but in case it didn't, we do it here as a fallback as it is critical
   useEffect(() => {
-    devlog('🔓', 'usePinPrompt', 'hiding splash screen')
+    devlog('🔏', 'usePinPrompt', 'hiding splash screen')
     void hideSplashScreen()
   }, [])
 


### PR DESCRIPTION
In this PR, we've added additional layers of security to our React Native app to handle Android back button presses and App state changes more effectively. 

Specifically, we've:

- Created a `SecurityNavigationService` that listens for Android back button presses and exits the app if the user is currently on one of the following routes: lock screen, PIN prompt, or password prompt. This prevents users from navigating back to the previous route without successful authentication. 

- Added an AppState listener to the `SecurityNavigationService`. This ensures that we only listen for back button presses when the app is active (i.e., in the foreground). When the app goes to the background, the listener is removed to prevent unnecessary usage of resources.

- Added comprehensive unit tests to ensure the new service behaves as expected.

This change enhances the security of our app by ensuring that sensitive information cannot be accessed without proper authentication and improves resource usage by only listening for back button presses when necessary.

## Testing

Tests have been added for the `SecurityNavigationService`. You can run these tests using the command `yarn test`.

Please also manually test this feature by trying to use the Android back button to navigate from the lock, PIN prompt, and password prompt screens.

## Impact

This change impacts any screens that use the lock, PIN prompt, and password prompt screens. The back button on Android will now behave differently on these screens, improving the security of the app.
