### PR TITLE
Fix: Handle Offline on CozyApp Open

### DIFF
--- a/src/libs/functions/iconTable.ts
+++ b/src/libs/functions/iconTable.ts
@@ -11,7 +11,7 @@ import { getErrorMessage } from '/libs/functions/getErrorMessage'
 
 const log = Minilog('Icon Table')
 
-export let iconTable = {}
+export let iconTable: Record<string, { version: string; xml: string }> = {}
 
 export type IconsCache = Record<string, { version: string; xml: string }>
 

--- a/src/libs/services/NetService.spec.ts
+++ b/src/libs/services/NetService.spec.ts
@@ -1,12 +1,10 @@
 import NetInfo, { NetInfoState } from '@react-native-community/netinfo'
 
 import strings from '/constants/strings.json'
-
-import { NetService } from './NetService'
-
+import { NetService } from '/libs/services/NetService'
 import { routes } from '/constants/routes'
 
-const mockReset = jest.fn<jest.Mock, unknown[]>()
+const mockNavigate = jest.fn<jest.Mock, unknown[]>()
 const callbackRoute = 'foo'
 const mockedNetInfo = NetInfo as jest.Mocked<typeof NetInfo>
 
@@ -18,7 +16,7 @@ const mockedListener = mockedNetInfo.addEventListener as unknown as jest.Mock<
 const mockedFetch = NetInfo.fetch as jest.Mock
 
 jest.mock('../RootNavigation', () => ({
-  reset: (...args: unknown[]): jest.Mock => mockReset(...args)
+  navigate: (...args: unknown[]): jest.Mock => mockNavigate(...args)
 }))
 
 afterEach(() => {
@@ -68,11 +66,11 @@ it('handles imperative offline fallback', async () => {
 
   await new Promise(resolve => setTimeout(resolve, timeBeforeReconnect))
 
-  expect(mockReset).toHaveBeenNthCalledWith(1, routes.error, {
+  expect(mockNavigate).toHaveBeenNthCalledWith(1, routes.error, {
     type: strings.errorScreens.offline
   })
 
-  expect(mockReset).toHaveBeenNthCalledWith(2, callbackRoute)
+  expect(mockNavigate).toHaveBeenNthCalledWith(2, callbackRoute)
 
   expect(mockUnsubscribe).toHaveBeenCalledTimes(1)
 })

--- a/src/screens/cozy-app/CozyAppScreen.Animation.tsx
+++ b/src/screens/cozy-app/CozyAppScreen.Animation.tsx
@@ -4,63 +4,17 @@ import { SvgXml } from 'react-native-svg'
 
 import ProgressBar from '/components/Bar'
 import { iconTable, iconFallback } from '/libs/functions/iconTable'
-import { getDimensions } from '/libs/dimensions'
-import { palette } from '/ui/palette'
 
+import {
+  config,
+  containerAnimConfig,
+  getScaleInput,
+  getTranslateInput,
+  progressBarAnimConfig,
+  progressBarConfig
+} from './CozyAppScreen.functions'
 import { styles } from './CozyAppScreen.styles'
-
-const { screenHeight, screenWidth } = getDimensions()
-
-const config = {
-  duration: 300,
-  width: '44%',
-  height: '44%',
-  driver: true
-}
-
-const progressBarConfig = {
-  width: null,
-  indeterminate: true,
-  unfilledColor: palette.Grey[200],
-  color: palette.Primary[600],
-  borderWidth: 0,
-  height: 8,
-  borderRadius: 100,
-  indeterminateAnimationDuration: 1500
-}
-
-const progressBarAnimConfig = {
-  fadeIn: {
-    toValue: 1,
-    duration: 50,
-    useNativeDriver: config.driver
-  },
-  fadeOut: {
-    toValue: 0,
-    duration: 50,
-    useNativeDriver: config.driver
-  }
-}
-
-const containerAnimConfig = {
-  fadeOut: {
-    toValue: 0,
-    duration: 300,
-    useNativeDriver: config.driver
-  }
-}
-
-const getTranslateInput = params => ({
-  x:
-    params.x - styles.fadingContainer.left - (screenWidth - params.width) * 0.5,
-  y:
-    params.y - styles.fadingContainer.top - (screenHeight - params.height) * 0.5
-})
-
-const getScaleInput = params => ({
-  x: params.width / screenWidth,
-  y: params.height / screenHeight
-})
+import { CozyAppScreenAnimationProps } from './CozyAppScreen.types'
 
 export const Animation = ({
   onFirstHalf,
@@ -68,7 +22,7 @@ export const Animation = ({
   shouldExit,
   params,
   slug
-}) => {
+}: CozyAppScreenAnimationProps): JSX.Element => {
   const animateTranslate = useRef(
     new Animated.ValueXY(getTranslateInput(params))
   ).current
@@ -79,9 +33,10 @@ export const Animation = ({
   const animateBarOpacity = useRef(new Animated.Value(0)).current
 
   class SVG extends React.Component {
-    render() {
+    render(): JSX.Element {
       return (
         <SvgXml
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           xml={iconTable[slug]?.xml || iconFallback}
           width={config.width}
           height={config.height}

--- a/src/screens/cozy-app/CozyAppScreen.functions.ts
+++ b/src/screens/cozy-app/CozyAppScreen.functions.ts
@@ -22,7 +22,7 @@ export const handleError = ({ nativeEvent }: WebViewErrorEvent): void => {
   const { code, description } = nativeEvent
 
   if (code === -2 && description === 'net::ERR_INTERNET_DISCONNECTED')
-    NetService.handleOffline(routes.stack)
+    NetService.handleOffline(routes.home)
 }
 
 const { screenHeight, screenWidth } = getDimensions()

--- a/src/screens/cozy-app/CozyAppScreen.functions.ts
+++ b/src/screens/cozy-app/CozyAppScreen.functions.ts
@@ -1,0 +1,87 @@
+import { WebViewErrorEvent } from 'react-native-webview/lib/WebViewTypes'
+
+import { styles } from './CozyAppScreen.styles'
+
+import { routes } from '/constants/routes'
+import { getDimensions } from '/libs/dimensions'
+import { internalMethods } from '/libs/intents/localMethods'
+import { NetService } from '/libs/services/NetService'
+import { palette } from '/ui/palette'
+
+export const firstHalfUI = (): Promise<null> =>
+  internalMethods.setFlagshipUI({
+    bottomBackground: 'white',
+    bottomTheme: 'dark',
+    bottomOverlay: 'transparent',
+    topBackground: 'white',
+    topTheme: 'dark',
+    topOverlay: 'transparent'
+  })
+
+export const handleError = ({ nativeEvent }: WebViewErrorEvent): void => {
+  const { code, description } = nativeEvent
+
+  if (code === -2 && description === 'net::ERR_INTERNET_DISCONNECTED')
+    NetService.handleOffline(routes.stack)
+}
+
+const { screenHeight, screenWidth } = getDimensions()
+
+export const config = {
+  duration: 300,
+  width: '44%',
+  height: '44%',
+  driver: true
+}
+
+export const progressBarConfig = {
+  width: null,
+  indeterminate: true,
+  unfilledColor: palette.Grey[200],
+  color: palette.Primary[600],
+  borderWidth: 0,
+  height: 8,
+  borderRadius: 100,
+  indeterminateAnimationDuration: 1500
+}
+
+export const progressBarAnimConfig = {
+  fadeIn: {
+    toValue: 1,
+    duration: 50,
+    useNativeDriver: config.driver
+  },
+  fadeOut: {
+    toValue: 0,
+    duration: 50,
+    useNativeDriver: config.driver
+  }
+}
+
+export const containerAnimConfig = {
+  fadeOut: {
+    toValue: 0,
+    duration: 300,
+    useNativeDriver: config.driver
+  }
+}
+
+export const getTranslateInput = (params: {
+  x: number
+  y: number
+  height: number
+  width: number
+}): { x: number; y: number } => ({
+  x:
+    params.x - styles.fadingContainer.left - (screenWidth - params.width) * 0.5,
+  y:
+    params.y - styles.fadingContainer.top - (screenHeight - params.height) * 0.5
+})
+
+export const getScaleInput = (params: {
+  width: number
+  height: number
+}): { x: number; y: number } => ({
+  x: params.width / screenWidth,
+  y: params.height / screenHeight
+})

--- a/src/screens/cozy-app/CozyAppScreen.styles.ts
+++ b/src/screens/cozy-app/CozyAppScreen.styles.ts
@@ -34,7 +34,9 @@ export const styles = StyleSheet.create({
     flex: 1, // Allows full height for loading animation
     opacity: 1
   },
-  immersiveHeight: 0,
+  immersiveHeight: {
+    height: 0
+  },
   progressBarContainer: {
     width: '60%',
     display: 'flex'

--- a/src/screens/cozy-app/CozyAppScreen.tsx
+++ b/src/screens/cozy-app/CozyAppScreen.tsx
@@ -1,40 +1,21 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { StatusBar, View } from 'react-native'
 
-import { Animation } from './CozyAppScreen.Animation'
-import { styles } from './CozyAppScreen.styles'
-import { CozyProxyWebView } from '../../components/webviews/CozyProxyWebView'
-
-import { NetService } from '/libs/services/NetService'
-
-import { flagshipUI } from '../../libs/intents/setFlagshipUI'
-
+import { CozyProxyWebView } from '/components/webviews/CozyProxyWebView'
+import { flagshipUI, NormalisedFlagshipUI } from '/libs/intents/setFlagshipUI'
 import { useDimensions } from '/libs/dimensions'
-
-import { internalMethods } from '../../libs/intents/localMethods'
-
-import { routes } from '/constants/routes'
 import { useHomeStateContext } from '/screens/home/HomeStateProvider'
 
-const firstHalfUI = () =>
-  internalMethods.setFlagshipUI({
-    bottomBackground: 'white',
-    bottomTheme: 'dark',
-    bottomOverlay: 'transparent',
-    topBackground: 'white',
-    topTheme: 'dark',
-    topOverlay: 'transparent'
-  })
+import { Animation } from './CozyAppScreen.Animation'
+import { firstHalfUI, handleError } from './CozyAppScreen.functions'
+import { styles } from './CozyAppScreen.styles'
+import { CozyAppScreenProps } from './CozyAppScreen.types'
 
-const handleError = ({ nativeEvent }) => {
-  const { code, description } = nativeEvent
-
-  if (code === -2 && description === 'net::ERR_INTERNET_DISCONNECTED')
-    NetService.handleOffline(routes.stack)
-}
-
-export const CozyAppScreen = ({ route, navigation }) => {
-  const [UIState, setUIState] = useState({})
+export const CozyAppScreen = ({
+  route,
+  navigation
+}: CozyAppScreenProps): JSX.Element => {
+  const [UIState, setUIState] = useState<NormalisedFlagshipUI>({})
   const {
     bottomBackground,
     bottomOverlay,
@@ -48,7 +29,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
   const { setShouldWaitCozyApp } = useHomeStateContext()
 
   useEffect(() => {
-    flagshipUI.on('change', state => {
+    flagshipUI.on('change', (state: NormalisedFlagshipUI) => {
       setUIState({ ...UIState, ...state })
     })
 
@@ -60,9 +41,10 @@ export const CozyAppScreen = ({ route, navigation }) => {
   useEffect(() => {
     if (isReady) return // We don't want to trigger the animation UI changes twice (in case of app unlock for instance)
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     !route.params.iconParams && setReady(true)
 
-    isFirstHalf && firstHalfUI()
+    isFirstHalf && void firstHalfUI()
   }, [isFirstHalf, isReady, route.params.iconParams])
   const dimensions = useDimensions()
 
@@ -84,7 +66,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
         style={{
           height: isFirstHalf
             ? dimensions.statusBarHeight
-            : styles.immersiveHeight,
+            : styles.immersiveHeight.height,
           backgroundColor: topBackground
         }}
       >
@@ -97,15 +79,18 @@ export const CozyAppScreen = ({ route, navigation }) => {
       </View>
 
       <View style={styles.mainView}>
-        {route.params.iconParams && !isReady && (
-          <Animation
-            onFirstHalf={setFirstHalf}
-            onFinished={setReady}
-            shouldExit={shouldExitAnimation}
-            params={route.params.iconParams}
-            slug={route.params.slug}
-          />
-        )}
+        {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          route.params.iconParams && !isReady && (
+            <Animation
+              onFirstHalf={setFirstHalf}
+              onFinished={setReady}
+              shouldExit={shouldExitAnimation}
+              params={route.params.iconParams}
+              slug={route.params.slug}
+            />
+          )
+        }
 
         <CozyProxyWebView
           style={webViewStyle}
@@ -123,7 +108,7 @@ export const CozyAppScreen = ({ route, navigation }) => {
         style={{
           height: isFirstHalf
             ? dimensions.navbarHeight
-            : styles.immersiveHeight,
+            : styles.immersiveHeight.height,
           backgroundColor: bottomBackground
         }}
       >

--- a/src/screens/cozy-app/CozyAppScreen.types.ts
+++ b/src/screens/cozy-app/CozyAppScreen.types.ts
@@ -1,0 +1,40 @@
+import type {
+  RouteProp,
+  NavigationContainerRef
+} from '@react-navigation/native'
+import type { Dispatch, SetStateAction } from 'react'
+
+export interface IconParams {
+  x: number
+  y: number
+  width: number
+  height: number
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+export interface RootStackParamList {
+  cozyapp: {
+    href: string
+    slug: string
+    iconParams: IconParams
+  }
+  [key: string]:
+    | undefined
+    | { href: string; slug: string; iconParams: IconParams }
+}
+
+export interface CozyAppScreenProps {
+  route: RouteProp<RootStackParamList, 'cozyapp'>
+  navigation: NavigationContainerRef<Record<string, unknown>>
+}
+
+export interface CozyAppScreenAnimationProps {
+  onFirstHalf: (arg: boolean) => void
+  onFinished: Dispatch<SetStateAction<boolean>>
+  shouldExit: boolean
+  params: { x: number; y: number; width: number; height: number }
+  slug: string
+}


### PR DESCRIPTION
This PR introduces several improvements to our offline handling strategy. The main changes include:

- **Redirect to Home instead of Stack:** Previously, when the device was offline, the app would redirect the user to the Stack when online again. To provide an updated user experience, we've changed this functionality to redirect users to the Home screen instead.

- **Graceful Unsubscribe Event Handling:** This update ensures that the `unsubscribe` event is handled more gracefully, preventing any potential issues that could arise from calling it while undefined.

- **Removal of Navigation Reset:** We've removed the use of the navigation reset function (`reset()`) because it was causing destructive effects. Instead, we've opted for less disruptive methods of navigation. Destructive effects were linked to the unmounting of the HomeView, which provokes a lot of issues with post-me. Navigating avoid these issues entirely and the home stays rendered. Better performance and fewer issues.

- **Addressing Potential Backpress Issues:** We have started investigating how to handle scenarios where a user triggers a back press from the Offline Screen, especially as we have removed the navigation reset function. This is a complex area that we will continue to explore and improve upon in future updates.

- **Migration to TypeScript:** All files related to `CozyAppScreen` have been migrated from JavaScript to TypeScript. This change not only provides more robust type-checking and tooling support but also makes the codebase more consistent and maintainable. All types have been fully defined to ensure strict type checking. 

This PR provides a safer and more user-friendly approach to handling offline scenarios, enhancing the overall performance and reliability of our app.