### PR TITLE
Fix icon feat splashscreen issues

### DIFF
--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -56,7 +56,8 @@ jest.mock('@react-native-cookies/cookies', () => {
 
 jest.mock('react-native-bootsplash', () => ({
   hide: jest.fn(),
-  show: jest.fn()
+  show: jest.fn(),
+  getVisibilityStatus: jest.fn()
 }))
 
 jest.mock('react-native-idle-timer', () => ({

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -366,7 +366,7 @@ PODS:
   - react-native-gzip (2.0.0):
     - NVHTarGzip
     - React
-  - react-native-keep-awake (1.1.0):
+  - react-native-idle-timer (2.2.1):
     - React-Core
   - react-native-netinfo (9.3.7):
     - React-Core
@@ -535,7 +535,7 @@ DEPENDENCIES:
   - react-native-document-scanner-plugin (from `../node_modules/react-native-document-scanner-plugin`)
   - react-native-flipper (from `../node_modules/react-native-flipper`)
   - "react-native-gzip (from `../node_modules/@fengweichong/react-native-gzip`)"
-  - "react-native-keep-awake (from `../node_modules/@sayem314/react-native-keep-awake`)"
+  - react-native-idle-timer (from `../node_modules/react-native-idle-timer`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -648,8 +648,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-flipper"
   react-native-gzip:
     :path: "../node_modules/@fengweichong/react-native-gzip"
-  react-native-keep-awake:
-    :path: "../node_modules/@sayem314/react-native-keep-awake"
+  react-native-idle-timer:
+    :path: "../node_modules/react-native-idle-timer"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
@@ -762,7 +762,7 @@ SPEC CHECKSUMS:
   react-native-document-scanner-plugin: df5b82df67ff612262c40c26ef2c8239c5af5c55
   react-native-flipper: 4bfe0a324e663f1ae2f76ad0da75673de6895efe
   react-native-gzip: 5ffb84bf191c7cd135338eca748317bc466d41a1
-  react-native-keep-awake: acbee258db16483744910f0da3ace39eb9ab47fd
+  react-native-idle-timer: f1920a59fe776340d004ff9de13c4a6eedcc8807
   react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-webview: 8ec7ddf9eb4ddcd92b32cee7907efec19a9ec7cb

--- a/src/app/theme/SplashScreenService.ts
+++ b/src/app/theme/SplashScreenService.ts
@@ -1,4 +1,4 @@
-import RNBootSplash from 'react-native-bootsplash'
+import RNBootSplash, { VisibilityStatus } from 'react-native-bootsplash'
 
 import { resetUIState } from '/libs/intents/setFlagshipUI'
 import { navigationRef } from '/libs/RootNavigation'
@@ -28,4 +28,8 @@ export const hideSplashScreen = (): Promise<void> => {
   }
 
   return RNBootSplash.hide({ fade: true })
+}
+
+export const getSplashScreenStatus = (): Promise<VisibilityStatus> => {
+  return RNBootSplash.getVisibilityStatus()
 }

--- a/src/libs/icon/icon.spec.ts
+++ b/src/libs/icon/icon.spec.ts
@@ -1,3 +1,4 @@
+import { getVisibilityStatus } from 'react-native-bootsplash'
 import { changeIcon as RNChangeIcon } from 'react-native-change-icon'
 
 import flag from 'cozy-flags'
@@ -8,6 +9,9 @@ jest.mock('react-native-change-icon')
 jest.mock('cozy-flags')
 
 const mockFlag = flag as jest.MockedFunction<typeof flag>
+const mockGetVisibilityStatus = getVisibilityStatus as jest.MockedFunction<
+  typeof getVisibilityStatus
+>
 
 const mockedRNChangeIcon = RNChangeIcon as jest.MockedFunction<
   typeof RNChangeIcon
@@ -29,6 +33,12 @@ const ICON_CHANGE_UNDEFINED_FLAGS = {
 type Flags = Record<string, boolean | string>
 
 describe('icon', () => {
+  beforeEach(() => {
+    mockFlag.mockReset()
+    mockedRNChangeIcon.mockReset()
+    mockGetVisibilityStatus.mockResolvedValue('hidden')
+  })
+
   const mockFlags = (flags: Flags): void => {
     // @ts-expect-error flag is not correctly typed for the moment
     mockFlag.mockImplementation(flagName => {
@@ -51,6 +61,7 @@ describe('icon', () => {
   })
 
   it('should not throw if icon already used error', async () => {
+    mockFlags(ICON_CHANGE_ALLOWED_FLAGS)
     mockedRNChangeIcon.mockImplementation(() => {
       throw new Error('ICON_ALREADY_USED')
     })
@@ -59,6 +70,7 @@ describe('icon', () => {
   })
 
   it('should throw if other error', async () => {
+    mockFlags(ICON_CHANGE_ALLOWED_FLAGS)
     mockedRNChangeIcon.mockImplementation(() => {
       throw new Error('ICON_INVALID')
     })

--- a/src/libs/icon/icon.ts
+++ b/src/libs/icon/icon.ts
@@ -6,6 +6,7 @@ import {
 
 import flag from 'cozy-flags'
 
+import { getSplashScreenStatus } from '/app/theme/SplashScreenService'
 import { toggleIconChangedModal } from '/libs/icon/IconChangedModal'
 
 import { DEFAULT_ICON, ALLOWED_ICONS, DEFAULT_VALUE } from './config'
@@ -20,6 +21,19 @@ const isSameIcon = (firstIconName: string, secondIconName: string): boolean => {
 }
 
 export const changeIcon = async (slug: string): Promise<void> => {
+  // Changing icon and using splash screen do not work well together.
+  // If we call hideSplashScreen when iOS native popup "Icon has changed" is displayed,
+  // hideSplashScreen hides iOS native popup instead of splash screen. So here we avoid
+  // to call changeIcon when splash screen is displayed.
+  const status = await getSplashScreenStatus()
+  if (status === 'visible') {
+    setTimeout(() => {
+      void changeIcon(slug)
+    }, 1000)
+
+    return
+  }
+
   const changeAllowed = flag('flagship.icon.changeAllowed')
   const defaultIcon =
     (flag('flagship.icon.defaultIcon') as unknown as string) || DEFAULT_ICON

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -242,6 +242,8 @@ const LoginSteps = ({
         }))
       } else {
         showSplashScreen()
+        await result.client.registerPlugin(flag.plugin)
+        await result.client.plugins.flags.initializing
         setClient(result.client)
       }
     } catch (error) {
@@ -289,6 +291,8 @@ const LoginSteps = ({
           }))
         } else {
           showSplashScreen()
+          await result.client.registerPlugin(flag.plugin)
+          await result.client.plugins.flags.initializing
           setClient(result.client)
         }
       } catch (error) {


### PR DESCRIPTION
 **fix: Flags were not fetched at login with oidc and magic link**

Solve icon not changing at first login with oidc and magic link.

 **fix: Splash screen does not hide when icon has changed on iOS**

Changing icon and using splash screen do not work well together. If
we call hideSplashScreen when iOS native popup "Icon has changed" is
displayed, hideSplashScreen hides iOS native popup instead of splash
screen. So here we avoid to call changeIcon when splash screen is
displayed.