### PR TITLE
Backup : create folder structure for Android, fix various bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "@sentry/integrations": "6.19.2",
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
-    "cozy-clisk": "^0.20.2",
     "cozy-client": "^38.7.0",
+    "cozy-clisk": "^0.20.2",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
     "cozy-intent": "^2.14.0",
@@ -52,6 +52,7 @@
     "intl-pluralrules": "2.0.1",
     "lodash": "^4.17.21",
     "microee": "^0.0.6",
+    "mime": "^3.0.0",
     "patch-package": "^6.4.7",
     "post-me": "^0.4.5",
     "postinstall-postinstall": "^2.1.0",
@@ -109,6 +110,7 @@
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/react-native": "11.5.0",
     "@types/fs-extra": "9.0.13",
+    "@types/mime": "^3.0.1",
     "@types/react-native": "0.66.4",
     "@types/redux-logger": "3.0.9",
     "@types/tar": "6.1.3",
@@ -133,6 +135,7 @@
     "jest": "29.4.3",
     "metro-react-native-babel-preset": "^0.73.6",
     "nock": "13.2.9",
+    "pod-install": "0.1.38",
     "prettier": "2.8.4",
     "react-app-rewired": "2.1.8",
     "react-native-svg-transformer": "1.0.0",
@@ -142,8 +145,7 @@
     "url-loader": "4.1.1",
     "webpack": "5.75.0",
     "webpack-cli": "4.7.2",
