### PR TITLE
fix: Call login, saveClient and listenTokenRefresh on magicLink and OIDC

### DIFF
--- a/src/libs/client.spec.js
+++ b/src/libs/client.spec.js
@@ -23,7 +23,8 @@ const mockCozyClient = {
     setUri: mockSetUri,
     register: mockRegister,
     updateInformation: mockUpdateInformation
-  })
+  }),
+  registerPlugin: jest.fn()
 }
 
 CozyClient.mockImplementation(() => mockCozyClient)

--- a/src/libs/clientHelpers/authorizeClient.ts
+++ b/src/libs/clientHelpers/authorizeClient.ts
@@ -1,10 +1,7 @@
 import type CozyClient from 'cozy-client'
 
 import { queryResultToCrypto } from '/components/webviews/CryptoWebView/cryptoObservable/cryptoObservable'
-import {
-  listenTokenRefresh,
-  saveClient
-} from '/libs/clientHelpers/persistClient'
+import { finalizeClientCreation } from '/libs/clientHelpers/createClient'
 import {
   CozyClientCreationContext,
   STATE_CONNECTED
@@ -52,9 +49,7 @@ export const authorizeClientAndLogin = async ({
 }: AuthorizeClientParams): Promise<CozyClientCreationContext> => {
   await authorizeClient({ client, sessionCode })
 
-  await client.login()
-  await saveClient(client)
-  listenTokenRefresh(client)
+  await finalizeClientCreation(client)
 
   return {
     client: client,

--- a/src/libs/clientHelpers/connectClient.ts
+++ b/src/libs/clientHelpers/connectClient.ts
@@ -1,10 +1,7 @@
 import type CozyClient from 'cozy-client'
 
+import { finalizeClientCreation } from '/libs/clientHelpers/createClient'
 import { loginFlagship } from '/libs/clientHelpers/loginFlagship'
-import {
-  listenTokenRefresh,
-  saveClient
-} from '/libs/clientHelpers/persistClient'
 import {
   CozyClientCreationContext,
   is2faNeededResult,
@@ -79,9 +76,7 @@ export const connectClient = async ({
   const stackClient = client.getStackClient()
   stackClient.setToken(result)
 
-  await client.login()
-  await saveClient(client)
-  listenTokenRefresh(client)
+  await finalizeClientCreation(client)
 
   return {
     client: client,

--- a/src/libs/clientHelpers/createClient.ts
+++ b/src/libs/clientHelpers/createClient.ts
@@ -1,7 +1,12 @@
 import CozyClient from 'cozy-client'
+import flag from 'cozy-flags'
 
 import { androidSafetyNetApiKey } from '/constants/api-keys'
 import strings from '/constants/strings.json'
+import {
+  listenTokenRefresh,
+  saveClient
+} from '/libs/clientHelpers/persistClient'
 import { SOFTWARE_ID } from '/libs/constants'
 import { getClientName } from '/app/domain/authentication/services/SynchronizeService'
 
@@ -31,10 +36,32 @@ export const createClient = async (instance: string): Promise<CozyClient> => {
   }
 
   const client = new CozyClient(options)
+  await registerPlugins(client)
 
   const stackClient = client.getStackClient()
   stackClient.setUri(instance)
   await stackClient.register(instance)
 
   return client
+}
+
+export const finalizeClientCreation = async (
+  client: CozyClient
+): Promise<void> => {
+  await client.login()
+  await saveClient(client)
+  listenTokenRefresh(client)
+
+  await initializePlugins(client)
+}
+
+const registerPlugins = async (client: CozyClient): Promise<void> => {
+  // @ts-expect-error Plugins are not typed yet
+  await client.registerPlugin(flag.plugin, null)
+}
+
+const initializePlugins = async (client: CozyClient): Promise<void> => {
+  // @ts-expect-error Plugins are not typed yet
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  await client.plugins.flags.initializing
 }

--- a/src/libs/clientHelpers/initClient.ts
+++ b/src/libs/clientHelpers/initClient.ts
@@ -2,11 +2,10 @@ import CozyClient from 'cozy-client'
 
 import { authorizeClient } from '/libs/clientHelpers/authorizeClient'
 import { connectClient } from '/libs/clientHelpers/connectClient'
-import { createClient } from '/libs/clientHelpers/createClient'
 import {
-  listenTokenRefresh,
-  saveClient
-} from '/libs/clientHelpers/persistClient'
+  createClient,
+  finalizeClientCreation
+} from '/libs/clientHelpers/createClient'
 import {
   CozyClientCreationContext,
   isAccessToken,
@@ -86,9 +85,7 @@ export const callOnboardingInitClient = async ({
     await authorizeClient({ client, sessionCode: result.session_code })
   }
 
-  await client.login()
-  await saveClient(client)
-  listenTokenRefresh(client)
+  await finalizeClientCreation(client)
 
   return client
 }

--- a/src/libs/clientHelpers/magicLink.ts
+++ b/src/libs/clientHelpers/magicLink.ts
@@ -1,11 +1,10 @@
 import type CozyClient from 'cozy-client'
 
 import { authorizeClient } from '/libs/clientHelpers/authorizeClient'
-import { createClient } from '/libs/clientHelpers/createClient'
 import {
-  listenTokenRefresh,
-  saveClient
-} from '/libs/clientHelpers/persistClient'
+  createClient,
+  finalizeClientCreation
+} from '/libs/clientHelpers/createClient'
 import {
   CozyClientCreationContext,
   is2faNeededResult,
@@ -107,9 +106,7 @@ export const connectMagicLinkClient = async (
   }
 
   stackClient.setToken(result)
-  await client.login()
-  await saveClient(client)
-  listenTokenRefresh(client)
+  await finalizeClientCreation(client)
 
   return {
     client: client,
@@ -150,9 +147,7 @@ export const callMagicLinkOnboardingInitClient = async ({
     await authorizeClient({ client, sessionCode: result.session_code })
   }
 
-  await client.login()
-  await saveClient(client)
-  listenTokenRefresh(client)
+  await finalizeClientCreation(client)
 
   return client
 }

--- a/src/libs/clientHelpers/magicLink.ts
+++ b/src/libs/clientHelpers/magicLink.ts
@@ -107,6 +107,9 @@ export const connectMagicLinkClient = async (
   }
 
   stackClient.setToken(result)
+  await client.login()
+  await saveClient(client)
+  listenTokenRefresh(client)
 
   return {
     client: client,

--- a/src/libs/clientHelpers/oidc.ts
+++ b/src/libs/clientHelpers/oidc.ts
@@ -1,6 +1,10 @@
 import type CozyClient from 'cozy-client'
 
 import {
+  listenTokenRefresh,
+  saveClient
+} from '/libs/clientHelpers/persistClient'
+import {
   CozyClientCreationContext,
   is2faNeededResult,
   is2faPasswordNeededResult,
@@ -105,6 +109,9 @@ export const connectOidcClient = async (
 
   const stackClient = client.getStackClient()
   stackClient.setToken(result)
+  await client.login()
+  await saveClient(client)
+  listenTokenRefresh(client)
 
   return {
     client: client,

--- a/src/libs/clientHelpers/oidc.ts
+++ b/src/libs/clientHelpers/oidc.ts
@@ -1,9 +1,6 @@
 import type CozyClient from 'cozy-client'
 
-import {
-  listenTokenRefresh,
-  saveClient
-} from '/libs/clientHelpers/persistClient'
+import { finalizeClientCreation } from '/libs/clientHelpers/createClient'
 import {
   CozyClientCreationContext,
   is2faNeededResult,
@@ -109,9 +106,8 @@ export const connectOidcClient = async (
 
   const stackClient = client.getStackClient()
   stackClient.setToken(result)
-  await client.login()
-  await saveClient(client)
-  listenTokenRefresh(client)
+
+  await finalizeClientCreation(client)
 
   return {
     client: client,

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -2,8 +2,6 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { BackHandler, StyleSheet, View } from 'react-native'
 import Minilog from '@cozy/minilog'
 
-import flag from 'cozy-flags'
-
 import { ClouderyView } from './components/ClouderyView'
 import { ErrorView } from './components/ErrorView'
 import { OidcOnboardingView } from './components/OidcOnboardingView'
@@ -242,8 +240,6 @@ const LoginSteps = ({
         }))
       } else {
         showSplashScreen()
-        await result.client.registerPlugin(flag.plugin)
-        await result.client.plugins.flags.initializing
         setClient(result.client)
       }
     } catch (error) {
@@ -291,8 +287,6 @@ const LoginSteps = ({
           }))
         } else {
           showSplashScreen()
-          await result.client.registerPlugin(flag.plugin)
-          await result.client.plugins.flags.initializing
           setClient(result.client)
         }
       } catch (error) {
@@ -355,8 +349,6 @@ const LoginSteps = ({
         if (loginData) {
           await resetKeychainAndSaveLoginData(loginData)
         }
-        await result.client.registerPlugin(flag.plugin)
-        await result.client.plugins.flags.initializing
         setClient(result.client)
       }
     } catch (error) {
@@ -411,8 +403,6 @@ const LoginSteps = ({
           if (loginData) {
             await resetKeychainAndSaveLoginData(loginData)
           }
-          await result.client.registerPlugin(flag.plugin)
-          await result.client.plugins.flags.initializing
           setClient(result.client)
         }
       } catch (error) {
@@ -465,8 +455,6 @@ const LoginSteps = ({
           if (loginData) {
             await resetKeychainAndSaveLoginData(loginData)
           }
-          await result.client.registerPlugin(flag.plugin)
-          await result.client.plugins.flags.initializing
           setClient(result.client)
         }
       } catch (error) {
@@ -492,8 +480,6 @@ const LoginSteps = ({
       if (loginData) {
         await resetKeychainAndSaveLoginData(loginData)
       }
-      await result.client.registerPlugin(flag.plugin)
-      await result.client.plugins.flags.initializing
       setClient(result.client)
     } catch (error) {
       if (error === OAUTH_USER_CANCELED_ERROR) {


### PR DESCRIPTION
Those methods were missing from the MagicLink and OIDC login processes

Without them:
- the `client.emit('login', ...)` would never be called and so CozyClient's plugins would not be initialized, which would produce infinite await on `client.plugins.flags.initializing` on LoginScreen
- the client would not be persisted
- the TokenRefresh event wouldn't be handled

This happens only on production environment and on Flagship certified devices. Otherwise, the manual certification workflow would correctly call those methods