### PR TITLE
fix: Fully reload the CozyProxyWebView from ReloadInterceptorWebView

### DIFF
--- a/src/components/webviews/ReloadInterceptorWebView.js
+++ b/src/components/webviews/ReloadInterceptorWebView.js
@@ -225,7 +225,13 @@ const ReloadInterceptorWebView = React.forwardRef((props, ref) => {
             navigation,
             onShouldStartLoadWithRequest,
             interceptReload: true,
-            onReloadInterception: () => setTimestamp(Date.now()),
+            onReloadInterception: () => {
+              if (props.reloadProxyWebView) {
+                props.reloadProxyWebView()
+              } else {
+                setTimestamp(Date.now())
+              }
+            },
             isFirstCall,
             client,
             setDownloadProgress


### PR DESCRIPTION
The ReloadInterceptorWebView component is responsible to intercept the WebView's reload events and to remount the component instead of just doing an HTML reload

With current implementation, if the cozy-home app is in an error state due to invalid cookies, then reloading ReloadInterceptorWebView won't fix the problem as the same HTML content will be served from the CozyProxyWebView that is not re-rendered

To fix this, we want to do the reload process on the CozyProxyWebView instead, so the getIndexHtmlForSlug is called and then cookies would be refreshed