### PR TITLE
feat: Add more context to konnector execution

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -5,7 +5,7 @@ import { getBuildId, getVersion } from 'react-native-device-info'
 
 // @ts-ignore
 import flag from 'cozy-flags'
-import { Q, models } from 'cozy-client'
+import { Q, QueryDefinition, models } from 'cozy-client'
 import { saveFiles, saveBills, saveIdentity } from 'cozy-clisk'
 
 import { cleanExistingAccountsForKonnector } from './Launcher.functions'
@@ -494,6 +494,25 @@ export default class Launcher {
     log.debug(result, 'saveFiles result')
 
     return result
+  }
+
+  /**
+   * Fetch all documents according to given query definition
+   *
+   * @param {import('cozy-client').QueryDefinition} queryDefinition - object which can be passed to QueryDefinition constructor
+   * @param {import('cozy-client/types/types').QueryOptions} options - query options
+   * @returns {Promise<import('cozy-client/types/types').QueryResult>} - query result
+   */
+  async queryAll(queryDefinition, options) {
+    const { launcherClient: client } = this.getStartContext() || {}
+
+    // undefined is converted to null in post-me interface and null
+    // is not supported by cozy-client
+    const queryOption = options === null ? undefined : options
+    return await client.queryAll(
+      new QueryDefinition(queryDefinition),
+      queryOption
+    )
   }
 
   /**

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -567,36 +567,6 @@ export default class Launcher {
       }
     }
   }
-
-  /**
-   * Fetches data already imported by the konnector with the current sourceAccountIdentifier
-   * This allows the konnector to only fetch new data
-   *
-   * @param {object} options                         - options object
-   * @param {String} options.sourceAccountIdentifier - current account unique identifier
-   * @param {String} options.slug - konnector slug
-   * @returns {Promise<Object>}
-   */
-  async getPilotContext({ sourceAccountIdentifier, slug }) {
-    const { launcherClient: client } = this.getStartContext()
-    const result = await client.queryAll(
-      Q('io.cozy.files')
-        .where({
-          trashed: false,
-          cozyMetadata: {
-            sourceAccountIdentifier,
-            createdByApp: slug
-          }
-        })
-        .indexFields([
-          'trashed',
-          'cozyMetadata.sourceAccountIdentifier',
-          'cozyMetadata.createdByApp'
-        ])
-    )
-
-    return result
-  }
 }
 
 /**

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -229,7 +229,7 @@ class ReactNativeLauncher extends Launcher {
 
   async _start({ initKonnectorError } = {}) {
     activateKeepAwake('clisk')
-    const { account, konnector } = this.getStartContext()
+    const { account: prevAccount, konnector } = this.getStartContext()
     try {
       if (initKonnectorError) {
         log.info('Got initKonnectorError ' + initKonnectorError.message)
@@ -253,7 +253,7 @@ class ReactNativeLauncher extends Launcher {
           await this.pilot.call('ensureNotAuthenticated')
         }
       }
-      await this.pilot.call('ensureAuthenticated', { account })
+      await this.pilot.call('ensureAuthenticated', { account: prevAccount })
 
       this.setUserData(await this.pilot.call('getUserDataFromWebsite'))
 
@@ -268,12 +268,16 @@ class ReactNativeLauncher extends Launcher {
 
       launcherEvent.emit('loginSuccess', ensureResult.createdAccount?._id)
 
-      const pilotContext = []
-      // FIXME not used at the moment since the fetched file will not have the proper "createdByApp"
-      // const pilotContext = await this.getPilotContext({
-      //   sourceAccountIdentifier: userData.sourceAccountIdentifier,
-      //   slug: manifest.slug,
-      // })
+      const { account, trigger, job, manifest } = this.getStartContext()
+      const { sourceAccountIdentifier } = this.getUserData()
+
+      const pilotContext = {
+        manifest,
+        account,
+        trigger,
+        job,
+        sourceAccountIdentifier
+      }
       await this.pilot.call('fetch', pilotContext)
       await this.stop()
     } catch (err) {

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -61,6 +61,7 @@ class ReactNativeLauncher extends Launcher {
     })
 
     this.getExistingFilesIndex = wrapTimer(this, 'getExistingFilesIndex')
+    this.queryAll = wrapTimer(this, 'queryAll')
     this.init = wrapTimer(this, 'init', {
       displayName: 'pilot and worker init'
     })
@@ -116,6 +117,7 @@ class ReactNativeLauncher extends Launcher {
           'saveFiles',
           'saveBills',
           'saveIdentity',
+          'queryAll',
           'setUserAgent',
           'getCredentials',
           'saveCredentials',

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -189,11 +189,13 @@ describe('ReactNativeLauncher', () => {
     })
     it('should work normaly in nominal case', async () => {
       const { launcher, client, launch } = setup()
+      const konnector = { slug: 'konnectorslug', clientSide: true }
       launcher.setStartContext({
         client,
         account: fixtures.account,
         trigger: fixtures.trigger,
-        konnector: { slug: 'konnectorslug', clientSide: true },
+        konnector,
+        manifest: konnector,
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -263,7 +265,18 @@ describe('ReactNativeLauncher', () => {
         3,
         'getUserDataFromWebsite'
       )
-      expect(launcher.pilot.call).toHaveBeenNthCalledWith(4, 'fetch', [])
+      expect(launcher.pilot.call).toHaveBeenNthCalledWith(4, 'fetch', {
+        account: {
+          ...fixtures.account,
+          auth: { accountName: 'testsourceaccountidentifier' }
+        },
+        trigger: fixtures.trigger,
+        job: {
+          _id: 'normal_job_id'
+        },
+        sourceAccountIdentifier: 'testsourceaccountidentifier',
+        manifest: konnector
+      })
       expect(launcher.pilot.call).not.toHaveBeenCalledWith(
         'ensureNotAuthenticated'
       )

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -253,7 +253,7 @@ class LauncherView extends Component {
                 ref={ref => (this.pilotWebView = ref)}
                 originWhitelist={['*']}
                 source={{
-                  uri: get(this, 'state.konnector.manifest.vendor_link')
+                  uri: 'about:blank'
                 }}
                 useWebKit={true}
                 javaScriptEnabled={true}


### PR DESCRIPTION
- expose the `queryAll` method from the launcher to the konnector
- add current account, trigger, manifest, job, sourceAccountIdentifier to the context given to the `fetch` method.

Linked to https://github.com/konnectors/libs/pull/952 for the cozy-clisk side

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

