### PR TITLE
Add Device Synchronization at App Start and Wake Up

### DIFF
--- a/src/app/domain/authentication/services/SynchronizeService.spec.ts
+++ b/src/app/domain/authentication/services/SynchronizeService.spec.ts
@@ -1,0 +1,29 @@
+import CozyClient from 'cozy-client'
+
+import { synchronizeDevice } from '/app/domain/authentication/services/SynchronizeService'
+
+jest.mock('cozy-client')
+
+describe('SynchronizeService', () => {
+  let client: CozyClient
+
+  beforeEach(() => {
+    client = new CozyClient()
+  })
+
+  it('should synchronize device successfully', async () => {
+    // Mock the client response for successful synchronization
+    client.getStackClient = jest.fn().mockReturnValue({
+      fetchJSON: jest.fn().mockResolvedValue({})
+    })
+
+    await synchronizeDevice(client)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(client.getStackClient).toHaveBeenCalled()
+    expect(client.getStackClient().fetchJSON).toHaveBeenCalledWith(
+      'POST',
+      '/settings/synchronized'
+    )
+  })
+})

--- a/src/app/domain/authentication/services/SynchronizeService.ts
+++ b/src/app/domain/authentication/services/SynchronizeService.ts
@@ -1,0 +1,14 @@
+import Minilog from '@cozy/minilog'
+
+import type CozyClient from 'cozy-client'
+
+const log = Minilog('SynchronizeService')
+
+export const synchronizeDevice = async (client: CozyClient): Promise<void> => {
+  try {
+    await client.getStackClient().fetchJSON('POST', '/settings/synchronized')
+    log.info('📱 Device synchronized')
+  } catch (error) {
+    log.warn('Error while synchronizing device', error)
+  }
+}

--- a/src/libs/client.spec.js
+++ b/src/libs/client.spec.js
@@ -46,7 +46,7 @@ describe('client', () => {
             androidSafetyNetApiKey: expect.any(String)
           },
           clientKind: 'mobile',
-          clientName: "Cloud Personnel (Becca's iPhone 6)",
+          clientName: "Application Mobile Cozy (Becca's iPhone 6)",
           redirectURI: 'cozy://',
           shouldRequireFlagshipPermissions: true,
           softwareID: 'amiral'

--- a/src/locales/fr-FR/translation.json
+++ b/src/locales/fr-FR/translation.json
@@ -69,7 +69,7 @@
   },
   "software": {
     "id": "amiral",
-    "name": "Cloud Personnel"
+    "name": "Application Mobile Cozy"
   },
   "ui": {
     "buttons": {


### PR DESCRIPTION
## Summary

This PR introduces a new feature to synchronize the device with the stack. The `synchronizeDevice` function has been added, which is responsible for synchronizing the state of the device with the backend. It's called both at the app start and whenever the app wakes up from the background.

## Changes

- Added `synchronizeDevice` function in `SynchronizeService`.
- Added tests for `synchronizeDevice` to ensure its proper functioning.
- Integrated `synchronizeDevice` so that it is called at the app's start in useGlobalAppState.
- Integrated `synchronizeDevice` to be called when the app wakes up in useGlobalAppState.

## How to Test

1. Clone the branch.
2. Run the application.
3. Check the logs to ensure that the device is being synchronized at the start.
4. Put the app in the background and then bring it back to the foreground to see the synchronization happening again.

## Impact

This feature ensures that the device name and last utilisation are always synchronized with the stack.

## Screenshots and Recordings

![image](https://github.com/cozy/cozy-flagship-app/assets/12577784/16c5b4bd-8f26-4aee-a160-352d6d3f8ded)

## Other Notes

- Feedback for additional test scenarios or edge cases is appreciated.
