### PR TITLE
Add keep awake API

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -366,6 +366,8 @@ PODS:
   - react-native-gzip (2.0.0):
     - NVHTarGzip
     - React
+  - react-native-keep-awake (1.1.0):
+    - React-Core
   - react-native-netinfo (9.3.7):
     - React-Core
   - react-native-safe-area-context (4.5.0):
@@ -533,6 +535,7 @@ DEPENDENCIES:
   - react-native-document-scanner-plugin (from `../node_modules/react-native-document-scanner-plugin`)
   - react-native-flipper (from `../node_modules/react-native-flipper`)
   - "react-native-gzip (from `../node_modules/@fengweichong/react-native-gzip`)"
+  - "react-native-keep-awake (from `../node_modules/@sayem314/react-native-keep-awake`)"
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -645,6 +648,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-flipper"
   react-native-gzip:
     :path: "../node_modules/@fengweichong/react-native-gzip"
+  react-native-keep-awake:
+    :path: "../node_modules/@sayem314/react-native-keep-awake"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
@@ -757,6 +762,7 @@ SPEC CHECKSUMS:
   react-native-document-scanner-plugin: df5b82df67ff612262c40c26ef2c8239c5af5c55
   react-native-flipper: 4bfe0a324e663f1ae2f76ad0da75673de6895efe
   react-native-gzip: 5ffb84bf191c7cd135338eca748317bc466d41a1
+  react-native-keep-awake: acbee258db16483744910f0da3ace39eb9ab47fd
   react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-webview: 8ec7ddf9eb4ddcd92b32cee7907efec19a9ec7cb

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@react-navigation/routers": "6.1.6",
     "@react-navigation/stack": "^6.3.10",
     "@reduxjs/toolkit": "^1.9.1",
+    "@sayem314/react-native-keep-awake": "^1.1.0",
     "@sentry/integrations": "6.19.2",
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",

--- a/src/app/domain/sleep/services/sleep.ts
+++ b/src/app/domain/sleep/services/sleep.ts
@@ -1,0 +1,6 @@
+import {
+  activateKeepAwake,
+  deactivateKeepAwake
+} from '@sayem314/react-native-keep-awake'
+
+export { activateKeepAwake, deactivateKeepAwake }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3080,6 +3080,11 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@sayem314/react-native-keep-awake@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@sayem314/react-native-keep-awake/-/react-native-keep-awake-1.1.0.tgz#852f9f8481c0ab38a54d6f0b85324f3024eb6031"
+  integrity sha512-1k57PXJIfhZrjA4ZQr+goTEYer8MBhe1At6XjVYJq1oBuhG/CIu0gX1EH9fU9exC65e5uDs/zAwjl6Ps+3lCgg==
+
 "@sentry/browser@6.19.2":
   version "6.19.2"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.19.2.tgz#c0f6df07584f3b36fa037067aea20b2c8c2095a3"


### PR DESCRIPTION
Add react-native-keep-awake and wrap it in a service. Tested on Android simulator and iOS device.

This API **works** when app is **in foreground** and **until app is quit**.

#### How to use it 

```
import {
  activateKeepAwake,
  deactivateKeepAwake
} from '/app/domain/sleep/services/sleep'


...

activateKeepAwake()

// long task where you do not want to go to sleep

deactivateKeepAwake()

...
```

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] ~~Faithful integration of the mockups at all screen sizes~~
* [x] Tested on iOS
* [x] Tested on Android
* [x] Localized in English and French
* [ ] ~~All changes have test coverage~~
* [ ] ~~Updated README & CHANGELOG, if necessary~~

