### PR TITLE
Refactor `settings.gradle` to remove duplicate module references

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,13 +1,14 @@
 rootProject.name = 'CozyReactNative'
+
 include ':react-native-device-info'
 project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
+
 include ':react-native-fs'
 project(':react-native-fs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fs/android')
-include ':@fengweichong_react-native-gzip'
-project(':@fengweichong_react-native-gzip').projectDir = new File(rootProject.projectDir, '../node_modules/@fengweichong/react-native-gzip/android')
-apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
-include ':app'
-include ':react-native-fs'
-project(':react-native-fs').projectDir = new File(settingsDir, '../node_modules/react-native-fs/android')
+
 include ':react-native-google-safetynet'
-project(':react-native-google-safetynet').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-google-safetynet/android')
+project(':react-native-google-safetynet').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-safetynet/android')
+
+apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+
+include ':app'


### PR DESCRIPTION
In this PR, we've made the following improvements to the `settings.gradle` file:

- Removed the redundant inclusion of the `@fengweichong/react-native-gzip` module. It was creating an error because of an import duplication: `Multiple projects in the build are located in the same directory: /home/anc/cozy/cozy-react-native/node_modules/@fengweichong/react-native-gzip/android`
- Formatted the file for better readability by adding spaces between module includes.

By making these changes, we've resolved the Java workspace error that was caused due to multiple projects being located in the same directory.