### PR TITLE
feat: save oauthName on app bootstrap if needed

### DIFF
--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -23,6 +23,7 @@ declare module 'cozy-client' {
 
   interface OAuthOptions {
     clientID: string
+    clientName: string
     clientSecret: string
   }
 
@@ -81,6 +82,7 @@ declare module 'cozy-client' {
     setPassphraseFlagship: (
       params: SetPassphraseFlagshipParams
     ) => Promise<SetPassphraseFlagshipResult>
+    updateInformation: (options: OAuthOptions) => Promise<OAuthOptions>
   }
 
   interface InstanceOptions {

--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ import { useGlobalAppState } from '/hooks/useGlobalAppState'
 import { useCookieResyncOnResume } from '/hooks/useCookieResyncOnResume'
 import { useCozyEnvironmentOverride } from '/hooks/useCozyEnvironmentOverride'
 import { useNotifications } from '/hooks/useNotifications'
+import { useSynchronizeOnInit } from '/hooks/useSynchronizeOnInit'
 import { useNetService } from '/libs/services/NetService'
 import { withSentry } from '/libs/monitoring/Sentry'
 import { ThemeProvider } from '/app/theme/ThemeProvider'
@@ -45,6 +46,7 @@ if (!global.atob) {
 const App = ({ setClient }) => {
   const client = useClient()
 
+  useSynchronizeOnInit()
   useNetService(client)
 
   const { initialRoute, isLoading } = useAppBootstrap(client)

--- a/src/app/domain/authentication/services/SynchronizeService.spec.ts
+++ b/src/app/domain/authentication/services/SynchronizeService.spec.ts
@@ -1,29 +1,164 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import CozyClient from 'cozy-client'
 
-import { synchronizeDevice } from '/app/domain/authentication/services/SynchronizeService'
+import * as SynchronizeService from '/app/domain/authentication/services/SynchronizeService'
+
+const {
+  checkClientName,
+  getClientName,
+  syncLog,
+  synchronizeDevice,
+  synchronizeOnInit
+} = SynchronizeService
 
 jest.mock('cozy-client')
 
 describe('SynchronizeService', () => {
   let client: CozyClient
+  let syncLogInfoSpy: jest.SpyInstance
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
 
   beforeEach(() => {
     client = new CozyClient()
+    syncLogInfoSpy = jest.spyOn(syncLog, 'info')
   })
 
   it('should synchronize device successfully', async () => {
-    // Mock the client response for successful synchronization
     client.getStackClient = jest.fn().mockReturnValue({
       fetchJSON: jest.fn().mockResolvedValue({})
     })
 
     await synchronizeDevice(client)
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(client.getStackClient).toHaveBeenCalled()
     expect(client.getStackClient().fetchJSON).toHaveBeenCalledWith(
       'POST',
       '/settings/synchronized'
     )
+  })
+
+  it("should update the client name if it doesn't start with the software name", async () => {
+    const mockResponse = {
+      data: {
+        foo: 'bar'
+      }
+    }
+
+    client.getStackClient = jest.fn().mockReturnValue({
+      oauthOptions: { clientName: 'wrongName' },
+      updateInformation: jest.fn().mockResolvedValue(mockResponse)
+    })
+
+    await checkClientName(client)
+
+    expect(client.getStackClient).toHaveBeenCalled()
+    expect(client.getStackClient().updateInformation).toHaveBeenCalledWith({
+      clientName: await getClientName()
+    })
+    expect(syncLogInfoSpy).toHaveBeenNthCalledWith(
+      1,
+      'Updating client name...',
+      { oldClientName: 'wrongName' }
+    )
+    expect(syncLogInfoSpy).toHaveBeenNthCalledWith(
+      2,
+      `Client name updated with "${await getClientName()}"`,
+      { OAuthOptions: { data: mockResponse.data } }
+    )
+  })
+
+  it('should not update the client name if it starts with the software name', async () => {
+    client.getStackClient = jest.fn().mockReturnValue({
+      oauthOptions: { clientName: await getClientName() },
+      updateInformation: jest.fn().mockResolvedValue({})
+    })
+
+    await checkClientName(client)
+
+    expect(client.getStackClient).toHaveBeenCalled()
+    expect(client.getStackClient().updateInformation).not.toHaveBeenCalled()
+  })
+
+  it('should log an error if updating the client name fails', async () => {
+    const mockError = new Error('update failed')
+
+    syncLog.error = jest.fn()
+
+    client.getStackClient = jest.fn().mockReturnValue({
+      oauthOptions: { clientName: 'wrongName' },
+      updateInformation: jest.fn().mockRejectedValueOnce(mockError)
+    })
+
+    await checkClientName(client)
+
+    expect(client.getStackClient().updateInformation).toHaveBeenCalled()
+    expect(syncLog.error).toHaveBeenCalledWith(
+      'Failed to update clientName',
+      mockError.message
+    )
+  })
+
+  it('should call synchronizeDevice after checkClientName has resolved in synchronizeOnInit', async () => {
+    jest.useRealTimers()
+
+    client.getStackClient = jest.fn().mockReturnValue({
+      oauthOptions: { clientName: 'wrongName' },
+      updateInformation: jest.fn().mockResolvedValueOnce({})
+    })
+
+    const checkClientNameSpy = jest
+      .spyOn(SynchronizeService, 'checkClientName')
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            setTimeout(() => resolve(), 0)
+          })
+      )
+
+    const synchronizeDeviceSpy = jest
+      .spyOn(SynchronizeService, 'synchronizeDevice')
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            setTimeout(() => resolve(), 0)
+          })
+      )
+
+    const synchronizeOnInitPromise =
+      SynchronizeService.synchronizeOnInit(client)
+
+    await synchronizeOnInitPromise
+
+    const checkClientNameOrder = checkClientNameSpy.mock.invocationCallOrder[0]
+    const synchronizeDeviceOrder =
+      synchronizeDeviceSpy.mock.invocationCallOrder[0]
+
+    expect(checkClientNameSpy).toHaveBeenCalledTimes(1)
+    expect(synchronizeDeviceSpy).toHaveBeenCalledTimes(1)
+    expect(checkClientNameOrder).toBeLessThan(synchronizeDeviceOrder)
+
+    checkClientNameSpy.mockRestore()
+    synchronizeDeviceSpy.mockRestore()
+  })
+
+  it('should call synchronizeDevice even when checkClientName throws in synchronizeOnInit', async () => {
+    const mockError = new Error('update failed')
+
+    client.getStackClient = jest.fn().mockReturnValue({
+      oauthOptions: { clientName: 'wrongName' },
+      updateInformation: jest.fn().mockRejectedValueOnce(mockError)
+    })
+
+    const spy = jest
+      .spyOn(SynchronizeService, 'synchronizeDevice')
+      .mockImplementation(() => Promise.resolve())
+
+    await synchronizeOnInit(client)
+
+    expect(spy).toBeCalledWith(client)
+    spy.mockRestore()
   })
 })

