### PR TITLE
fix: Upgrade cozy-clisk to 0.20.2 to fix saveIdentity bug 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
     "cozy-client": "^38.6.0",
-    "cozy-clisk": "^0.15.0",
+    "cozy-clisk": "^0.20.2",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
     "cozy-intent": "^2.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6353,17 +6353,17 @@ cozy-client@^38.6.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-clisk@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.15.0.tgz#4223aa36c09a75461bd493e5f643824f6a4ea175"
-  integrity sha512-7eqiT+4MDkFH6aIVrX/O0srgEnPZ7BmXrOm2YDoDohL/96hypO6mctgXyE4xFBrLeF+GlI+oi5RfWssltFHTNw==
+cozy-clisk@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.20.2.tgz#4508b4f98efc51ddca7845f0c3208540fdef3aba"
+  integrity sha512-T2sEmogtrShPDgSnJIB7yDluKkgd4G2yW4Ky1V1BcCs60vnes+gPOQ+lgQTpV0psl9A2h7IUICAOYqC0S3JJtA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     bluebird-retry "^0.11.0"
     cozy-client "^34.11.0"
     ky "^0.25.1"
     lodash "^4.17.21"
-    p-wait-for "^5.0.1"
+    p-wait-for "^5.0.2"
     post-me "^0.4.5"
 
 cozy-device-helper@^2.7.0:
@@ -12753,7 +12753,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-p-wait-for@^5.0.1:
+p-wait-for@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/p-wait-for/-/p-wait-for-5.0.2.tgz#1546a15e64accf1897377cb1507fa4c756fffe96"
   integrity sha512-lwx6u1CotQYPVju77R+D0vFomni/AqRfqLmqQ8hekklqZ6gAY9rONh7lBQ0uxWMkC2AuX9b2DVAl8To0NyP1JA==


### PR DESCRIPTION
See https://github.com/konnectors/libs/pull/957

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

