### PR TITLE
fix: Don't show splashscreen before sending app to background

### DIFF
--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -12,10 +12,7 @@ import {
 import * as RootNavigation from '/libs/RootNavigation'
 import { getData, StorageKeys, storeData } from '/libs/localStore/storage'
 import { routes } from '/constants/routes'
-import {
-  showSplashScreen,
-  hideSplashScreen
-} from '/app/theme/SplashScreenService'
+import { hideSplashScreen } from '/app/theme/SplashScreenService'
 import { determineSecurityFlow } from '/app/domain/authorization/services/SecurityService'
 
 import CozyClient, { useClient } from 'cozy-client'
@@ -55,9 +52,9 @@ const tryLockingApp = async (
 }
 
 const handleSleep = (): void => {
-  showSplashScreen()
-    .then(() => storeData(StorageKeys.LastActivity, Date.now().toString()))
-    .catch(reason => log.error('Failed when going to sleep', reason))
+  storeData(StorageKeys.LastActivity, Date.now().toString()).catch(reason =>
+    log.error('Failed when going to sleep', reason)
+  )
 }
 
 /**


### PR DESCRIPTION
When implementing the Lock screen we tried to call the `showSplashScreen()` method before the app being sent to background

This would prevent the app's content to be briefly displayed when going back to the app in the scenario where the Lock screen would need to be displayed

However due to react-native limitations, the Splashscreen would not have the time to appear before the app is paused

Then it would appear only when the app got the focus again

The main impact is that when no Lock screen is needed, then we get the Splashscreen briefly displayed before seeing the app's content, which gives an impression of slowness

When the Lock screen is needed, then we have the same effect but the Lock screen is displayed fast enough so the Splashscreen is not really needed

By removing the Splashscreen we remove the slowness effect without losing any feature (the Lock screen appears fast enough)

However we may want to revert this the day we find a way to force the Splashscreen BEFORE the app being sent to background