--- a/src/app/domain/authentication/services/SynchronizeService.ts
+++ b/src/app/domain/authentication/services/SynchronizeService.ts
@@ -1,14 +1,55 @@
 import Minilog from '@cozy/minilog'
+import { getDeviceName } from 'react-native-device-info'
 
 import type CozyClient from 'cozy-client'
+import { getErrorMessage } from 'cozy-intent'
 
-const log = Minilog('SynchronizeService')
+import { SOFTWARE_NAME } from '/libs/constants'
+import { saveClient } from '/libs/clientHelpers/persistClient'
+
+export const syncLog = Minilog('📱 SynchronizeService')
 
 export const synchronizeDevice = async (client: CozyClient): Promise<void> => {
   try {
     await client.getStackClient().fetchJSON('POST', '/settings/synchronized')
-    log.info('📱 Device synchronized')
+    syncLog.info('Device synchronized')
   } catch (error) {
-    log.warn('Error while synchronizing device', error)
+    syncLog.warn('Error while synchronizing device', error)
   }
+}
+
+export const getClientName = async (): Promise<string> =>
+  `${SOFTWARE_NAME} (${await getDeviceName()})`
+
+export const checkClientName = async (client: CozyClient): Promise<void> => {
+  try {
+    const { clientName, ...oauthOptions } = client.getStackClient().oauthOptions
+    const newClientName = await getClientName()
+
+    if (!clientName.startsWith(newClientName)) {
+      syncLog.info(`Updating client name...`, {
+        oldClientName: clientName
+      })
+
+      const response = await client.getStackClient().updateInformation({
+        ...oauthOptions,
+        clientName: newClientName
+      })
+
+      await saveClient(client)
+
+      syncLog.info(`Client name updated with "${newClientName}"`, {
+        OAuthOptions: response
+      })
+    } else {
+      syncLog.info(`Client name is up to date: "${clientName}"`)
+    }
+  } catch (error) {
+    syncLog.error('Failed to update clientName', getErrorMessage(error))
+  }
+}
+
+export const synchronizeOnInit = async (client: CozyClient): Promise<void> => {
+  await checkClientName(client)
+  await synchronizeDevice(client)
 }

