### PR TITLE
feat: enhance cozywebview URL scheme handling

### DIFF
--- a/src/app/domain/navigation/webviews/UrlUtils.spec.ts
+++ b/src/app/domain/navigation/webviews/UrlUtils.spec.ts
@@ -14,7 +14,7 @@ jest.mock('react-native', () => ({
 }))
 
 jest.mock('/app/domain/navigation/webviews/UrlModels', () => ({
-  webviewUrlLog: { error: jest.fn() }
+  webviewUrlLog: { error: jest.fn(), info: jest.fn() }
 }))
 
 // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/app/domain/navigation/webviews/UrlUtils.ts
+++ b/src/app/domain/navigation/webviews/UrlUtils.ts
@@ -19,6 +19,7 @@ export const isHttpOrHttps = (url: string): boolean => {
  */
 export const openUrlWithOs = async (url: string): Promise<void> => {
   try {
+    webviewUrlLog.info(`Opening url "${url}" with operating system`)
     await Linking.openURL(url)
   } catch (error) {
     webviewUrlLog.error(

--- a/src/components/webviews/CozyWebView.js
+++ b/src/components/webviews/CozyWebView.js
@@ -1,8 +1,8 @@
 import React, { useCallback, useState, useEffect } from 'react'
 import { BackHandler } from 'react-native'
 import { useIsFocused } from '@react-navigation/native'
-import Minilog from 'cozy-minilog'
 
+import Minilog from 'cozy-minilog'
 import { useNativeIntent } from 'cozy-intent'
 
 import { jsCozyGlobal } from '/components/webviews/jsInteractions/jsCozyInjection'
@@ -20,6 +20,7 @@ import {
 } from '/components/webviews/jsInteractions/jsLogInterception'
 import { postMessageFunctionDeclaration } from '/components/webviews/CryptoWebView/jsInteractions/jsFunctions/jsMessaging'
 import { jsSubscribers } from '/components/webviews/jsInteractions/jsSubscribers'
+import strings from '/constants/strings.json'
 import { useSession } from '/hooks/useSession'
 import ReloadInterceptorWebView from '/components/webviews/ReloadInterceptorWebView'
 import { getHostname } from '/libs/functions/getHostname'
@@ -145,7 +146,7 @@ export const CozyWebView = ({
       }}
       source={webviewSource}
       injectedJavaScriptBeforeContentLoaded={run}
-      originWhitelist={['http://*', 'https://*', 'intent://*']}
+      originWhitelist={strings.ORIGIN_WHITELIST}
       useWebKit={true}
       javaScriptEnabled={true}
       ref={ref => {

--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -10,6 +10,16 @@
   "SESSION_CODE": "session_code",
   "SESSION_CREATED_FLAG": "@cozy_AmiralAppSessionCreated",
   "USER_AGENT": "io.cozy.flagship.mobile",
+  "ORIGIN_WHITELIST": [
+    "http://*",
+    "https://*",
+    "intent://*",
+    "mailto:*",
+    "tel:*",
+    "sms:*",
+    "maps:*",
+    "geo:*"
+  ],
   "appTouched": "appTouched",
   "authLogin": "/auth/login?redirect=",
   "konnectors": {


### PR DESCRIPTION
**Addition of new URL schemes**: We have extended our URL handling capabilities by including more URL schemes - mailto:, tel:, sms:, maps:, and geo:. This allows our application to support a wider range of user interactions directly within our WebView.

**Refactoring origin whitelist into constants**: For better maintainability and readability, we have moved the origin whitelist URL schemes into a separate constant into the `strings` JSON file. The ORIGIN_WHITELIST constant can now be imported wherever it is needed, promoting better code organization and reducing the potential for error.

**Integration with existing openUrl() function**: The enhanced URL scheme handling uses our existing openUrlWithOs() function, ensuring that all non-HTTP/HTTPS URLs are safely handled by the appropriate external apps. With built-in error handling via a try-catch block, this function provides robust protection against potential errors when opening these URLs.