### PR TITLE
fix: Make i18n work on iOS

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -472,6 +472,8 @@ PODS:
     - React
   - RNKeychain (8.0.0):
     - React-Core
+  - RNLocalize (2.2.6):
+    - React-Core
   - RNPermissions (3.8.0):
     - React-Core
   - RNScreens (3.18.2):
@@ -570,6 +572,7 @@ DEPENDENCIES:
   - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
   - RNIOS11DeviceCheck (from `../node_modules/react-native-ios11-devicecheck/ios`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
+  - RNLocalize (from `../node_modules/react-native-localize`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
@@ -715,6 +718,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-ios11-devicecheck/ios"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
+  RNLocalize:
+    :path: "../node_modules/react-native-localize"
   RNPermissions:
     :path: "../node_modules/react-native-permissions"
   RNScreens:
@@ -806,6 +811,7 @@ SPEC CHECKSUMS:
   RNInAppBrowser: 48b95ba7a4eaff5cc223bca338d3e319561dbd1b
   RNIOS11DeviceCheck: 9b36378a945711eba558e5e0db3a15a9ccb83150
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
+  RNLocalize: d4b8af4e442d4bcca54e68fc687a2129b4d71a81
   RNPermissions: fc1ff3d0e0a96ba2332282be063358f5f97e3462
   RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
   RNSentry: 85f6525b5fe8d2ada065858026b338605b3c09da

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "cozy-minilog": "3.3.0",
     "html-entities": "^2.3.3",
     "i18next": "23.2.10",
+    "intl": "^1.2.5",
     "intl-pluralrules": "2.0.1",
     "lodash": "^4.17.21",
     "microee": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-native-inappbrowser-reborn": "^3.5.1",
     "react-native-ios11-devicecheck": "https://github.com/cozy/react-native-devicecheck#app-attest-v0.1",
     "react-native-keychain": "^8.0.0",
-    "react-native-localize": "3.0.2",
+    "react-native-localize": "2.2.6",
     "react-native-mask-input": "1.2.1",
     "react-native-permissions": "^3.8.0",
     "react-native-play-install-referrer": "^1.1.8",

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -1,4 +1,5 @@
 import _i18n, { Resource } from 'i18next'
+import 'intl'
 import 'intl-pluralrules'
 import { initReactI18next, useTranslation } from 'react-i18next'
 import { getLocales } from 'react-native-localize'

--- a/yarn.lock
+++ b/yarn.lock
@@ -14402,10 +14402,10 @@ react-native-keychain@^8.0.0:
   resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-8.0.0.tgz#ff708e4dc2a5440df717179bf9b7cd50f78b61d7"
   integrity sha512-c7Cs+YQN26UaQsRG1dmlXL7VL2ctnXwH/dl0IOMEQ7ZaL2NdN313YSAI8ZEZZjrVhNmPsyWEuvTFqWrdpItqQg==
 
-react-native-localize@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-3.0.2.tgz#43fa75c0097dbdb24a54ff320b3c8ad732407365"
-  integrity sha512-/l/oE1LVNgIRRhLbhmfFMHiWV0xhUn0A0iz1ytLVRYywL7FTp8Rx2vkJS/q/RpExDvV7yLw2493XZBYIM1dnLQ==
+react-native-localize@2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-2.2.6.tgz#484f8c700bc629f230066e819265f80f6dd3ef58"
+  integrity sha512-EZETlC1ZlW/4g6xfsNCwAkAw5BDL2A6zk/08JjFR/GRGxYuKRD7iP1hHn1+h6DEu+xROjPpoNeXfMER2vkTVIQ==
 
 react-native-mask-input@1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9505,6 +9505,11 @@ intl-pluralrules@2.0.1:
   resolved "https://registry.yarnpkg.com/intl-pluralrules/-/intl-pluralrules-2.0.1.tgz#de16c3df1e09437635829725e88ea70c9ad79569"
   integrity sha512-astxTLzIdXPeN0K9Rumi6LfMpm3rvNO0iJE+h/k8Kr/is+wPbRe4ikyDjlLr6VTh/mEfNv8RjN+gu3KwDiuhqg==
 
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+  integrity sha512-rK0KcPHeBFBcqsErKSpvZnrOmWOj+EmDkyJ57e90YWaQNqbcivcqmKDlHEeNprDWOsKzPsh1BfSpPQdDvclHVw==
+
 invariant@2.2.4, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
`react-native-localize` has been upgraded to `2.2.6` to make it
compatible with iOS `11`

After `3.0.0` this library requires iOS `12.4` and react-native `0.70`
so we should not upgrade to this version until we do the react-native
migration and chose to drop iOS `11` support

Also `Intl` is only provided on Android's Hermes but is not available on iOS
so we should add a polyfill to use it