### PR TITLE
feat: Download files progressively only when needed 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
     "cozy-client": "^38.6.0",
-    "cozy-clisk": "^0.13.0",
+    "cozy-clisk": "^0.15.0",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
     "cozy-intent": "^2.13.0",

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -60,6 +60,7 @@ class ReactNativeLauncher extends Launcher {
       logFn: msg => this.log({ level: 'info', msg })
     })
 
+    this.getExistingFilesIndex = wrapTimer(this, 'getExistingFilesIndex')
     this.init = wrapTimer(this, 'init', {
       displayName: 'pilot and worker init'
     })

--- a/src/screens/login/components/ClouderyViewSwitch.tsx
+++ b/src/screens/login/components/ClouderyViewSwitch.tsx
@@ -226,7 +226,7 @@ const ClouderyWebView = forwardRef(
         onOpenWindow={openWindowWithInAppBrowser}
         injectedJavaScriptBeforeContentLoaded={run}
         style={{
-          backgroundColor: clouderyTheme?.backgroundColor
+          backgroundColor: clouderyTheme.backgroundColor
         }}
         onError={handleError}
         {...other}

--- a/src/screens/login/components/ClouderyViewSwitch.tsx
+++ b/src/screens/login/components/ClouderyViewSwitch.tsx
@@ -243,7 +243,7 @@ const run = `
     ${jsLogInterception}
 
     ${fetchThemeOnLoad}
-    
+
     ${handleAutofocusFields}
 
     ${jsPaddingInjection}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6353,10 +6353,10 @@ cozy-client@^38.6.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-clisk@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.13.0.tgz#31b6faab5ba357024ccdf0e7afbdfa59e2436740"
-  integrity sha512-APuaQqPRTpSjkpaS9IvkSv7Ru8zfpUPCb+7dkdRnKv/M4b9IdhM+PSJogBpBJPXy8a9MzZ4iZjXmCfJ5GzAwxA==
+cozy-clisk@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.15.0.tgz#4223aa36c09a75461bd493e5f643824f6a4ea175"
+  integrity sha512-7eqiT+4MDkFH6aIVrX/O0srgEnPZ7BmXrOm2YDoDohL/96hypO6mctgXyE4xFBrLeF+GlI+oi5RfWssltFHTNw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     bluebird-retry "^0.11.0"


### PR DESCRIPTION
Now call cozy-clisk saveFiles directly for all the given files and pass
a callback which saveFiles will call when the download of a file is
needed. This downloadAndFormatFile callback downloads the given file in
the worker webview and format it to ArrayBuffer as expected by the cozy
stack.

See https://github.com/konnectors/libs/pull/949 for the related
cozy-clisk PR

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

