### PR TITLE
fix: Clisk on iOS

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -255,7 +255,8 @@ export class LauncherView extends Component {
                 ref={ref => (this.pilotWebView = ref)}
                 originWhitelist={['*']}
                 source={{
-                  uri: 'about:blank'
+                  uri: 'about:blank',
+                  html: '<html></html>'
                 }}
                 useWebKit={true}
                 javaScriptEnabled={true}


### PR DESCRIPTION
about:blank was introduced in https://github.com/cozy/cozy-flagship-app/pull/850 . It seems to work great on Android, but on iOS we got a native crash:
"NSInvalidArgumentException UIInputWindowController" see #54051 issue on sentry.

By reading the source code https://github.com/react-native-webview/react-native-webview/blob/891e595bcf5cafe4a903d5aa643e8361d0c3d467/apple/RNCWebViewImpl.m#L750-L758 it works great if we inject an html.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [x] Tested on iOS
* [ ] Tested on Android