-    "webpack-dev-server": "3.11.2",
-    "pod-install": "0.1.38"
+    "webpack-dev-server": "3.11.2"
   },
   "browserslist": {
     "production": [

--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -129,6 +129,8 @@ declare module 'cozy-client' {
       params: object
     ) => Promise<{ included: { attributes: unknown }[] }>
     createDirectoryByPath: (path: string) => Promise<FileCollectionGetResult>
+    ensureDirectoryExists: (path: string) => Promise<string>
+    createFileMetadata: (metadata: object) => Promise<{ data: { id: string } }>
     addReferencesTo: (references: object, dirs: object[]) => Promise<void>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     launch: (trigger: any) => any

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -16,6 +16,7 @@ export interface Media {
   remotePath: string
   type: 'image' | 'video'
   subType?: 'PhotoLive'
+  mimeType?: string
   creationDate: number
   albums: Album[]
 }

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -6,12 +6,14 @@ import { Album } from '/app/domain/backup/models'
  * A media on the device
  * @member {string} name
  * @member {number} path
+ * @member {string} remotePath e.g. /Sauvegardé depuis mon mobile/My Android/Download
  * @member {string} type
  * @member {number} creationDate
  */
 export interface Media {
   name: string
   path: string
+  remotePath: string
   type: 'image' | 'video'
   subType?: 'PhotoLive'
   creationDate: number
@@ -21,9 +23,11 @@ export interface Media {
 /**
  * A selection of media metadata stored locally to identify if a media has already been backuped
  * @member {string} name
+ * @member {string} remotePath e.g. /Sauvegardé depuis mon mobile/My Android/Download
  */
 export interface BackupedMedia {
   name: string
+  remotePath: string
 }
 
 export type UploadMediaError = {

--- a/src/app/domain/backup/queries/index.ts
+++ b/src/app/domain/backup/queries/index.ts
@@ -1,6 +1,7 @@
 import { Q, QueryDefinition } from 'cozy-client'
 
 const DOCTYPE_FILES = 'io.cozy.files'
+const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
 
 export const buildFilesQuery = (deviceId: string): QueryDefinition => {
   return Q(DOCTYPE_FILES)
@@ -25,3 +26,21 @@ export interface File {
 }
 
 export type FilesQueryAllResult = File[]
+
+export const buildAlbumsQuery = (deviceId: string): QueryDefinition => {
+  return Q(DOCTYPE_ALBUMS)
+    .where({
+      backupDeviceIds: {
+        $elemMatch: { $eq: deviceId }
+      }
+    })
+    .indexFields(['backupDeviceIds'])
+    .select(['backupDeviceIds', 'name'])
+}
+
+export interface AlbumDocument {
+  id: string
+  name: string
+}
+
+export type AlbumsQueryAllResult = AlbumDocument[]

--- a/src/app/domain/backup/queries/index.ts
+++ b/src/app/domain/backup/queries/index.ts
@@ -2,23 +2,26 @@ import { Q, QueryDefinition } from 'cozy-client'
 
 const DOCTYPE_FILES = 'io.cozy.files'
 
-export const buildFilesQuery = (dirId: string): QueryDefinition => {
+export const buildFilesQuery = (deviceId: string): QueryDefinition => {
   return Q(DOCTYPE_FILES)
     .where({
-      dir_id: dirId,
-      type: 'file'
+      type: 'file',
+      'metadata.backupDeviceIds': {
+        $elemMatch: { $eq: deviceId }
+      }
     })
-    .indexFields(['dir_id', 'type'])
-    .select(['name', 'dir_id', 'type'])
+    .indexFields(['metadata.backupDeviceIds', 'type'])
+    .select(['metadata.backupDeviceIds', 'type', 'name', 'path'])
 }
 
 export const buildFileQuery = (id: string): QueryDefinition => {
   return Q(DOCTYPE_FILES).getById(id)
 }
 
-interface File {
+export interface File {
   id: string
   name: string
+  path: string
 }
 
 export type FilesQueryAllResult = File[]

--- a/src/app/domain/backup/services/getMedias.spec.ts
+++ b/src/app/domain/backup/services/getMedias.spec.ts
@@ -1,3 +1,4 @@
+import { PhotoIdentifier } from '@react-native-camera-roll/camera-roll'
 import { Platform } from 'react-native'
 import RNFS from 'react-native-fs'
 
@@ -30,5 +31,139 @@ describe('getRemotePath', () => {
 
     // Then
     expect(remotePath).toBe('/Pictures')
+  })
+})
+
+describe('formatMediasFromPhotoIdentifier', () => {
+  test('format Android image', () => {
+    // Given
+    Platform.OS = 'android'
+    const photoIdentifier = {
+      node: {
+        group_name: 'Pictures',
+        image: {
+          extension: 'jpg',
+          fileSize: null,
+          filename: 'IMG_20230519_204453.jpg',
+          height: null,
+          orientation: null,
+          playableDuration: null,
+          uri: 'file:///storage/emulated/0/Pictures/IMG_20230519_204453.jpg',
+          width: null
+        },
+        location: null,
+        modificationTimestamp: 1684521894,
+        subTypes: [],
+        timestamp: 1684521894.234,
+        type: 'image/jpeg'
+      }
+    } as unknown as PhotoIdentifier
+
+    // When
+    const media = getMedias.formatMediasFromPhotoIdentifier(photoIdentifier)
+
+    // Then
+    expect(media).toEqual([
+      {
+        name: 'IMG_20230519_204453.jpg',
+        path: 'file:///storage/emulated/0/Pictures/IMG_20230519_204453.jpg',
+        remotePath: '/Pictures',
+        type: 'image',
+        mimeType: 'image/jpeg',
+        creationDate: 1684521894234,
+        albums: [{ name: 'Pictures' }]
+      }
+    ])
+  })
+
+  test('format iOS image', () => {
+    // Given
+    Platform.OS = 'ios'
+    const photoIdentifier = {
+      node: {
+        group_name: ['Pictures'],
+        image: {
+          extension: 'heic',
+          fileSize: null,
+          filename: 'IMG_0744.HEIC',
+          height: null,
+          playableDuration: null,
+          uri: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
+          width: null
+        },
+        location: null,
+        modificationTimestamp: 1688756699.463186,
+        subTypes: [],
+        timestamp: 1682604478.599,
+        type: 'image'
+      }
+    } as unknown as PhotoIdentifier
+
+    // When
+    const media = getMedias.formatMediasFromPhotoIdentifier(photoIdentifier)
+
+    // Then
+    expect(media).toEqual([
+      {
+        name: 'IMG_0744.HEIC',
+        path: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
+        remotePath: '/',
+        type: 'image',
+        mimeType: undefined,
+        creationDate: 1682604478599,
+        albums: [{ name: 'Pictures' }]
+      }
+    ])
+  })
+
+  test('format iOS Live Photo', () => {
+    // Given
+    Platform.OS = 'ios'
+    const photoIdentifier = {
+      node: {
+        group_name: ['Pictures'],
+        image: {
+          extension: 'heic',
+          fileSize: null,
+          filename: 'IMG_0744.HEIC',
+          height: null,
+          playableDuration: null,
+          uri: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
+          width: null
+        },
+        location: null,
+        modificationTimestamp: 1688756699.463186,
+        subTypes: ['PhotoLive'],
+        timestamp: 1682604478.599,
+        type: 'image'
+      }
+    } as unknown as PhotoIdentifier
+
+    // When
+    const media = getMedias.formatMediasFromPhotoIdentifier(photoIdentifier)
+
+    // Then
+    expect(media).toEqual([
+      {
+        name: 'IMG_0744.MOV',
+        path: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
+        remotePath: '/',
+        type: 'video',
+        subType: 'PhotoLive',
+        mimeType: undefined,
+        creationDate: 1682604478599,
+        albums: [{ name: 'Pictures' }]
+      },
+      {
+        name: 'IMG_0744.HEIC',
+        path: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
+        remotePath: '/',
+        type: 'image',
+        subType: 'PhotoLive',
+        mimeType: undefined,
+        creationDate: 1682604478599,
+        albums: [{ name: 'Pictures' }]
+      }
+    ])
   })
 })

--- a/src/app/domain/backup/services/getMedias.spec.ts
+++ b/src/app/domain/backup/services/getMedias.spec.ts
@@ -1,0 +1,34 @@
+import { Platform } from 'react-native'
+import RNFS from 'react-native-fs'
+
+import * as getMedias from '/app/domain/backup/services/getMedias'
+
+describe('getRemotePath', () => {
+  test('return / on iOS', () => {
+    // Given
+    const path = 'file:///storage/emulated/0/Pictures/IMG_20230713_103203.jpg'
+    Platform.OS = 'ios'
+    // @ts-expect-error We want to modify this read only property for test purpose
+    RNFS.ExternalStorageDirectoryPath = '/storage/emulated/0'
+
+    // When
+    const remotePath = getMedias.getRemotePath(path)
+
+    // Then
+    expect(remotePath).toBe('/')
+  })
+
+  test('return remote path on Android', () => {
+    // Given
+    const path = 'file:///storage/emulated/0/Pictures/IMG_20230713_103203.jpg'
+    Platform.OS = 'android'
+    // @ts-expect-error We want to modify this read only property for test purpose
+    RNFS.ExternalStorageDirectoryPath = '/storage/emulated/0'
+
+    // When
+    const remotePath = getMedias.getRemotePath(path)
+
+    // Then
+    expect(remotePath).toBe('/Pictures')
+  })
+})

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -27,6 +27,36 @@ const getPhotoIdentifiersPage = async (
   return photoIdentifiersPage
 }
 
+export const getMimeType = (media: Media): string => {
+  if (media.mimeType) {
+    return media.mimeType
+  }
+
+  const extension = media.name
+    .substring(media.name.lastIndexOf('.') + 1)
+    .toLowerCase()
+
+  if (media.type === 'image') {
+    switch (extension) {
+      case 'jpg':
+        return 'image/jpeg'
+      default:
+        return `image/${extension}`
+    }
+  }
+
+  if (media.type === 'video') {
+    switch (extension) {
+      case 'mp4':
+        return 'video/mpeg'
+      default:
+        return `video/${extension}`
+    }
+  }
+
+  throw new Error('Platform is not supported for backup')
+}
+
 export const getRemotePath = (uri: string): string => {
   if (Platform.OS === 'ios') {
     return '/'
@@ -94,6 +124,7 @@ const formatMediasFromPhotoIdentifier = (
       path: uri,
       remotePath: getRemotePath(uri),
       type: type.includes('image') ? 'image' : 'video',
+      mimeType: Platform.OS == 'android' ? type : undefined,
       creationDate: timestamp * 1000,
       albums
     }

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -3,6 +3,7 @@ import {
   PhotoIdentifiersPage,
   PhotoIdentifier
 } from '@react-native-camera-roll/camera-roll'
+import mime from 'mime/lite'
 import { Platform } from 'react-native'
 import RNFS from 'react-native-fs'
 
@@ -32,29 +33,13 @@ export const getMimeType = (media: Media): string => {
     return media.mimeType
   }
 
-  const extension = media.name
-    .substring(media.name.lastIndexOf('.') + 1)
-    .toLowerCase()
+  const guessedMimeType = mime.getType(media.name)
 
-  if (media.type === 'image') {
-    switch (extension) {
-      case 'jpg':
-        return 'image/jpeg'
-      default:
-        return `image/${extension}`
-    }
+  if (guessedMimeType === null) {
+    throw new Error('File is not supported for backup')
   }
 
-  if (media.type === 'video') {
-    switch (extension) {
-      case 'mp4':
-        return 'video/mpeg'
-      default:
-        return `video/${extension}`
-    }
-  }
-
-  throw new Error('Platform is not supported for backup')
+  return guessedMimeType
 }
 
 export const getRemotePath = (uri: string): string => {

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -79,7 +79,7 @@ export const getRemotePath = (uri: string): string => {
   throw new Error('Platform is not supported for backup')
 }
 
-const formatMediasFromPhotoIdentifier = (
+export const formatMediasFromPhotoIdentifier = (
   photoIdentifier: PhotoIdentifier
 ): Media[] => {
   const {

--- a/src/app/domain/backup/services/manageAlbums.ts
+++ b/src/app/domain/backup/services/manageAlbums.ts
@@ -2,6 +2,12 @@ import { CameraRoll } from '@react-native-camera-roll/camera-roll'
 
 import { Album, BackupedAlbum } from '/app/domain/backup/models'
 import { getLocalBackupConfig } from '/app/domain/backup/services/manageLocalBackupConfig'
+import { getDeviceId } from '/app/domain/backup/services/manageRemoteBackupConfig'
+import {
+  buildAlbumsQuery,
+  AlbumDocument,
+  AlbumsQueryAllResult
+} from '/app/domain/backup/queries'
 
 import type CozyClient from 'cozy-client'
 
@@ -26,13 +32,16 @@ export const createRemoteAlbums = async (
       !backupedAlbums.find(backupedAlbum => backupedAlbum.name === album.name)
   )
 
+  const deviceId = await getDeviceId()
+
   const createdAlbums = []
 
   for (const albumToCreate of albumsToCreate) {
     const createdAlbum = (await client.save({
       _type: 'io.cozy.photos.albums',
       name: albumToCreate.name,
-      created_at: new Date().toISOString()
+      created_at: new Date().toISOString(),
+      backupDeviceIds: [deviceId]
     })) as { data: { name: string; id: string } }
 
     createdAlbums.push({
@@ -42,4 +51,25 @@ export const createRemoteAlbums = async (
   }
 
   return createdAlbums
+}
+
+const formatBackupedAlbum = (album: AlbumDocument): BackupedAlbum => {
+  return {
+    name: album.name,
+    remoteId: album.id
+  }
+}
+
+export const fetchBackupedAlbums = async (
+  client: CozyClient
+): Promise<BackupedAlbum[]> => {
+  const deviceId = await getDeviceId()
+
+  const albumsQuery = buildAlbumsQuery(deviceId)
+
+  const data = (await client.queryAll(albumsQuery)) as AlbumsQueryAllResult
+
+  const backupedAlbums = data.map(album => formatBackupedAlbum(album))
+
+  return backupedAlbums
 }

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -11,7 +11,8 @@ import {
 } from '/app/domain/backup/services/manageLocalBackupConfig'
 import {
   getAlbums,
-  createRemoteAlbums
+  createRemoteAlbums,
+  fetchBackupedAlbums
 } from '/app/domain/backup/services/manageAlbums'
 import { getMediasToBackup } from '/app/domain/backup/services/getMedias'
 import {
@@ -34,6 +35,7 @@ import {
   BackupInfo,
   ProgressCallback,
   BackupedMedia,
+  BackupedAlbum,
   LocalBackupConfig
 } from '/app/domain/backup/models'
 
@@ -146,6 +148,7 @@ const initializeBackup = async (
     // if there is no local backup config
     let deviceRemoteBackupConfig = await fetchDeviceRemoteBackupConfig(client)
     let backupedMedias
+    let backupedAlbums
 
     if (deviceRemoteBackupConfig) {
       log.debug('Backup will be restored')
@@ -154,16 +157,20 @@ const initializeBackup = async (
         client,
         deviceRemoteBackupConfig
       )
+      backupedAlbums = await fetchBackupedAlbums(client)
     } else {
       log.debug('Backup will be created')
+
       deviceRemoteBackupConfig = await createRemoteBackupFolder(client)
       backupedMedias = [] as BackupedMedia[]
+      backupedAlbums = [] as BackupedAlbum[]
     }
 
     const backupConfig = await initiazeLocalBackupConfig(
       client,
       deviceRemoteBackupConfig,
-      backupedMedias
+      backupedMedias,
+      backupedAlbums
     )
 
     return backupConfig

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -20,6 +20,10 @@ import {
   setShouldStopBackup
 } from '/app/domain/backup/services/uploadMedias'
 import {
+  cancelUpload,
+  getCurrentUploadId
+} from '/app/domain/backup/services/uploadMedia'
+import {
   fetchDeviceRemoteBackupConfig,
   fetchBackupedMedias,
   createRemoteBackupFolder
@@ -114,6 +118,14 @@ export const startBackup = async (
 
 export const stopBackup = async (client: CozyClient): Promise<BackupInfo> => {
   setShouldStopBackup(true)
+
+  const uploadId = getCurrentUploadId()
+
+  if (uploadId) {
+    await cancelUpload(uploadId)
+  }
+
+  await setBackupAsReady(client)
 
   return await getBackupInfo(client)
 }

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -95,9 +95,15 @@ export const startBackup = async (
 
   deactivateKeepAwake('backup')
 
-  await setBackupAsDone(client)
+  const localBackupConfigAfterUpload = await getLocalBackupConfig(client)
 
-  log.debug('Backup done')
+  if (localBackupConfigAfterUpload.currentBackup.status === 'running') {
+    await setBackupAsDone(client)
+
+    log.debug('Backup done')
+  } else {
+    log.debug('Backup stopped')
+  }
 
   void onProgress(await getBackupInfo(client))
 

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -65,12 +65,14 @@ export const setLocalBackupConfig = async (
 export const initiazeLocalBackupConfig = async (
   client: CozyClient,
   remoteBackupConfig: RemoteBackupConfig,
-  backupedMedias: BackupedMedia[]
+  backupedMedias: BackupedMedia[],
+  backupedAlbums: BackupedAlbum[]
 ): Promise<LocalBackupConfig> => {
   const newLocalBackupConfig = {
     ...INITIAL_BACKUP_CONFIG,
     remoteBackupConfig: remoteBackupConfig,
-    backupedMedias: backupedMedias
+    backupedMedias: backupedMedias,
+    backupedAlbums: backupedAlbums
   }
 
   await setLocalBackupConfig(client, newLocalBackupConfig)

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -103,12 +103,15 @@ export const setMediaAsBackuped = async (
 
   // add media to backuped medias
   const backupedMedia = localBackupConfig.backupedMedias.find(
-    backupedMedia => backupedMedia.name === media.name
+    backupedMedia =>
+      backupedMedia.name === media.name &&
+      backupedMedia.remotePath === media.remotePath
   )
 
   if (!backupedMedia) {
     localBackupConfig.backupedMedias.push({
-      name: media.name
+      name: media.name,
+      remotePath: media.remotePath
     })
   }
 

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -140,19 +140,27 @@ export const setBackupAsInitializing = async (
 
 export const setBackupAsReady = async (
   client: CozyClient,
-  mediasToBackup: Media[]
+  mediasToBackup?: Media[]
 ): Promise<void> => {
   const localBackupConfig = await getLocalBackupConfig(client)
 
-  localBackupConfig.currentBackup.mediasToBackup = mediasToBackup
-  localBackupConfig.currentBackup.totalMediasToBackupCount =
-    mediasToBackup.length
+  if (mediasToBackup) {
+    localBackupConfig.currentBackup.mediasToBackup = mediasToBackup
+    localBackupConfig.currentBackup.totalMediasToBackupCount =
+      mediasToBackup.length
+  } else {
+    localBackupConfig.currentBackup.totalMediasToBackupCount =
+      localBackupConfig.currentBackup.mediasToBackup.length
+  }
+
   localBackupConfig.currentBackup.status = 'ready'
 
   await setLocalBackupConfig(client, localBackupConfig)
 
   log.debug('Backup set as ready')
-  log.debug(`  ${mediasToBackup.length}  medias to backup`)
+  log.debug(
+    `  ${localBackupConfig.currentBackup.totalMediasToBackupCount}  medias to backup`
+  )
 }
 
 export const setBackupAsRunning = async (client: CozyClient): Promise<void> => {

--- a/src/app/domain/backup/services/uploadMedia.android.ts
+++ b/src/app/domain/backup/services/uploadMedia.android.ts
@@ -3,6 +3,7 @@ import RNBackgroundUpload, {
   UploadOptions
 } from 'react-native-background-upload'
 
+import { getMimeType } from '/app/domain/backup/services/getMedias'
 import { Media, UploadMediaResult } from '/app/domain/backup/models/Media'
 
 import CozyClient, { IOCozyFile } from 'cozy-client'
@@ -22,7 +23,7 @@ export const uploadMedia = async (
       type: 'raw',
       headers: {
         Accept: 'application/json',
-        'Content-Type': media.type,
+        'Content-Type': getMimeType(media),
         Authorization: `Bearer ${
           // @ts-expect-error Type issue which will be fixed in another PR
           client.getStackClient().token.accessToken as string

--- a/src/app/domain/backup/services/uploadMedia.android.ts
+++ b/src/app/domain/backup/services/uploadMedia.android.ts
@@ -8,6 +8,16 @@ import { Media, UploadMediaResult } from '/app/domain/backup/models/Media'
 
 import CozyClient, { IOCozyFile } from 'cozy-client'
 
+let currentUploadId: string | undefined
+
+export const getCurrentUploadId = (): string | undefined => {
+  return currentUploadId
+}
+
+const setCurrentUploadId = (value: string): void => {
+  currentUploadId = value
+}
+
 export const uploadMedia = async (
   client: CozyClient,
   uploadUrl: string,
@@ -36,6 +46,8 @@ export const uploadMedia = async (
 
     RNBackgroundUpload.startUpload(options)
       .then(uploadId => {
+        setCurrentUploadId(uploadId)
+
         RNBackgroundUpload.addListener('error', uploadId, error => {
           // RNBackgroundUpload does not return status code and response body...
           reject({
@@ -74,4 +86,8 @@ export const uploadMedia = async (
         reject(e)
       })
   })
+}
+
+export const cancelUpload = (uploadId: string): Promise<boolean> => {
+  return RNBackgroundUpload.cancelUpload(uploadId)
 }

--- a/src/app/domain/backup/services/uploadMedia.ios.ts
+++ b/src/app/domain/backup/services/uploadMedia.ios.ts
@@ -8,7 +8,7 @@ import { Media, UploadMediaResult } from '/app/domain/backup/models/Media'
 import CozyClient, { StackErrors, IOCozyFile } from 'cozy-client'
 
 const getVideoPathFromLivePhoto = (photoPath: string): string => {
-  return photoPath.substring(0, photoPath.lastIndexOf('.')) + '.mov'
+  return photoPath.substring(0, photoPath.lastIndexOf('.')) + '.MOV'
 }
 
 const getRealFilepath = async (media: Media): Promise<string> => {

--- a/src/app/domain/backup/services/uploadMedia.ios.ts
+++ b/src/app/domain/backup/services/uploadMedia.ios.ts
@@ -22,13 +22,11 @@ const getRealFilepath = async (media: Media): Promise<string> => {
 
   filepath = filepath.replace('file://', '')
 
-  if (media.type === 'image') {
-    return filepath
-  } else if (media.type === 'video' && media.subType === 'PhotoLive') {
+  if (media.type === 'video' && media.subType === 'PhotoLive') {
     return getVideoPathFromLivePhoto(filepath)
   }
 
-  throw new Error('Impossible to get a real filepath')
+  return filepath
 }
 
 export const uploadMedia = async (

--- a/src/app/domain/backup/services/uploadMedia.ios.ts
+++ b/src/app/domain/backup/services/uploadMedia.ios.ts
@@ -29,6 +29,16 @@ const getRealFilepath = async (media: Media): Promise<string> => {
   return filepath
 }
 
+let currentUploadId: string | undefined
+
+export const getCurrentUploadId = (): string | undefined => {
+  return currentUploadId
+}
+
+const setCurrentUploadId = (value: string): void => {
+  currentUploadId = value
+}
+
 export const uploadMedia = async (
   client: CozyClient,
   uploadUrl: string,
@@ -56,6 +66,9 @@ export const uploadMedia = async (
           // @ts-expect-error Type issue which will be fixed in another PR
           client.getStackClient().token.accessToken as string
         }`
+      },
+      begin: ({ jobId }) => {
+        setCurrentUploadId(jobId.toString())
       }
     })
       .promise.then(response => {
@@ -79,5 +92,11 @@ export const uploadMedia = async (
       .catch(e => {
         reject(e)
       })
+  })
+}
+
+export const cancelUpload = (uploadId: string): Promise<void> => {
+  return new Promise(resolve => {
+    resolve(RNFileSystem.stopUpload(parseInt(uploadId)))
   })
 }

--- a/src/app/domain/backup/services/uploadMedia.ios.ts
+++ b/src/app/domain/backup/services/uploadMedia.ios.ts
@@ -2,6 +2,7 @@
 import { CameraRoll } from '@react-native-camera-roll/camera-roll'
 import RNFileSystem from 'react-native-fs'
 
+import { getMimeType } from '/app/domain/backup/services/getMedias'
 import { Media, UploadMediaResult } from '/app/domain/backup/models/Media'
 
 import CozyClient, { StackErrors, IOCozyFile } from 'cozy-client'
@@ -52,7 +53,7 @@ export const uploadMedia = async (
       method: 'POST',
       headers: {
         Accept: 'application/json',
-        'Content-Type': media.type,
+        'Content-Type': getMimeType(media),
         Authorization: `Bearer ${
           // @ts-expect-error Type issue which will be fixed in another PR
           client.getStackClient().token.accessToken as string

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -214,18 +214,15 @@ const getUploadUrl = (
 ): string => {
   const createdAt = new Date(media.creationDate).toISOString()
 
-  const toURL =
-    client.getStackClient().uri +
-    '/files/' +
-    backupFolderId +
-    '?Name=' +
-    encodeURIComponent(media.name) +
-    '&Type=file&Tags=library&Executable=false&CreatedAt=' +
-    createdAt +
-    '&UpdatedAt=' +
-    createdAt +
-    '&MetadataID=' +
-    metadataId
+  const toURL = new URL(client.getStackClient().uri)
+  toURL.pathname = `/files/${backupFolderId}`
+  toURL.searchParams.append('Name', media.name)
+  toURL.searchParams.append('Type', 'file')
+  toURL.searchParams.append('Tags', 'library')
+  toURL.searchParams.append('Executable', 'false')
+  toURL.searchParams.append('CreatedAt', createdAt)
+  toURL.searchParams.append('UpdatedAt', createdAt)
+  toURL.searchParams.append('MetadataID', metadataId)
 
-  return toURL
+  return toURL.toString()
 }

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -3,7 +3,7 @@ import Minilog from 'cozy-minilog'
 
 import { uploadMedia } from '/app/domain/backup/services/uploadMedia'
 import {
-  setBackupAsDone,
+  setBackupAsReady,
   setMediaAsBackuped
 } from '/app/domain/backup/services/manageLocalBackupConfig'
 import { getDeviceId } from '/app/domain/backup/services/manageRemoteBackupConfig'
@@ -46,7 +46,7 @@ export const uploadMedias = async (
   for (const mediaToUpload of mediasToUpload) {
     if (shouldStopBackup) {
       shouldStopBackup = false
-      await setBackupAsDone(client)
+      await setBackupAsReady(client)
       return
     }
 

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -1,10 +1,7 @@
 /* eslint-disable promise/always-return */
 
 import { uploadMedia } from '/app/domain/backup/services/uploadMedia'
-import {
-  setBackupAsReady,
-  setMediaAsBackuped
-} from '/app/domain/backup/services/manageLocalBackupConfig'
+import { setMediaAsBackuped } from '/app/domain/backup/services/manageLocalBackupConfig'
 import { getDeviceId } from '/app/domain/backup/services/manageRemoteBackupConfig'
 import {
   Media,
@@ -48,7 +45,6 @@ export const uploadMedias = async (
   for (const mediaToUpload of mediasToUpload) {
     if (shouldStopBackup) {
       shouldStopBackup = false
-      await setBackupAsReady(client)
       return
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3671,6 +3671,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
 
+"@types/mime@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
 "@types/minimatch@*":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
@@ -11908,6 +11913,11 @@ mime@^2.4.1, mime@^2.4.4:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
+
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
- Create same folder structure for Android as on device
- Stopping backup return ready state so that we can see number of medias remaining to backup
- Fix various bugs