### PR TITLE
fix: Don't capitalize password input

### DIFF
--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -114,6 +114,7 @@ const LockView = ({
               returnKeyType="go"
               secureTextEntry={!passwordVisibility}
               value={input}
+              autoCapitalize="none"
             />
           ) : null}
 


### PR DESCRIPTION
We don't want to autocapitalize input password field



