### PR TITLE
refactor: remove unused rn-web setup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,3 @@ import App from './App'
 import { name as appName } from './app.json'
 
 AppRegistry.registerComponent(appName, () => App)
-
-AppRegistry.runApplication(appName, {
-  rootTag: document.getElementById('root')
-})


### PR DESCRIPTION
This was set up two years ago when the app was supposed to run in the browser too. That is no more the case. Hence, it seems a good idea to remove such setup in a cleanup effort.