### PR TITLE
fix: forcing the light theme for the app

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,8 +1,10 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
-        <item name="android:enforceNavigationBarContrast">false</item>
+    <!-- Set the base theme to light for the entire app -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- Additional customizations can be added here -->
+        <item name="android:enforceNavigationBarContrast">false</item> <!-- Optional: Disabling enforced contrast for navigation bar -->
+        <item name="android:forceDarkAllowed">false</item> <!-- Prevent the system from applying automatic dark mode transformations -->
     </style>
 
     <style name="BootTheme" parent="AppTheme">

--- a/src/libs/httpserver/httpServerProvider.js
+++ b/src/libs/httpserver/httpServerProvider.js
@@ -16,7 +16,8 @@ import { setCookie } from '/libs/httpserver/httpCookieManager'
 import {
   addBodyClasses,
   addMetaAttributes,
-  addBarStyles
+  addBarStyles,
+  addColorSchemeMetaIfNecessary
 } from './server-helpers'
 
 import {
@@ -105,6 +106,7 @@ export const HttpServerProvider = props => {
       })
       if (slug === 'home') {
         return flow(
+          addColorSchemeMetaIfNecessary,
           addBarStyles,
           addBodyClasses,
           addMetaAttributes
@@ -112,7 +114,11 @@ export const HttpServerProvider = props => {
       } else {
         // We do not need the bar styles for other app. We only need it for
         // the Home application since this is the only "immersive app"
-        return flow(addBodyClasses, addMetaAttributes)(computedHtml)
+        return flow(
+          addColorSchemeMetaIfNecessary,
+          addBodyClasses,
+          addMetaAttributes
+        )(computedHtml)
       }
     } catch (err) {
       log.error(

--- a/src/libs/httpserver/server-helpers.spec.ts
+++ b/src/libs/httpserver/server-helpers.spec.ts
@@ -1,7 +1,8 @@
 import {
   addBodyClasses,
   addBarStyles,
-  addMetaAttributes
+  addMetaAttributes,
+  addColorSchemeMetaIfNecessary
 } from '/libs/httpserver/server-helpers'
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -45,4 +46,16 @@ it('should return a stringified HTML with added meta tags', () => {
   const expected = `<html><head><meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" /></head><body></body></html>`
 
   expect(addMetaAttributes(html)).toEqual(expected)
+})
+
+it('should add color-scheme meta tag if not present', () => {
+  const html = `<html><head></head><body></body></html>`
+  const expected = `<html><head><meta name="color-scheme" content="light only"/></head><body></body></html>`
+  expect(addColorSchemeMetaIfNecessary(html)).toEqual(expected)
+})
+
+it('should not add color-scheme meta tag if already present', () => {
+  const html = `<html><head><meta name="color-scheme" content="dark only"/></head><body></body></html>`
+  const expected = `<html><head><meta name="color-scheme" content="dark only"/></head><body></body></html>`
+  expect(addColorSchemeMetaIfNecessary(html)).toEqual(expected)
 })

--- a/src/libs/httpserver/server-helpers.ts
+++ b/src/libs/httpserver/server-helpers.ts
@@ -35,3 +35,18 @@ export const addMetaAttributes = (HTMLstring: string): string => {
 
   return HTMLstring.replace('</head>', metaAttributes + '</head>')
 }
+
+export const addColorSchemeMetaIfNecessary = (HTMLstring: string): string => {
+  const metaColorScheme = `<meta name="color-scheme" content="light only"/>`
+
+  // Check if color-scheme meta tag is already present
+  const colorSchemeRegex = /<meta[^>]*name=['"]?color-scheme['"]?[^>]*>/i
+  const colorSchemeExists = colorSchemeRegex.test(HTMLstring)
+
+  // Add the meta tag before the closing </head> tag if not present
+  if (!colorSchemeExists) {
+    return HTMLstring.replace('</head>', `${metaColorScheme}</head>`)
+  }
+
+  return HTMLstring
+}


### PR DESCRIPTION
In order to avoid issues with unhandled dark modes,
we disable the DayNight compat of the app
and replace it with a Light compat only.
This will disable algorithmic darkening

Tested with forceDarkMode on WebView on a Android phone in dark theme with a dark themed chrome: the homepage is not dark despite not having a meta color-scheme
