### PR TITLE
Temp: Proposal for ComposedWebView

### DIFF
--- a/src/components/webviews/ComposedWebView.js
+++ b/src/components/webviews/ComposedWebView.js
@@ -1,0 +1,78 @@
+import Minilog from '@cozy/minilog'
+import React, { useEffect, useRef } from 'react'
+
+import { CozyProxyWebView } from '/components/webviews/CozyProxyWebView'
+import { CozyWebView } from '/components/webviews/CozyWebView'
+import ReloadInterceptorWebView from '/components/webviews/ReloadInterceptorWebView'
+import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
+
+const log = Minilog('🌍 ComposedWebView')
+
+const ComposedWebViewItem = React.forwardRef(
+  ({ ItemType, childrenTypes, currentLevel, ...otherProps }, ref) => {
+    const [firstChild, ...otherChildren] = childrenTypes
+
+    console.log('1️⃣ currentLevel', currentLevel)
+    const ChildWebview = React.forwardRef((subOtherProps, subRef) => {
+
+      useEffect(() => {
+        log.debug('ComposedWebView mount')
+
+        return () => {
+          log.debug('ComposedWebView unmount')
+        }
+      }, [])
+
+      return (
+        <ComposedWebViewItem
+          ItemType={firstChild}
+          childrenTypes={otherChildren}
+          currentLevel={currentLevel + 1}
+          ref={subRef}
+          {...subOtherProps}
+        />
+      )
+    })
+    ChildWebview.displayName = 'ChildWebviewRef'
+
+    return (
+      <>
+        {childrenTypes?.length > 0 ? (
+          <ItemType ChildWebview={ChildWebview} ref={ref} {...otherProps} />
+        ) : (
+          <ItemType ref={ref} {...otherProps} />
+        )}
+      </>
+    )
+  }
+)
+ComposedWebViewItem.displayName = 'ComposedWebViewItem'
+
+export const ComposedWebView = ({ childrenTypes, ...otherProps }) => {
+  const [ChildWebview, ...otherChildren] = childrenTypes
+  const ref = useRef(null)
+
+  return (
+    <ComposedWebViewItem
+      ItemType={ChildWebview}
+      childrenTypes={otherChildren}
+      currentLevel={0}
+      ref={ref}
+      {...otherProps}
+    />
+  )
+}
+
+export const CozyAppWebView = props => {
+  return (
+    <ComposedWebView
+      {...props}
+      childrenTypes={[
+        CozyProxyWebView,
+        CozyWebView,
+        // ReloadInterceptorWebView,
+        SupervisedWebView
+      ]}
+    />
+  )
+}

--- a/src/components/webviews/ReloadInterceptorWebView.js
+++ b/src/components/webviews/ReloadInterceptorWebView.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
+import { WebView } from 'react-native-webview'
 
 import { useClient } from 'cozy-client'
 
