### PR TITLE
fix: Clean IconsTable on logout

### DIFF
--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -1,5 +1,4 @@
 {
-  "APPS_ICONS": "@cozy_AmiralAppIcons",
   "BUNDLE_STORAGE_KEY": "@cozy_AmiralAppBundleConfig",
   "COOKIE_STORAGE_KEY": "@cozy_AmiralAppCookieConfig",
   "COZY_SCHEME": "cozy://",

--- a/src/libs/functions/iconTable.spec.ts
+++ b/src/libs/functions/iconTable.spec.ts
@@ -2,15 +2,15 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 
 import CozyClient from 'cozy-client'
 
-import strings from '/constants/strings.json'
 import { expectedTable } from '/tests/fixtures/expected-table'
 import { getApps } from '/tests/fixtures/get-apps'
 import {
-  IconsCache,
   TESTING_ONLY_clearIconTable,
   iconTable,
   manageIconCache
 } from '/libs/functions/iconTable'
+import { getData, StorageKeys, storeData } from '/libs/localStore/storage'
+import type { IconsCache } from '/libs/localStore/storage'
 
 const client = {
   getStackClient: (): { fetchJSON: jest.Mock } => ({
@@ -22,7 +22,7 @@ const client = {
 afterEach(async () => {
   jest.clearAllMocks()
   TESTING_ONLY_clearIconTable()
-  await AsyncStorage.removeItem(strings.APPS_ICONS)
+  await AsyncStorage.removeItem(StorageKeys.IconsTable)
 })
 
 it('works with an empty cache', async () => {
@@ -30,105 +30,87 @@ it('works with an empty cache', async () => {
 
   expect(iconTable).toStrictEqual(expectedTable)
 
-  const item = await AsyncStorage.getItem(strings.APPS_ICONS)
+  const item = await getData<IconsCache>(StorageKeys.IconsTable)
 
   if (!item) throw new Error('No item found in AsyncStorage.')
 
-  const cache = JSON.parse(item) as IconsCache
-
-  expect(cache).toStrictEqual(expectedTable)
+  expect(item).toStrictEqual(expectedTable)
 })
 
 it('works with an incomplete cache', async () => {
-  await AsyncStorage.setItem(
-    strings.APPS_ICONS,
-    JSON.stringify({ store: { version: '1.9.11', xml: '<svg></svg>' } })
-  )
+  await storeData(StorageKeys.IconsTable, {
+    store: { version: '1.9.11', xml: '<svg></svg>' }
+  })
 
   await manageIconCache(client)
 
   expect(iconTable).toStrictEqual(expectedTable)
 
-  const item = await AsyncStorage.getItem(strings.APPS_ICONS)
-
+  const item = await getData<IconsCache>(StorageKeys.IconsTable)
   if (!item) throw new Error('No item found in AsyncStorage.')
 
-  const cache = JSON.parse(item) as IconsCache
-
-  expect(cache).toStrictEqual(expectedTable)
+  expect(item).toStrictEqual(expectedTable)
 })
 
 it('works with a broken cache', async () => {
-  await AsyncStorage.setItem(
-    strings.APPS_ICONS,
-    JSON.stringify({ drive: 'bar' })
-  )
+  // @ts-expect-error Since we want to break stuff
+  await storeData(StorageKeys.IconsTable, { drive: 'bar' })
 
   await manageIconCache(client)
 
   expect(iconTable).toStrictEqual(expectedTable)
 
-  const item = await AsyncStorage.getItem(strings.APPS_ICONS)
+  const item = await getData<IconsCache>(StorageKeys.IconsTable)
 
   if (!item) throw new Error('No item found in AsyncStorage.')
 
-  const cache = JSON.parse(item) as IconsCache
-
-  expect(cache).toStrictEqual(expectedTable)
+  expect(item).toStrictEqual(expectedTable)
 })
 
 it('works with a complete cache', async () => {
-  await AsyncStorage.setItem(strings.APPS_ICONS, JSON.stringify(expectedTable))
+  await storeData(StorageKeys.IconsTable, expectedTable)
 
   await manageIconCache(client)
 
   expect(iconTable).toStrictEqual(expectedTable)
 
-  const item = await AsyncStorage.getItem(strings.APPS_ICONS)
+  const item = await getData<IconsCache>(StorageKeys.IconsTable)
 
   if (!item) throw new Error('No item found in AsyncStorage.')
 
-  const cache = JSON.parse(item) as IconsCache
-
-  expect(cache).toStrictEqual(expectedTable)
+  expect(item).toStrictEqual(expectedTable)
 })
 
 it('works with an obsolete cache', async () => {
-  await AsyncStorage.setItem(
-    strings.APPS_ICONS,
-    JSON.stringify({
-      banks: { version: '0.0.0', xml: '<svg></svg>' },
-      coachco2: { version: '0.0.0', xml: '<svg></svg>' },
-      contacts: { version: '0.0.0', xml: '<svg></svg>' },
-      drive: { version: '0.0.0', xml: '<svg></svg>' },
-      home: { version: '0.0.0', xml: '<svg></svg>' },
-      mespapiers: { version: '0.0.0', xml: '<svg></svg>' },
-      notes: { version: '0.0.0', xml: '<svg></svg>' },
-      passwords: { version: '0.0.0', xml: '<svg></svg>' },
-      photos: { version: '0.0.0', xml: '<svg></svg>' },
-      settings: { version: '0.0.0', xml: '<svg></svg>' },
-      store: { version: '0.0.0', xml: '<svg></svg>' }
-    })
-  )
+  await storeData(StorageKeys.IconsTable, {
+    banks: { version: '0.0.0', xml: '<svg></svg>' },
+    coachco2: { version: '0.0.0', xml: '<svg></svg>' },
+    contacts: { version: '0.0.0', xml: '<svg></svg>' },
+    drive: { version: '0.0.0', xml: '<svg></svg>' },
+    home: { version: '0.0.0', xml: '<svg></svg>' },
+    mespapiers: { version: '0.0.0', xml: '<svg></svg>' },
+    notes: { version: '0.0.0', xml: '<svg></svg>' },
+    passwords: { version: '0.0.0', xml: '<svg></svg>' },
+    photos: { version: '0.0.0', xml: '<svg></svg>' },
+    settings: { version: '0.0.0', xml: '<svg></svg>' },
+    store: { version: '0.0.0', xml: '<svg></svg>' }
+  })
 
   await manageIconCache(client)
 
   expect(iconTable).toStrictEqual(expectedTable)
 
-  const item = await AsyncStorage.getItem(strings.APPS_ICONS)
+  const item = await getData<IconsCache>(StorageKeys.IconsTable)
 
   if (!item) throw new Error('No item found in AsyncStorage.')
 
-  const cache = JSON.parse(item) as IconsCache
-
-  expect(cache).toStrictEqual(expectedTable)
+  expect(item).toStrictEqual(expectedTable)
 })
 
 it('works with unusual semver', async () => {
-  await AsyncStorage.setItem(
-    strings.APPS_ICONS,
-    JSON.stringify({ store: { version: '1.0.0', xml: '<svg></svg>' } })
-  )
+  await storeData(StorageKeys.IconsTable, {
+    store: { version: '1.0.0', xml: '<svg></svg>' }
+  })
 
   const client = {
     getStackClient: (): { fetchJSON: jest.Mock } => ({
@@ -145,40 +127,33 @@ it('works with unusual semver', async () => {
     store: { version: '1.0.0-beta.1', xml: '<svg></svg>' }
   })
 
-  const item = await AsyncStorage.getItem(strings.APPS_ICONS)
+  const item = await getData<IconsCache>(StorageKeys.IconsTable)
 
   if (!item) throw new Error('No item found in AsyncStorage.')
 
-  const cache = JSON.parse(item) as IconsCache
-
-  expect(cache).toStrictEqual({
+  expect(item).toStrictEqual({
     store: { version: '1.0.0-beta.1', xml: '<svg></svg>' }
   })
 })
 
 it('works with an incomplete and obsolete cache', async () => {
-  await AsyncStorage.setItem(
-    strings.APPS_ICONS,
-    JSON.stringify({
-      banks: { version: '0.0.0', xml: '<svg></svg>' },
-      coachco2: { version: '0.0.0', xml: '<svg></svg>' },
-      contacts: { version: '0.0.0', xml: '<svg></svg>' },
-      drive: { version: '0.0.0', xml: '<svg></svg>' },
-      home: { version: '0.0.0', xml: '<svg></svg>' }
-    })
-  )
+  await storeData(StorageKeys.IconsTable, {
+    banks: { version: '0.0.0', xml: '<svg></svg>' },
+    coachco2: { version: '0.0.0', xml: '<svg></svg>' },
+    contacts: { version: '0.0.0', xml: '<svg></svg>' },
+    drive: { version: '0.0.0', xml: '<svg></svg>' },
+    home: { version: '0.0.0', xml: '<svg></svg>' }
+  })
 
   await manageIconCache(client)
 
   expect(iconTable).toStrictEqual(expectedTable)
 
-  const item = await AsyncStorage.getItem(strings.APPS_ICONS)
+  const item = await getData<IconsCache>(StorageKeys.IconsTable)
 
   if (!item) throw new Error('No item found in AsyncStorage.')
 
-  const cache = JSON.parse(item) as IconsCache
-
-  expect(cache).toStrictEqual(expectedTable)
+  expect(item).toStrictEqual(expectedTable)
 })
 
 it('works offline or with network issues without cache', async () => {
@@ -192,7 +167,7 @@ it('works offline or with network issues without cache', async () => {
 
   expect(iconTable).toStrictEqual({})
 
-  expect(await AsyncStorage.getItem(strings.APPS_ICONS)).toStrictEqual(null)
+  expect(await getData<IconsCache>(StorageKeys.IconsTable)).toStrictEqual(null)
 })
 
 it('works offline or with network issues with cache', async () => {
@@ -202,10 +177,9 @@ it('works offline or with network issues with cache', async () => {
     })
   } as unknown as CozyClient
 
-  await AsyncStorage.setItem(
-    strings.APPS_ICONS,
-    JSON.stringify({ store: { version: '1.9.11', xml: '<svg></svg>' } })
-  )
+  await storeData(StorageKeys.IconsTable, {
+    store: { version: '1.9.11', xml: '<svg></svg>' }
+  })
 
   await manageIconCache(client)
 
@@ -213,7 +187,7 @@ it('works offline or with network issues with cache', async () => {
     store: { version: '1.9.11', xml: '<svg></svg>' }
   })
 
-  expect(await AsyncStorage.getItem(strings.APPS_ICONS)).toStrictEqual(
-    '{"store":{"version":"1.9.11","xml":"<svg></svg>"}}'
+  expect(await getData<IconsCache>(StorageKeys.IconsTable)).toStrictEqual(
+    JSON.parse('{"store":{"version":"1.9.11","xml":"<svg></svg>"}}')
   )
 })

--- a/src/libs/functions/iconTable.ts
+++ b/src/libs/functions/iconTable.ts
@@ -8,12 +8,11 @@ import strings from '/constants/strings.json'
 import iconFallbackJson from '/assets/iconFallback.json'
 import { clearClient } from '/libs/client'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
-
+import { getData, StorageKeys, storeData } from '/libs/localStore/storage'
+import type { IconsCache } from '/libs/localStore/storage'
 const log = Minilog('Icon Table')
 
 export let iconTable: Record<string, { version: string; xml: string }> = {}
-
-export type IconsCache = Record<string, { version: string; xml: string }>
 
 const setIconTable = (table: IconsCache): void => {
   iconTable = table
@@ -139,8 +138,8 @@ const attemptFetchIcons = async (
 
 const getPersistentIconTable = async (): Promise<IconsCache | null> => {
   try {
-    const table = await AsyncStorage.getItem(strings.APPS_ICONS)
-    return table ? (JSON.parse(table) as IconsCache) : null
+    const table = await getData<IconsCache>(StorageKeys.IconsTable)
+    return table
   } catch (error) {
     log.error(strings.errors.getPersistentIconTable, error)
     return null
@@ -151,7 +150,7 @@ const setPersistentIconTable = async (table: IconsCache): Promise<void> => {
   try {
     setIconTable(table)
     Object.entries(table).length > 0 &&
-      (await AsyncStorage.setItem(strings.APPS_ICONS, JSON.stringify(table)))
+      (await storeData(StorageKeys.IconsTable, table))
   } catch (error) {
     log.error(strings.errors.setPersistentIconTable, error)
   }
@@ -159,7 +158,7 @@ const setPersistentIconTable = async (table: IconsCache): Promise<void> => {
 
 const clearPersistentIconTable = async (): Promise<void> => {
   try {
-    await AsyncStorage.removeItem(strings.APPS_ICONS)
+    await AsyncStorage.removeItem(StorageKeys.IconsTable)
   } catch (error) {
     log.error(strings.errors.clearPersistentIconTable, error)
   }

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -2,24 +2,26 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { BiometryType } from 'react-native-biometrics'
 
 import { logger } from '/libs/functions/logger'
-
 const log = logger('storage.ts')
 
 const { setItem, getItem, removeItem } = AsyncStorage
-
 export enum StorageKeys {
   AutoLockEnabled = '@cozy_AmiralApp_autoLockEnabled',
   BiometryActivated = '@cozy_AmiralApp_biometryActivated',
   Capabilities = '@cozy_AmiralApp_Capabilities',
   LastActivity = '@cozy_AmiralApp_lastActivity',
   DefaultRedirectionUrl = '@cozy_AmiralAppDefaultRedirectionUrl',
-  SessionCreatedFlag = 'SESSION_CREATED_FLAG'
+  SessionCreatedFlag = 'SESSION_CREATED_FLAG',
+  IconsTable = '@cozy_AmiralAppIcons'
 }
 
-interface StorageItems {
+export type IconsCache = Record<string, { version: string; xml: string }>
+
+export interface StorageItems {
   biometryActivated: boolean
   biometryType?: BiometryType
   sessionCreatedFlag: string
+  iconCache: IconsCache
 }
 
 export const storeData = async (


### PR DESCRIPTION
We can have different icons for the same slug depending on the context of your cozy.

So instead of serving the wrong one, let's clean this data on logout.


fix: Display the right Mes Papiers icons when switching between cozies.