--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -153,8 +153,6 @@ export const useGlobalAppState = (): void => {
         'useGlobalAppState: subscribing to AppState changes, synchronizing device'
       )
 
-      safePromise(synchronizeDevice)(client)
-
       subscription = AppState.addEventListener('change', e =>
         onStateChange(e, client)
       )

--- a/src/hooks/useSynchronizeOnInit.ts
+++ b/src/hooks/useSynchronizeOnInit.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+
+import { useClient } from 'cozy-client'
+
+import { synchronizeOnInit } from '/app/domain/authentication/services/SynchronizeService'
+import { safePromise } from '/utils/safePromise'
+
+export const useSynchronizeOnInit = (): void => {
+  const client = useClient()
+
+  useEffect(() => {
+    if (client) safePromise(synchronizeOnInit)(client)
+  }, [client])
+}

--- a/src/libs/clientHelpers/createClient.ts
+++ b/src/libs/clientHelpers/createClient.ts
@@ -1,10 +1,9 @@
-import { getDeviceName } from 'react-native-device-info'
-
 import CozyClient from 'cozy-client'
 
 import { androidSafetyNetApiKey } from '/constants/api-keys'
 import strings from '/constants/strings.json'
-import { SOFTWARE_ID, SOFTWARE_NAME } from '/libs/constants'
+import { SOFTWARE_ID } from '/libs/constants'
+import { getClientName } from '/app/domain/authentication/services/SynchronizeService'
 
 import packageJSON from '../../../package.json'
 
@@ -21,7 +20,7 @@ export const createClient = async (instance: string): Promise<CozyClient> => {
       redirectURI: strings.COZY_SCHEME,
       softwareID: SOFTWARE_ID,
       clientKind: 'mobile',
-      clientName: `${SOFTWARE_NAME} (${await getDeviceName()})`,
+      clientName: await getClientName(),
       shouldRequireFlagshipPermissions: true,
       certificationConfig: { androidSafetyNetApiKey }
     },


### PR DESCRIPTION
## Description

This PR introduces a new function `checkClientName` and its corresponding Jest tests. The function checks if a client's name starts with a specific string, defined as `translation.software.name`, and updates the client name on the server if it doesn't. In case of any error during the update, the error message is logged. 

This PR also includes TypeScript interfaces to represent the client response object, and Jest tests to ensure that `checkClientName` works as expected.

## Changes

- Created a new function `checkClientName` that checks a client's name and updates it on the server if necessary.
- Added TypeScript interfaces for the client response object.
- Wrote Jest tests for the `checkClientName` function, including tests for when the client name should be updated, should not be updated, and when an error occurs during update.
- Modified the logger to use `spyOn` for `info` and `error` methods, allowing for better isolation and control in testing.

## Testing

Run `yarn test` to execute the new Jest tests for the `checkClientName` function. All tests should pass, demonstrating that the function works as expected in different scenarios.

## Impact

This new function will help to ensure that all client names adhere to our desired naming convention. The added tests will help prevent regressions in this function in the future.