-import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
 import { userAgentDefault } from '/constants/userAgent'
 import { ProgressContainer } from '/components/ProgressContainer'
 import {
@@ -23,14 +23,15 @@ const ReloadInterceptorWebView = React.forwardRef((props, ref) => {
     source,
     onShouldStartLoadWithRequest,
     userAgent = userAgentDefault,
-    navigation
+    navigation,
+    ChildWebview = WebView
   } = props
 
   if (!source.html) {
     // Blocking this feature, when source={{ uri }} is set
     return (
       <ProgressContainer progress={progress}>
-        <SupervisedWebView
+        <ChildWebview
           {...props}
           ref={ref}
           {...userAgent}
@@ -63,7 +64,7 @@ const ReloadInterceptorWebView = React.forwardRef((props, ref) => {
 
   return (
     <ProgressContainer progress={progress}>
-      <SupervisedWebView
+      <ChildWebview
         {...props}
         {...userAgent}
         ref={ref}

--- a/src/components/webviews/SupervisedWebView.js
+++ b/src/components/webviews/SupervisedWebView.js
@@ -76,7 +76,12 @@ export const SupervisedWebView = React.forwardRef((props, ref) => {
     key: 0
   })
 
-  const { onLoad, supervisionShowProgress = true, ...otherProps } = props
+  const {
+    onLoad,
+    supervisionShowProgress = true,
+    ChildWebview = WebView,
+    ...otherProps
+  } = props
   const { isReloading, isLoaded, shouldBeLoaded, key, reloadDelay } = state
 
   useEffect(
@@ -131,7 +136,7 @@ export const SupervisedWebView = React.forwardRef((props, ref) => {
 
   return (
     <>
-      <WebView
+      <ChildWebview
         {...otherProps}
         ref={ref}
         key={key}

--- a/src/screens/cozy-app/CozyAppScreen.tsx
+++ b/src/screens/cozy-app/CozyAppScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { StatusBar, View } from 'react-native'
 
-import { CozyProxyWebView } from '/components/webviews/CozyProxyWebView'
+import { CozyAppWebView } from '/components/webviews/ComposedWebView'
 import { flagshipUI, NormalisedFlagshipUI } from '/libs/intents/setFlagshipUI'
 import { useDimensions } from '/libs/dimensions'
 import { useHomeStateContext } from '/screens/home/HomeStateProvider'
@@ -92,7 +92,7 @@ export const CozyAppScreen = ({
           )
         }
 
-        <CozyProxyWebView
+        <CozyAppWebView
           style={webViewStyle}
           slug={route.params.slug}
           href={route.params.href}

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -11,7 +11,7 @@ import { useNativeIntent } from 'cozy-intent'
 
 import { AppState } from 'react-native'
 
-import { CozyProxyWebView } from '/components/webviews/CozyProxyWebView'
+import { CozyAppWebView } from '/components/webviews/ComposedWebView'
 import {
   consumeRouteParameter,
   useInitialParam
@@ -244,7 +244,7 @@ const HomeView = ({ route, navigation, setLauncherContext, setBarStyle }) => {
   }
 
   return uri && shouldWaitCozyApp !== undefined && !shouldWaitCozyApp ? (
-    <CozyProxyWebView
+    <CozyAppWebView
       setParentRef={setParentRef}
       slug="home"
       href={uri}


### PR DESCRIPTION
This PR is a proposal for a refactoring on our WebView management.

What I'm waiting from you are some feedback on the proposal, if you think is a good idea or not. I'm currently stuck on the implementation and I don't want to invest more time until I'm sure it is the good direction.

### Problem

Today our codebase structure is the following:
```
HomeView
└ CozyProxyWebView
   └ CozyWebView
      └ ReloadInterceptorWebView
         └ SupervisedWebView
```

Each WebView component has a hard-coded reference to its WebView child (i.e `CozyWebView` defines that its child is a `ReloadInterceptorWebView`)

This makes difficult to add a layer to the WebView's tree, or to invert some of them in the hierarchy.

Imagine that we want to add a `ReloadableWebView` that embed ALL of our webviews and allows to unmount/remount everything when we want a reload (so we enforce the proxywebview to generate a new HTML)

To make this we would have to edit `HomeView` to use a `ReloadableWebView` instead of `CozyProxyWebView`, to hard code `ReloadableWebView` with `CozyProxyWebView` as child, and then we should remember to search for all other `CozyProxyWebView` references in the code and replace `CozyProxyWebView` by `ReloadableWebView` like we did in `HomeView`

Here would be the new codebase structure
```
HomeView
└ ReloadableWebView
  └ CozyProxyWebView
     └ CozyWebView
        └ ReloadInterceptorWebView
           └ SupervisedWebView
```

So my question is `How can we make this more flexible?`

### Proposal

My proposal is to create a `ComposedWebView` that would allow developers to "compose" their WebView like they want.

The API would be like this:
```js
return (
  <ComposedWebView
      {...props}
      childrenTypes={[
        CozyProxyWebView,
        CozyWebView,
        ReloadInterceptorWebView,
        SupervisedWebView
      ]}
    />
)
```

Which would be translated on runtime as the following
```
CozyProxyWebView
└ CozyWebView
   └ ReloadInterceptorWebView
      └ SupervisedWebView
```

This would allow to easily add/remove parts. If we want to remove the `ReloadInterceptorWebView` from the generated tree then we can do:
```js
return (
  <ComposedWebView
      {...props}
      childrenTypes={[
        CozyProxyWebView,
        CozyWebView,
        //ReloadInterceptorWebView,
        SupervisedWebView
      ]}
    />
)
```

If we want to add a `ReloadableWebView` on the top level then we can do:
```js
return (
  <ComposedWebView
      {...props}
      childrenTypes={[
        ReloadableWebView,
        CozyProxyWebView,
        CozyWebView,
        ReloadInterceptorWebView,
        SupervisedWebView
      ]}
    />
)
```

### Work in progress

This PR is a draft implementation for this concept.

`src/components/webviews/ComposedWebView.js` contains the logic that translates the flat declaration into a nested WebView tree on runtime.

This would have some repercussions on the way we create WebViews:
- WebView components must be wrapped in a `forwardRef`
- WebView components must take a `ChildWebview` prop defaulted to `WebView` and use it as their child
- All WebView methods like `onShouldStartLoadWithRequest` should consider they can have a parent and call it if exists
  - Example:
```js
<ChildWebView
  onShouldStartLoadWithRequest={(initialRequest) => {
    if (/* some condition */) {
      // do stuff
      return false
    }

    if (props.onShouldStartLoadWithRequest) {
      return props.onShouldStartLoadWithRequest(initialRequest)
    }  else {
      return true
    }
  }}
/>
```

⚠️ Current implementation is not complete and has some issues:
- ReloadInterceptorWebView gets nodeHandle errors
  - but if we remove it from the tree then everything seems to work
- CozyAppScreen will do an infinite loop
  - however HomeView seems to work correctly