### PR TITLE
feat: Add blockWorkerInteraction command support

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -144,27 +144,6 @@ export default class Launcher {
   }
 
   /**
-   * Injects credentials found in io.cozy.test.credentials/slug document in
-   * the "value" attribute. Only for testing purpose. Needs to have
-   * test.flagship.clisk.credentials.injecter flag set to true.
-   * Credentientials are then removed from io.cozy.test.credentials/current.
-   *
-   * @returns {Promise<void>}
-   */
-  async injectCredentials() {
-    const { client, account, konnector } = this.getStartContext()
-    if (!flag('test.flagship.clisk.credentials.injecter') || !account) return
-
-    const { data: credentialsToInject } = await client.query(
-      Q('io.cozy.test.credentials').getById(konnector.slug)
-    )
-    if (credentialsToInject) {
-      await this.saveCredentials(credentialsToInject.value)
-      await client.destroy(credentialsToInject)
-    }
-  }
-
-  /**
    * Remove any existing credential for the current context
    *
    * @returns {Promise<void>}

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -112,6 +112,8 @@ class ReactNativeLauncher extends Launcher {
         contentScript,
         exposedMethodsNames: [
           'setWorkerState',
+          'blockWorkerInteractions',
+          'unblockWorkerInteractions',
           'runInWorker',
           'saveFiles',
           'saveBills',
@@ -323,6 +325,14 @@ class ReactNativeLauncher extends Launcher {
       }, options?.timeout || SET_WORKER_STATE_TIMEOUT_MS)
       this.emit('SET_WORKER_STATE', options)
     })
+  }
+
+  async blockWorkerInteractions() {
+    this.emit('BLOCK_WORKER_INTERACTIONS')
+  }
+
+  async unblockWorkerInteractions() {
+    this.emit('UNBLOCK_WORKER_INTERACTIONS')
   }
 
   /**

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -38,7 +38,7 @@ const HEADER_PADDING_BOTTOM = 8
 const HEADER_LINE_HEIGHT = 16
 const TOUCHABLE_VERTICAL_PADDING = 8
 
-class LauncherView extends Component {
+export class LauncherView extends Component {
   constructor(props) {
     super(props)
     this.onPilotMessage = this.onPilotMessage.bind(this)
@@ -157,7 +157,7 @@ class LauncherView extends Component {
   }
 
   async componentDidMount() {
-    this.launcher = new ReactNativeLauncher()
+    this.launcher = this.props.launcher || new ReactNativeLauncher()
     // made to measure the time between the launcher initialization and the display of the worker webview (when needed)
     // this is not await not to block the initialization of the launcher
     this.launcher.waitForWorkerVisible(() =>
@@ -265,7 +265,7 @@ class LauncherView extends Component {
                 injectedJavaScriptBeforeContentLoaded={run}
               />
             </View>
-            <View style={workerStyle}>
+            <View testID="workerView" style={workerStyle}>
               <View style={styles.headerStyle}>
                 <TouchableOpacity
                   activeOpacity={0.5}
@@ -299,6 +299,7 @@ class LauncherView extends Component {
               />
               {workerVisible && this.state.workerInteractionBlockerVisible ? (
                 <View
+                  testID="workerInteractionBlocker"
                   style={[
                     styles.workerInteractionBlockerStyle,
                     this.DEBUG

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -33,6 +33,10 @@ const log = Minilog('LauncherView')
 
 const colors = getColors()
 const { statusBarHeight } = getDimensions()
+const HEADER_PADDING_TOP = statusBarHeight + 8
+const HEADER_PADDING_BOTTOM = 8
+const HEADER_LINE_HEIGHT = 16
+const TOUCHABLE_VERTICAL_PADDING = 8
 
 class LauncherView extends Component {
   constructor(props) {
@@ -386,26 +390,30 @@ const styles = StyleSheet.create({
     alignContent: 'center',
     backgroundColor: '#fff', // We do not want the default background color of <View /> which is blue in the app
     flexDirection: 'row',
-    paddingBottom: 8,
+    paddingBottom: HEADER_PADDING_BOTTOM,
     paddingHorizontal: 8,
-    paddingTop: statusBarHeight + 8
+    paddingTop: HEADER_PADDING_TOP
   },
   headerTouchableStyle: {
     flexDirection: 'row',
-    paddingVertical: 8,
+    paddingVertical: TOUCHABLE_VERTICAL_PADDING,
     paddingHorizontal: 6
   },
   headerTextStyle: {
     marginLeft: 10,
     fontSize: 13,
     fontFamily: 'Lato-Bold',
-    lineHeight: 16,
+    lineHeight: HEADER_LINE_HEIGHT,
     color: colors.primaryColor
   },
   workerInteractionBlockerStyle: {
     position: 'absolute',
     backgroundColor: 'red',
-    top: statusBarHeight + 48,
+    top:
+      HEADER_PADDING_BOTTOM +
+      HEADER_PADDING_TOP +
+      HEADER_LINE_HEIGHT +
+      TOUCHABLE_VERTICAL_PADDING * 2,
     width: '100%',
     height: '100%',
     opacity: 0.01

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -308,7 +308,14 @@ class LauncherView extends Component {
                 injectedJavaScriptBeforeContentLoaded={run}
               />
               {workerVisible && this.state.workerInteractionBlockerVisible ? (
-                <View style={styles.workerInteractionBlockerStyle} />
+                <View
+                  style={[
+                    styles.workerInteractionBlockerStyle,
+                    this.DEBUG
+                      ? styles.workerInteractionBlockerDebugStyle
+                      : null
+                  ]}
+                />
               ) : null}
             </View>
           </>
@@ -417,6 +424,9 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     opacity: 0.01
+  },
+  workerInteractionBlockerDebugStyle: {
+    opacity: 0.1
   }
 })
 

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -143,16 +143,6 @@ class LauncherView extends Component {
       })
       return new Error('UNKNOWN_ERROR.HANDSHAKE_FAILED')
     }
-
-    try {
-      await this.launcher.injectCredentials()
-    } catch (err) {
-      this.launcher.log({
-        level: 'error',
-        msg: 'launcherView.initKonnector.injectCredentials: ' + err.message
-      })
-      return new Error('UNKNOWN_ERROR.INJECT_CREDENTIALS')
-    }
   }
 
   async componentDidUpdate() {

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -52,7 +52,8 @@ class LauncherView extends Component {
       konnector: null,
       workerInnerUrl: null,
       worker: {},
-      workerKey: 0
+      workerKey: 0,
+      workerInteractionBlockerVisible: false
     }
     this.DEBUG = false
   }
@@ -194,6 +195,13 @@ class LauncherView extends Component {
       })
     })
 
+    this.launcher.on('BLOCK_WORKER_INTERACTIONS', () =>
+      this.setState({ workerInteractionBlockerVisible: true })
+    )
+    this.launcher.on('UNBLOCK_WORKER_INTERACTIONS', () =>
+      this.setState({ workerInteractionBlockerVisible: false })
+    )
+
     this.launcher.on('SET_USER_AGENT', userAgent => {
       this.setState({ userAgent })
     })
@@ -228,10 +236,10 @@ class LauncherView extends Component {
   }
 
   render() {
-    const workerStyle =
-      this.state.worker.visible || this.DEBUG
-        ? styles.workerVisible
-        : styles.workerHidden
+    const workerVisible = this.state.worker.visible || this.DEBUG
+    const workerStyle = workerVisible
+      ? styles.workerVisible
+      : styles.workerHidden
 
     const debug = shouldEnableKonnectorExtensiveLog()
     const run = debug
@@ -295,6 +303,9 @@ class LauncherView extends Component {
                 onError={this.onWorkerError}
                 injectedJavaScriptBeforeContentLoaded={run}
               />
+              {workerVisible && this.state.workerInteractionBlockerVisible ? (
+                <View style={styles.workerInteractionBlockerStyle} />
+              ) : null}
             </View>
           </>
         ) : null}
@@ -390,6 +401,14 @@ const styles = StyleSheet.create({
     fontFamily: 'Lato-Bold',
     lineHeight: 16,
     color: colors.primaryColor
+  },
+  workerInteractionBlockerStyle: {
+    position: 'absolute',
+    backgroundColor: 'red',
+    top: statusBarHeight + 48,
+    width: '100%',
+    height: '100%',
+    opacity: 0.01
   }
 })
 

--- a/src/screens/konnectors/LauncherView.spec.jsx
+++ b/src/screens/konnectors/LauncherView.spec.jsx
@@ -1,0 +1,155 @@
+import { toHaveStyle } from '@testing-library/jest-native'
+import { render, act, waitFor } from '@testing-library/react-native'
+import MicroEE from 'microee'
+import React from 'react'
+
+import { LauncherView } from './LauncherView'
+
+jest.mock('@fengweichong/react-native-gzip', () => {
+  return {}
+})
+
+jest.mock('cozy-client', () => ({
+  withClient: jest.fn().mockReturnValue({})
+}))
+
+jest.mock('/screens/konnectors/core/handleTimeout')
+
+describe('LauncherView', () => {
+  expect.extend({ toHaveStyle })
+  jest.setTimeout(15000)
+  function setup() {
+    const launcherContext = {
+      konnector: {
+        slug: 'testkonnectorslug'
+      }
+    }
+    const setLauncherContext = jest.fn()
+    const launcherClient = {}
+    const client = {}
+    const retry = jest.fn()
+    const onKonnectorJobUpdate = jest.fn()
+    const onKonnectorLog = jest.fn()
+
+    function Launcher() {}
+    MicroEE.mixin(Launcher)
+    const launcher = new Launcher()
+    launcher.waitForWorkerVisible = jest.fn()
+    launcher.setLogger = jest.fn()
+    launcher.start = jest.fn().mockImplementation(() => {
+      return new Promise(resolve => {
+        launcher.on('stop', () => {
+          resolve()
+        })
+      })
+    })
+    launcher.close = jest.fn()
+    launcher.init = jest.fn()
+    launcher.setStartContext = jest.fn()
+    launcher.ensureKonnectorIsInstalled = jest.fn().mockResolvedValue({})
+
+    const root = render(
+      <LauncherView
+        launcher={launcher}
+        client={client}
+        launcherClient={launcherClient}
+        launcherContext={launcherContext}
+        retry={retry}
+        setLauncherContext={setLauncherContext}
+        onKonnectorLog={onKonnectorLog}
+        onKonnectorJobUpdate={onKonnectorJobUpdate}
+      />
+    )
+    return { root, launcher }
+  }
+  it('should hide worker webview by default', async () => {
+    const { root, launcher } = setup()
+
+    await waitFor(
+      () => {
+        expect(root.queryByTestId('workerView')).not.toBe(null)
+      },
+      { timeout: 10000 } // 5s was not enough on travis side. I don't know why
+    )
+    const hiddenStyle = {
+      top: -2000
+    }
+    expect(root.queryByTestId('workerView')).toHaveStyle(hiddenStyle)
+    act(() => {
+      launcher.emit('stop')
+    })
+  })
+
+  it('should show the worker on SET_WORKER_STATE visible event', async () => {
+    const { root, launcher } = setup()
+
+    await waitFor(
+      () => {
+        expect(root.queryByTestId('workerView')).not.toBe(null)
+      },
+      { timeout: 10000 }
+    )
+    const visibleStyle = {
+      height: '100%'
+    }
+    const hiddenStyle = {
+      top: -2000
+    }
+    expect(root.queryByTestId('workerView')).toHaveStyle(hiddenStyle)
+
+    act(() => {
+      launcher.emit('SET_WORKER_STATE', { visible: true })
+    })
+    expect(root.queryByTestId('workerView')).toHaveStyle(visibleStyle)
+    act(() => {
+      launcher.emit('stop')
+    })
+  })
+  it('should show worker interaction blocker on BLOCK_WORKER_INTERACTIONS event', async () => {
+    const { root, launcher } = setup()
+
+    await waitFor(
+      () => {
+        expect(root.queryByTestId('workerView')).not.toBe(null)
+      },
+      { timeout: 10000 }
+    )
+    const visibleStyle = {
+      height: '100%'
+    }
+    act(() => {
+      launcher.emit('SET_WORKER_STATE', { visible: true })
+      launcher.emit('SET_WORKER_STATE', { visible: true })
+    })
+    expect(root.getByTestId('workerView')).toHaveStyle(visibleStyle)
+
+    const workerInteractionBlockBefore = await root.queryByTestId(
+      'workerInteractionBlocker'
+    )
+    expect(workerInteractionBlockBefore).toBe(null)
+
+    act(() => {
+      launcher.emit('BLOCK_WORKER_INTERACTIONS')
+    })
+
+    await waitFor(
+      () => {
+        expect(root.queryByTestId('workerInteractionBlocker')).not.toBe(null)
+      },
+      { timeout: 10000 }
+    )
+
+    act(() => {
+      launcher.emit('UNBLOCK_WORKER_INTERACTIONS')
+    })
+
+    const workerInteractionBlockAfter = root.queryByTestId(
+      'workerInteractionBlocker'
+    )
+    expect(workerInteractionBlockAfter).toBe(null)
+
+    act(() => {
+      launcher.emit('stop')
+    })
+  })
+})


### PR DESCRIPTION
when activated, display a view juste above the worker but not above the "Return to my cozy" link.

See https://github.com/konnectors/libs/pull/953 for the content script side

I had to set the timeout to wait for elements of LauncherView to display to 10s or else the tests would not pass on travis side.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

