### PR TITLE
feat: More logs in konnectors

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -97,14 +97,19 @@ class ReactNativeLauncher extends Launcher {
    *
    * @param  {ContentScriptLogMessage} message - log message
    */
-  log(logContent) {
+  log({ timestamp, ...logContent }) {
     const context = this.getStartContext()
-    const slug = context.konnector.slug // konnector attribut is available before manifest one
+    const slug = context.konnector.slug // konnector attribute is available before manifest one
     let jobId
     if (context.job) {
       jobId = context.job.id
     }
-    this.logger({ ...logContent, slug, jobId })
+    this.logger({
+      ...logContent,
+      slug,
+      jobId,
+      timestamp: timestamp ?? new Date().toISOString()
+    })
   }
 
   async init({ bridgeOptions, contentScript }) {
@@ -197,7 +202,7 @@ class ReactNativeLauncher extends Launcher {
     const { client, job } = this.getStartContext()
 
     if (message) {
-      this.log({ level: 'error', message, timestamp: new Date().toISOString() })
+      this.log({ level: 'error', message })
     }
     await sendKonnectorsLogs(client)
     if (job) {

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -184,8 +184,7 @@ class ReactNativeLauncher extends Launcher {
     } catch (error) {
       throw new Error(
         `Critical error while ensuring "${slug}" konnector is installed.
-        The konnector will not be able to run.`,
-        error
+        The konnector will not be able to run: ${error.message}`
       )
     }
   }

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -196,6 +196,9 @@ class ReactNativeLauncher extends Launcher {
     deactivateKeepAwake('clisk')
     const { client, job } = this.getStartContext()
 
+    if (message) {
+      this.log({ level: 'error', message, timestamp: new Date().toISOString() })
+    }
     await sendKonnectorsLogs(client)
     if (job) {
       launcherEvent.emit('launchResult', { cancel: true })

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -1,4 +1,5 @@
 import Minilog from 'cozy-minilog'
+
 import CookieManager from '@react-native-cookies/cookies'
 import debounce from 'lodash/debounce'
 import MicroEE from 'microee'
@@ -195,9 +196,9 @@ class ReactNativeLauncher extends Launcher {
     deactivateKeepAwake('clisk')
     const { client, job } = this.getStartContext()
 
+    await sendKonnectorsLogs(client)
     if (job) {
       launcherEvent.emit('launchResult', { cancel: true })
-      await sendKonnectorsLogs(client)
       if (message) {
         await this.updateJobResult({
           state: 'errored',


### PR DESCRIPTION
- Log error result of a konnector execution, to see the error in logs even if the error occurs before authentication
- Send logs to stack even when no job is created (theses logs are useful and will be sent by the flagship app later anyway)


#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

