### PR TITLE
feat: Intercept window.open in worker

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -45,6 +45,7 @@ export class LauncherView extends Component {
     this.onWorkerMessage = this.onWorkerMessage.bind(this)
     this.onWorkerError = this.onWorkerError.bind(this)
     this.onWorkerLoad = this.onWorkerLoad.bind(this)
+    this.onWorkerOpenWindow = this.onWorkerOpenWindow.bind(this)
     this.onStopExecution = this.onStopExecution.bind(this)
     this.onCreatedAccount = this.onCreatedAccount.bind(this)
     this.onCreatedJob = this.onCreatedJob.bind(this)
@@ -297,6 +298,8 @@ export class LauncherView extends Component {
                 onMessage={this.onWorkerMessage}
                 onError={this.onWorkerError}
                 injectedJavaScriptBeforeContentLoaded={run}
+                javaScriptCanOpenWindowsAutomatically={true}
+                onOpenWindow={this.onWorkerOpenWindow}
               />
               {workerVisible && this.state.workerInteractionBlockerVisible ? (
                 <View
@@ -369,6 +372,19 @@ export class LauncherView extends Component {
     if (this.launcher) {
       this.launcher.onWorkerMessage(event)
     }
+  }
+
+  /**
+   * Intercept window.open inside worker webview and redirect the worker to the given url
+   *
+   * @param {Object} event
+   */
+  onWorkerOpenWindow({ nativeEvent }) {
+    log.info('onWorkerOpenWindow', nativeEvent)
+    const { targetUrl } = nativeEvent
+    this.launcher.setWorkerState({
+      url: targetUrl
+    })
   }
 }
 


### PR DESCRIPTION
And convert it to a change of url in the worker.

I suppose this is the expected behavior for every konnector we have at the moment or else we may make it optional.

This is needed for the sncf konnector login but we still have to check if this does not affect other konnectors regarding the download of files and this is why this PR is still draft

We also will have to check if this works as expected on iOS

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

