### PR TITLE
feat: Add job_id in konnector log when possible

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -91,8 +91,12 @@ class ReactNativeLauncher extends Launcher {
    */
   log(logContent) {
     const context = this.getStartContext()
-    const slug = context.konnector.slug // konnector is available before manifest
-    this.logger({ ...logContent, slug })
+    const slug = context.konnector.slug // konnector attribut is available before manifest one
+    let jobId
+    if (context.job) {
+      jobId = context.job.id
+    }
+    this.logger({ ...logContent, slug, jobId })
   }
 
   async init({ bridgeOptions, contentScript }) {

--- a/src/redux/KonnectorState/KonnectorLogsSlice.ts
+++ b/src/redux/KonnectorState/KonnectorLogsSlice.ts
@@ -7,7 +7,10 @@ export interface LogObj {
   timestamp: string
   level: string
   slug: string
+  jobId: string
 }
+
+export type LogObjWithoutSlug = Omit<LogObj, 'slug'>
 
 type LogDict = Record<string, LogObj[] | undefined>
 


### PR DESCRIPTION
When possible, we add job_id to konnectors log send to the stack.
The job is only created after the ensureAuthentificated function so, only log after that will be tagged by job_ib




* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Localized in English and French
* [x] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

