### PR TITLE
feat: Implement OAuthClientsLimitExceeded dialog

### DIFF
--- a/src/app/domain/limits/OauthClientsLimitService.spec.ts
+++ b/src/app/domain/limits/OauthClientsLimitService.spec.ts
@@ -188,6 +188,35 @@ describe('interceptNavigation', () => {
     expect(closePopup).not.toHaveBeenCalled()
     expect(navigateToApp).not.toHaveBeenCalled()
   })
+
+  it('should be error safe and interrupt navigation if any', () => {
+    const initialUrl =
+      'http://claude.mycozy.cloud/settings/clients/limit-exceeded?redirect=http%3A%2F%2Fclaude-drive.mycozy.cloud%2F'
+    const destinationUrl = 'http://claude-drive.mycozy.cloud/'
+
+    const client = mockClient()
+    const closePopup = jest.fn()
+    const navigationRequest = mockWebViewNavigationRequest(destinationUrl)
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    navigationRef.current = {
+      getCurrentRoute: jest.fn().mockImplementation(() => {
+        throw new Error('SOME_ERROR')
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    const allowNavigation = interceptNavigation(
+      initialUrl,
+      closePopup,
+      client,
+      mockNavigationProp
+    )(navigationRequest)
+
+    expect(allowNavigation).toBe(false)
+    expect(closePopup).not.toHaveBeenCalled()
+    expect(navigateToApp).not.toHaveBeenCalled()
+  })
 })
 
 describe('interceptOpenWindow', () => {
@@ -215,5 +244,21 @@ describe('interceptOpenWindow', () => {
       slug: 'settings',
       navigation: mockNavigationProp
     })
+  })
+
+  it('should be error safe', () => {
+    const targetUrl = 'http://claude-settings.mycozy.cloud/#/connectedDevices'
+
+    const client = mockClient()
+    const openWindowRequest = mockOpenWindowRequest(targetUrl)
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    ;(navigateToApp as any).mockImplementation(() => {
+      throw new Error('SOME_ERROR')
+    })
+
+    interceptOpenWindow(client, mockNavigationProp)(openWindowRequest)
+
+    expect(true).toBe(true)
   })
 })

--- a/src/app/domain/limits/OauthClientsLimitService.spec.ts
+++ b/src/app/domain/limits/OauthClientsLimitService.spec.ts
@@ -1,0 +1,219 @@
+import { NavigationProp, ParamListBase } from '@react-navigation/native'
+import type {
+  WebViewOpenWindowEvent,
+  WebViewNavigation
+} from 'react-native-webview/lib/WebViewTypes'
+
+import CozyClient from 'cozy-client'
+
+import {
+  interceptNavigation,
+  interceptOpenWindow
+} from '/app/domain/limits/OauthClientsLimitService'
+import { routes } from '/constants/routes'
+import { navigateToApp } from '/libs/functions/openApp'
+import { navigationRef } from '/libs/RootNavigation'
+
+jest.mock('/libs/functions/openApp')
+
+const mockNavigationProp = {} as NavigationProp<ParamListBase>
+
+const mockClient = (): CozyClient => {
+  return {
+    getStackClient: (): { uri: string } => ({
+      uri: 'http://claude.mycozy.cloud'
+    }),
+    capabilities: { flat_subdomains: true }
+  } as CozyClient
+}
+
+const mockWebViewNavigationRequest = (url: string): WebViewNavigation => {
+  return {
+    url: url
+  } as WebViewNavigation
+}
+
+const mockOpenWindowRequest = (url: string): WebViewOpenWindowEvent => {
+  return {
+    nativeEvent: {
+      targetUrl: url
+    }
+  } as WebViewOpenWindowEvent
+}
+
+const mockCurrentRouteName = (currentRouteName: string): void => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  navigationRef.current = {
+    getCurrentRoute: jest.fn().mockReturnValue({ name: currentRouteName })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+describe('interceptNavigation', () => {
+  it('should do nothing if client is null', () => {
+    const initialUrl = 'SOME_URL'
+    const destinationUrl = 'SOME_DESTINATION_URL'
+
+    const client = null
+    const closePopup = jest.fn()
+    const navigationRequest = mockWebViewNavigationRequest(destinationUrl)
+
+    const allowNavigation = interceptNavigation(
+      initialUrl,
+      closePopup,
+      client,
+      mockNavigationProp
+    )(navigationRequest)
+
+    expect(allowNavigation).toBe(false)
+    expect(closePopup).not.toHaveBeenCalled()
+    expect(navigateToApp).not.toHaveBeenCalled()
+  })
+
+  it('should close the OAuthClientLimit popup when redirected to Home', () => {
+    const initialUrl =
+      'http://claude.mycozy.cloud/settings/clients/limit-exceeded?redirect=http%3A%2F%2Fclaude-home.mycozy.cloud%2F'
+    const destinationUrl = 'http://claude-home.mycozy.cloud/'
+
+    const client = mockClient()
+    const closePopup = jest.fn()
+    const navigationRequest = mockWebViewNavigationRequest(destinationUrl)
+
+    mockCurrentRouteName(routes.default)
+
+    const allowNavigation = interceptNavigation(
+      initialUrl,
+      closePopup,
+      client,
+      mockNavigationProp
+    )(navigationRequest)
+
+    expect(allowNavigation).toBe(false)
+    expect(closePopup).toHaveBeenCalled()
+    expect(navigateToApp).not.toHaveBeenCalled()
+  })
+
+  it('should close the OAuthClientLimit popup and navigate to drive when redirected to a cozy-drive url', () => {
+    const initialUrl =
+      'http://claude.mycozy.cloud/settings/clients/limit-exceeded?redirect=http%3A%2F%2Fclaude-drive.mycozy.cloud%2F'
+    const destinationUrl = 'http://claude-drive.mycozy.cloud/'
+
+    const client = mockClient()
+    const closePopup = jest.fn()
+    const navigationRequest = mockWebViewNavigationRequest(destinationUrl)
+
+    mockCurrentRouteName(routes.default)
+
+    const allowNavigation = interceptNavigation(
+      initialUrl,
+      closePopup,
+      client,
+      mockNavigationProp
+    )(navigationRequest)
+
+    expect(allowNavigation).toBe(false)
+    expect(closePopup).toHaveBeenCalled()
+    expect(navigateToApp).toHaveBeenCalledWith({
+      href: 'http://claude-drive.mycozy.cloud/',
+      slug: 'drive',
+      navigation: mockNavigationProp
+    })
+  })
+
+  it('should close the OAuthClientLimit popup but not navigate to drive when redirected to a cozy-drive url while in cozy-settings', () => {
+    const initialUrl =
+      'http://claude.mycozy.cloud/settings/clients/limit-exceeded?redirect=http%3A%2F%2Fclaude-drive.mycozy.cloud%2F'
+    const destinationUrl = 'http://claude-drive.mycozy.cloud/'
+
+    const client = mockClient()
+    const closePopup = jest.fn()
+    const navigationRequest = mockWebViewNavigationRequest(destinationUrl)
+
+    mockCurrentRouteName(routes.cozyapp)
+
+    const allowNavigation = interceptNavigation(
+      initialUrl,
+      closePopup,
+      client,
+      mockNavigationProp
+    )(navigationRequest)
+
+    expect(allowNavigation).toBe(false)
+    expect(closePopup).toHaveBeenCalled()
+    expect(navigateToApp).not.toHaveBeenCalled()
+  })
+
+  it('should allow navigation in case of refresh', () => {
+    const initialUrl =
+      'http://claude.mycozy.cloud/settings/clients/limit-exceeded?redirect=http%3A%2F%2Fclaude-drive.mycozy.cloud%2F'
+    const destinationUrl = initialUrl
+
+    const client = mockClient()
+    const closePopup = jest.fn()
+    const navigationRequest = mockWebViewNavigationRequest(destinationUrl)
+
+    mockCurrentRouteName(routes.default)
+
+    const allowNavigation = interceptNavigation(
+      initialUrl,
+      closePopup,
+      client,
+      mockNavigationProp
+    )(navigationRequest)
+
+    expect(allowNavigation).toBe(true)
+    expect(closePopup).not.toHaveBeenCalled()
+    expect(navigateToApp).not.toHaveBeenCalled()
+  })
+
+  it('should allow navigation in case of refresh (resilient to trailing hash)', () => {
+    const initialUrl =
+      'http://claude.mycozy.cloud/settings/clients/limit-exceeded?redirect=http%3A%2F%2Fclaude-drive.mycozy.cloud%2F'
+    const destinationUrl = `${initialUrl}#`
+
+    const client = mockClient()
+    const closePopup = jest.fn()
+    const navigationRequest = mockWebViewNavigationRequest(destinationUrl)
+
+    mockCurrentRouteName(routes.default)
+
+    const allowNavigation = interceptNavigation(
+      initialUrl,
+      closePopup,
+      client,
+      mockNavigationProp
+    )(navigationRequest)
+
+    expect(allowNavigation).toBe(true)
+    expect(closePopup).not.toHaveBeenCalled()
+    expect(navigateToApp).not.toHaveBeenCalled()
+  })
+})
+
+describe('interceptOpenWindow', () => {
+  it('should do nothing if client is null', () => {
+    const targetUrl = 'SOME_DESTINATION_URL'
+
+    const client = null
+    const openWindowRequest = mockOpenWindowRequest(targetUrl)
+
+    interceptOpenWindow(client, mockNavigationProp)(openWindowRequest)
+
+    expect(navigateToApp).not.toHaveBeenCalled()
+  })
+
+  it('should open cozy-settings when called with corresponding url', () => {
+    const targetUrl = 'http://claude-settings.mycozy.cloud/#/connectedDevices'
+
+    const client = mockClient()
+    const openWindowRequest = mockOpenWindowRequest(targetUrl)
+
+    interceptOpenWindow(client, mockNavigationProp)(openWindowRequest)
+
+    expect(navigateToApp).toHaveBeenCalledWith({
+      href: 'http://claude-settings.mycozy.cloud/#/connectedDevices',
+      slug: 'settings',
+      navigation: mockNavigationProp
+    })
+  })
+})

--- a/src/app/domain/limits/OauthClientsLimitService.ts
+++ b/src/app/domain/limits/OauthClientsLimitService.ts
@@ -20,9 +20,9 @@ export const OAUTH_CLIENTS_LIMIT_EXCEEDED = 'OAUTH_CLIENTS_LIMIT_EXCEEDED'
 
 export const oauthClientLimitEventHandler = new EventEmitter()
 
-export const showOauthClientsLimitExceeded = (): void => {
+export const showOauthClientsLimitExceeded = (href: string): void => {
   navigate('home')
-  oauthClientLimitEventHandler.emit(OAUTH_CLIENTS_LIMIT_EXCEEDED)
+  oauthClientLimitEventHandler.emit(OAUTH_CLIENTS_LIMIT_EXCEEDED, href)
 }
 
 export const interceptNavigation =

--- a/src/app/domain/limits/OauthClientsLimitService.ts
+++ b/src/app/domain/limits/OauthClientsLimitService.ts
@@ -10,8 +10,9 @@ import type CozyClient from 'cozy-client'
 import { deconstructCozyWebLinkWithSlug } from 'cozy-client'
 import Minilog from 'cozy-minilog'
 
+import { routes } from '/constants/routes'
 import { navigateToApp } from '/libs/functions/openApp'
-import { navigate } from '/libs/RootNavigation'
+import { navigate, navigationRef } from '/libs/RootNavigation'
 
 const log = Minilog('⛔ OAuth Clients Limit Service')
 
@@ -55,7 +56,25 @@ export const interceptNavigation =
       return false
     }
 
-    closePopup()
+    const currentRouteName =
+      navigationRef.current?.getCurrentRoute()?.name ?? ''
+
+    if (currentRouteName === routes.default) {
+      log.debug(
+        `Current route is Home, close popup and navigate to ${destinationUrl}`
+      )
+      closePopup()
+      void navigateToApp({
+        navigation,
+        href: destinationUrl,
+        slug: destinationUrlData.slug
+      })
+    } else {
+      log.debug(
+        `Current route is not Home but ${currentRouteName}, only close popup and don't interrupt user`
+      )
+      closePopup()
+    }
 
     return false
   }

--- a/src/app/domain/limits/OauthClientsLimitService.ts
+++ b/src/app/domain/limits/OauthClientsLimitService.ts
@@ -1,6 +1,19 @@
 import { EventEmitter } from 'events'
 
+import { NavigationProp, ParamListBase } from '@react-navigation/native'
+import type {
+  WebViewOpenWindowEvent,
+  WebViewNavigation
+} from 'react-native-webview/lib/WebViewTypes'
+
+import type CozyClient from 'cozy-client'
+import { deconstructCozyWebLinkWithSlug } from 'cozy-client'
+import Minilog from 'cozy-minilog'
+
+import { navigateToApp } from '/libs/functions/openApp'
 import { navigate } from '/libs/RootNavigation'
+
+const log = Minilog('⛔ OAuth Clients Limit Service')
 
 export const OAUTH_CLIENTS_LIMIT_EXCEEDED = 'OAUTH_CLIENTS_LIMIT_EXCEEDED'
 
@@ -9,4 +22,73 @@ export const oauthClientLimitEventHandler = new EventEmitter()
 export const showOauthClientsLimitExceeded = (): void => {
   navigate('home')
   oauthClientLimitEventHandler.emit(OAUTH_CLIENTS_LIMIT_EXCEEDED)
+}
+
+export const interceptNavigation =
+  (
+    initialUrl: string,
+    closePopup: () => void,
+    client: CozyClient | null,
+    navigation: NavigationProp<ParamListBase>
+  ) =>
+  (request: WebViewNavigation): boolean => {
+    if (client === null) {
+      log.error('Client is null, should not happen')
+      return false
+    }
+
+    const destinationUrl = cleanUrl(request.url)
+    const subdomainType = client.capabilities.flat_subdomains
+      ? 'flat'
+      : 'nested'
+
+    if (destinationUrl === initialUrl) {
+      return true
+    }
+
+    const destinationUrlData = deconstructCozyWebLinkWithSlug(
+      destinationUrl,
+      subdomainType
+    )
+
+    if (!destinationUrlData.slug) {
+      return false
+    }
+
+    closePopup()
+
+    return false
+  }
+
+export const interceptOpenWindow =
+  (client: CozyClient | null, navigation: NavigationProp<ParamListBase>) =>
+  (syntheticEvent: WebViewOpenWindowEvent): void => {
+    if (client === null) {
+      log.error('Client is null, should not happen')
+      return
+    }
+
+    const { nativeEvent } = syntheticEvent
+    const destinationUrl = nativeEvent.targetUrl
+
+    const subdomainType = client.capabilities.flat_subdomains
+      ? 'flat'
+      : 'nested'
+
+    const destinationUrlData = deconstructCozyWebLinkWithSlug(
+      destinationUrl,
+      subdomainType
+    )
+
+    if (destinationUrlData.slug) {
+      void navigateToApp({
+        navigation,
+        href: destinationUrl,
+        slug: destinationUrlData.slug
+      })
+    }
+  }
+
+const cleanUrl = (url: string): string => {
+  return url.endsWith('#') ? url.replace('#', '') : url
 }

--- a/src/app/domain/limits/OauthClientsLimitService.ts
+++ b/src/app/domain/limits/OauthClientsLimitService.ts
@@ -59,7 +59,17 @@ export const interceptNavigation =
     const currentRouteName =
       navigationRef.current?.getCurrentRoute()?.name ?? ''
 
-    if (currentRouteName === routes.default) {
+    if (destinationUrlData.slug === 'home') {
+      log.debug(
+        `Destination URL is Home which should already be rendered in background, only close popup to reveal the HomeView`
+      )
+      closePopup()
+    } else if (currentRouteName !== routes.default) {
+      log.debug(
+        `Current route is not Home but ${currentRouteName}, only close popup and don't interrupt user`
+      )
+      closePopup()
+    } else {
       log.debug(
         `Current route is Home, close popup and navigate to ${destinationUrl}`
       )
@@ -69,11 +79,6 @@ export const interceptNavigation =
         href: destinationUrl,
         slug: destinationUrlData.slug
       })
-    } else {
-      log.debug(
-        `Current route is not Home but ${currentRouteName}, only close popup and don't interrupt user`
-      )
-      closePopup()
     }
 
     return false

--- a/src/app/domain/limits/OauthClientsLimitService.ts
+++ b/src/app/domain/limits/OauthClientsLimitService.ts
@@ -1,0 +1,12 @@
+import { EventEmitter } from 'events'
+
+import { navigate } from '/libs/RootNavigation'
+
+export const OAUTH_CLIENTS_LIMIT_EXCEEDED = 'OAUTH_CLIENTS_LIMIT_EXCEEDED'
+
+export const oauthClientLimitEventHandler = new EventEmitter()
+
+export const showOauthClientsLimitExceeded = (): void => {
+  navigate('home')
+  oauthClientLimitEventHandler.emit(OAUTH_CLIENTS_LIMIT_EXCEEDED)
+}

--- a/src/app/domain/limits/checkOauthClientsLimit.spec.ts
+++ b/src/app/domain/limits/checkOauthClientsLimit.spec.ts
@@ -1,0 +1,71 @@
+import CozyClient from 'cozy-client'
+
+import { checkOauthClientsLimit } from '/app/domain/limits/checkOauthClientsLimit'
+
+jest.mock('cozy-client')
+
+describe('checkOauthClientsLimit', () => {
+  let client: CozyClient
+
+  beforeEach(() => {
+    client = new CozyClient()
+  })
+
+  it('should return false when limitExceeded is false', async () => {
+    client.getStackClient = jest.fn().mockReturnValue({
+      fetchJSON: jest.fn().mockResolvedValue({
+        data: {
+          attributes: {
+            limitExceeded: false
+          }
+        }
+      })
+    })
+
+    const result = await checkOauthClientsLimit(client)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false when limitExceeded is true', async () => {
+    client.getStackClient = jest.fn().mockReturnValue({
+      fetchJSON: jest.fn().mockResolvedValue({
+        data: {
+          attributes: {
+            limitExceeded: true
+          }
+        }
+      })
+    })
+
+    const result = await checkOauthClientsLimit(client)
+
+    expect(result).toBe(true)
+  })
+
+  describe('should not produce false positivies that would block the user', () => {
+    it(`should return false if any error`, async () => {
+      client.getStackClient = jest.fn().mockReturnValue({
+        fetchJSON: jest.fn().mockImplementation(() => {
+          throw new Error('SOME ERROR')
+        })
+      })
+
+      const result = await checkOauthClientsLimit(client)
+
+      expect(result).toBe(false)
+    })
+
+    it(`should return false if result's attributes is null`, async () => {
+      client.getStackClient = jest.fn().mockReturnValue({
+        fetchJSON: jest.fn().mockResolvedValue({
+          data: {}
+        })
+      })
+
+      const result = await checkOauthClientsLimit(client)
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/src/app/domain/limits/checkOauthClientsLimit.spec.ts
+++ b/src/app/domain/limits/checkOauthClientsLimit.spec.ts
@@ -1,14 +1,20 @@
 import CozyClient from 'cozy-client'
+import flag from 'cozy-flags'
 
 import { checkOauthClientsLimit } from '/app/domain/limits/checkOauthClientsLimit'
 
 jest.mock('cozy-client')
+jest.mock('cozy-flags')
+
+const mockFlag = flag as jest.Mock
 
 describe('checkOauthClientsLimit', () => {
   let client: CozyClient
 
   beforeEach(() => {
     client = new CozyClient()
+
+    mockFlag.mockReturnValue(2)
   })
 
   it('should return false when limitExceeded is false', async () => {
@@ -41,6 +47,24 @@ describe('checkOauthClientsLimit', () => {
     const result = await checkOauthClientsLimit(client)
 
     expect(result).toBe(true)
+  })
+
+  it('should skip verification if flag is not set', async () => {
+    mockFlag.mockReturnValue(null)
+
+    client.getStackClient = jest.fn().mockReturnValue({
+      fetchJSON: jest.fn().mockResolvedValue({
+        data: {
+          attributes: {
+            limitExceeded: true
+          }
+        }
+      })
+    })
+
+    const result = await checkOauthClientsLimit(client)
+
+    expect(result).toBe(false)
   })
 
   describe('should not produce false positivies that would block the user', () => {

--- a/src/app/domain/limits/checkOauthClientsLimit.ts
+++ b/src/app/domain/limits/checkOauthClientsLimit.ts
@@ -5,12 +5,16 @@ import { getErrorMessage } from '/libs/functions/getErrorMessage'
 
 const log = Minilog('⛔ Check OAuth Clients Limit')
 
+interface ClientUsage {
+  count: number
+  limit: number
+  limitReached: boolean
+  limitExceeded: boolean
+}
+
 interface ClientsUsageResult {
   data?: {
-    attributes?: {
-      count: number
-      limit: number
-    }
+    attributes?: ClientUsage
   }
 }
 
@@ -24,10 +28,7 @@ export const checkOauthClientsLimit = async (
       `/settings/clients-usage`
     )
 
-    const count = result.data?.attributes?.count ?? 0
-    const limit = result.data?.attributes?.limit ?? 1
-
-    return count > limit
+    return result.data?.attributes?.limitExceeded ?? false
   } catch (error) {
     const errorMessage = getErrorMessage(error)
     log.error(`Error while fetching OAuth clients limit: ${errorMessage}`)

--- a/src/app/domain/limits/checkOauthClientsLimit.ts
+++ b/src/app/domain/limits/checkOauthClientsLimit.ts
@@ -1,4 +1,9 @@
 import CozyClient from 'cozy-client'
+import Minilog from 'cozy-minilog'
+
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+const log = Minilog('⛔ Check OAuth Clients Limit')
 
 interface ClientsUsageResult {
   data?: {
@@ -12,14 +17,21 @@ interface ClientsUsageResult {
 export const checkOauthClientsLimit = async (
   client: CozyClient
 ): Promise<boolean> => {
-  const stackClient = client.getStackClient()
-  const result = await stackClient.fetchJSON<ClientsUsageResult>(
-    'GET',
-    `/settings/clients-usage`
-  )
+  try {
+    const stackClient = client.getStackClient()
+    const result = await stackClient.fetchJSON<ClientsUsageResult>(
+      'GET',
+      `/settings/clients-usage`
+    )
 
-  const count = result.data?.attributes?.count ?? 0
-  const limit = result.data?.attributes?.limit ?? 1
+    const count = result.data?.attributes?.count ?? 0
+    const limit = result.data?.attributes?.limit ?? 1
 
-  return count > limit
+    return count > limit
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error(`Error while fetching OAuth clients limit: ${errorMessage}`)
+
+    return false
+  }
 }

--- a/src/app/domain/limits/checkOauthClientsLimit.ts
+++ b/src/app/domain/limits/checkOauthClientsLimit.ts
@@ -1,0 +1,25 @@
+import CozyClient from 'cozy-client'
+
+interface ClientsUsageResult {
+  data?: {
+    attributes?: {
+      count: number
+      limit: number
+    }
+  }
+}
+
+export const checkOauthClientsLimit = async (
+  client: CozyClient
+): Promise<boolean> => {
+  const stackClient = client.getStackClient()
+  const result = await stackClient.fetchJSON<ClientsUsageResult>(
+    'GET',
+    `/settings/clients-usage`
+  )
+
+  const count = result.data?.attributes?.count ?? 0
+  const limit = result.data?.attributes?.limit ?? 1
+
+  return count > limit
+}

--- a/src/app/domain/limits/checkOauthClientsLimit.ts
+++ b/src/app/domain/limits/checkOauthClientsLimit.ts
@@ -1,4 +1,5 @@
 import CozyClient from 'cozy-client'
+import flag from 'cozy-flags'
 import Minilog from 'cozy-minilog'
 
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
@@ -22,6 +23,11 @@ export const checkOauthClientsLimit = async (
   client: CozyClient
 ): Promise<boolean> => {
   try {
+    if (!flag('cozy.oauthclients.max')) {
+      log.debug('No Oauth limit in flags, skip verification')
+      return false
+    }
+
     const stackClient = client.getStackClient()
     const result = await stackClient.fetchJSON<ClientsUsageResult>(
       'GET',

--- a/src/app/view/Limits/OauthClientsLimitExceeded.tsx
+++ b/src/app/view/Limits/OauthClientsLimitExceeded.tsx
@@ -1,9 +1,10 @@
 import { NavigationProp, ParamListBase } from '@react-navigation/native'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { StyleSheet, View } from 'react-native'
 import WebView from 'react-native-webview'
 
 import { useOAuthClientsLimitExceeded } from '/app/view/Limits/hooks/useOAuthClientsLimitExceeded'
+import { useHomeStateContext } from '/screens/home/HomeStateProvider'
 
 interface OauthClientsLimitExceededProps {
   navigation: NavigationProp<ParamListBase>
@@ -12,7 +13,18 @@ interface OauthClientsLimitExceededProps {
 export const OauthClientsLimitExceeded = ({
   navigation
 }: OauthClientsLimitExceededProps): JSX.Element | null => {
-  const { popupUrl, interceptNavigation, interceptOpenWindow } = useOAuthClientsLimitExceeded(navigation)
+  const { popupUrl, interceptNavigation, interceptOpenWindow } =
+    useOAuthClientsLimitExceeded(navigation)
+  const { setShouldWaitCozyApp, shouldWaitCozyApp } = useHomeStateContext()
+
+  useEffect(() => {
+    if (popupUrl && shouldWaitCozyApp) {
+      // When the default app is different than cozy-home, then the default cozy-app won't
+      // open because it is blocked by the OAuth Client limitation mechanism so we have to manually
+      // tell the HomeView to stop waiting for the never coming cozy-app
+      setShouldWaitCozyApp(false)
+    }
+  }, [popupUrl, shouldWaitCozyApp, setShouldWaitCozyApp])
 
   return popupUrl ? (
     <View style={styles.dialog}>

--- a/src/app/view/Limits/OauthClientsLimitExceeded.tsx
+++ b/src/app/view/Limits/OauthClientsLimitExceeded.tsx
@@ -1,15 +1,26 @@
+import { NavigationProp, ParamListBase } from '@react-navigation/native'
 import React from 'react'
 import { StyleSheet, View } from 'react-native'
 import WebView from 'react-native-webview'
 
 import { useOAuthClientsLimitExceeded } from '/app/view/Limits/hooks/useOAuthClientsLimitExceeded'
 
-export const OauthClientsLimitExceeded = (): JSX.Element | null => {
-  const { popupUrl } = useOAuthClientsLimitExceeded()
+interface OauthClientsLimitExceededProps {
+  navigation: NavigationProp<ParamListBase>
+}
+
+export const OauthClientsLimitExceeded = ({
+  navigation
+}: OauthClientsLimitExceededProps): JSX.Element | null => {
+  const { popupUrl, interceptNavigation, interceptOpenWindow } = useOAuthClientsLimitExceeded(navigation)
 
   return popupUrl ? (
     <View style={styles.dialog}>
-      <WebView source={{ uri: popupUrl }} />
+      <WebView
+        source={{ uri: popupUrl }}
+        onShouldStartLoadWithRequest={interceptNavigation}
+        onOpenWindow={interceptOpenWindow}
+      />
     </View>
   ) : null
 }

--- a/src/app/view/Limits/OauthClientsLimitExceeded.tsx
+++ b/src/app/view/Limits/OauthClientsLimitExceeded.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { StyleSheet, View } from 'react-native'
+import WebView from 'react-native-webview'
+
+import { useOAuthClientsLimitExceeded } from '/app/view/Limits/hooks/useOAuthClientsLimitExceeded'
+
+export const OauthClientsLimitExceeded = (): JSX.Element | null => {
+  const { popupUrl } = useOAuthClientsLimitExceeded()
+
+  return popupUrl ? (
+    <View style={styles.dialog}>
+      <WebView source={{ uri: popupUrl }} />
+    </View>
+  ) : null
+}
+
+const styles = StyleSheet.create({
+  dialog: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0
+  }
+})

--- a/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
+++ b/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
@@ -46,7 +46,9 @@ export const useOAuthClientsLimitExceeded = (
       const rootURL = client.getStackClient().uri
       const encodedRedirect = encodeURIComponent(href)
       setPopupUrl(
-        `${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}?redirect=${encodedRedirect}`
+        current =>
+          current ??
+          `${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}?redirect=${encodedRedirect}`
       )
     }
 

--- a/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
+++ b/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+
+import { useClient } from 'cozy-client'
+import Minilog from 'cozy-minilog'
+
+import {
+  OAUTH_CLIENTS_LIMIT_EXCEEDED,
+  oauthClientLimitEventHandler
+} from '/app/domain/limits/OauthClientsLimitService'
+
+const log = Minilog('⛔ OAuth Clients Limit Exceeded')
+
+const OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH = '/settings/clients/limit-exceeded'
+
+interface OAuthClientsLimitExceededState {
+  popupUrl: string | null
+}
+
+export const useOAuthClientsLimitExceeded =
+  (): OAuthClientsLimitExceededState => {
+    const client = useClient()
+
+    const [popupUrl, setPopupUrl] = useState<string | null>(null)
+
+    useEffect(() => {
+      const eventCallback = (): void => {
+        if (client === null) {
+          log.error('Client is null, should not happen')
+          return
+        }
+
+        const rootURL = client.getStackClient().uri
+        setPopupUrl(`${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}`)
+      }
+
+      const subscription = oauthClientLimitEventHandler.addListener(
+        OAUTH_CLIENTS_LIMIT_EXCEEDED,
+        eventCallback
+      )
+
+      return (): void => {
+        subscription.removeListener(OAUTH_CLIENTS_LIMIT_EXCEEDED, eventCallback)
+      }
+    }, [client])
+
+    return {
+      popupUrl
+    }
+  }

--- a/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
+++ b/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
@@ -1,10 +1,17 @@
+import { NavigationProp, ParamListBase } from '@react-navigation/native'
 import { useEffect, useState } from 'react'
+import type {
+  WebViewOpenWindowEvent,
+  WebViewNavigation
+} from 'react-native-webview/lib/WebViewTypes'
 
 import { useClient } from 'cozy-client'
 import Minilog from 'cozy-minilog'
 
 import {
   OAUTH_CLIENTS_LIMIT_EXCEEDED,
+  interceptNavigation,
+  interceptOpenWindow,
   oauthClientLimitEventHandler
 } from '/app/domain/limits/OauthClientsLimitService'
 
@@ -14,36 +21,50 @@ const OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH = '/settings/clients/limit-exceeded'
 
 interface OAuthClientsLimitExceededState {
   popupUrl: string | null
+  interceptNavigation: (request: WebViewNavigation) => boolean
+  interceptOpenWindow: (syntheticEvent: WebViewOpenWindowEvent) => void
 }
 
-export const useOAuthClientsLimitExceeded =
-  (): OAuthClientsLimitExceededState => {
-    const client = useClient()
+export const useOAuthClientsLimitExceeded = (
+  navigation: NavigationProp<ParamListBase>
+): OAuthClientsLimitExceededState => {
+  const client = useClient()
 
-    const [popupUrl, setPopupUrl] = useState<string | null>(null)
+  const [popupUrl, setPopupUrl] = useState<string | null>(null)
 
-    useEffect(() => {
-      const eventCallback = (): void => {
-        if (client === null) {
-          log.error('Client is null, should not happen')
-          return
-        }
-
-        const rootURL = client.getStackClient().uri
-        setPopupUrl(`${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}`)
-      }
-
-      const subscription = oauthClientLimitEventHandler.addListener(
-        OAUTH_CLIENTS_LIMIT_EXCEEDED,
-        eventCallback
-      )
-
-      return (): void => {
-        subscription.removeListener(OAUTH_CLIENTS_LIMIT_EXCEEDED, eventCallback)
-      }
-    }, [client])
-
-    return {
-      popupUrl
-    }
+  const closePopup = (): void => {
+    setPopupUrl(null)
   }
+
+  useEffect(() => {
+    const eventCallback = (): void => {
+      if (client === null) {
+        log.error('Client is null, should not happen')
+        return
+      }
+
+      const rootURL = client.getStackClient().uri
+      setPopupUrl(`${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}`)
+    }
+
+    const subscription = oauthClientLimitEventHandler.addListener(
+      OAUTH_CLIENTS_LIMIT_EXCEEDED,
+      eventCallback
+    )
+
+    return (): void => {
+      subscription.removeListener(OAUTH_CLIENTS_LIMIT_EXCEEDED, eventCallback)
+    }
+  }, [client])
+
+  return {
+    popupUrl,
+    interceptNavigation: interceptNavigation(
+      popupUrl ?? '',
+      closePopup,
+      client,
+      navigation
+    ),
+    interceptOpenWindow: interceptOpenWindow(client, navigation)
+  }
+}

--- a/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
+++ b/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
@@ -37,14 +37,17 @@ export const useOAuthClientsLimitExceeded = (
   }
 
   useEffect(() => {
-    const eventCallback = (): void => {
+    const eventCallback = (href: string): void => {
       if (client === null) {
         log.error('Client is null, should not happen')
         return
       }
 
       const rootURL = client.getStackClient().uri
-      setPopupUrl(`${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}`)
+      const encodedRedirect = encodeURIComponent(href)
+      setPopupUrl(
+        `${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}?redirect=${encodedRedirect}`
+      )
     }
 
     const subscription = oauthClientLimitEventHandler.addListener(

--- a/src/components/webviews/CozyProxyWebView.js
+++ b/src/components/webviews/CozyProxyWebView.js
@@ -85,9 +85,9 @@ const initHtmlContent = async ({
 
   if (isOauthClientsLimitExeeded) {
     if (slug === 'home') {
-      showOauthClientsLimitExceeded()
+      showOauthClientsLimitExceeded(href)
     } else if (slug !== 'settings') {
-      showOauthClientsLimitExceeded()
+      showOauthClientsLimitExceeded(href)
       return
     }
   }

--- a/src/components/webviews/CozyProxyWebView.js
+++ b/src/components/webviews/CozyProxyWebView.js
@@ -8,6 +8,8 @@ import { useClient } from 'cozy-client'
 import { styles } from './CozyProxyWebView.styles'
 import { CozyWebView } from './CozyWebView'
 
+import { checkOauthClientsLimit } from '/app/domain/limits/checkOauthClientsLimit'
+import { showOauthClientsLimitExceeded } from '/app/domain/limits/OauthClientsLimitService'
 import { RemountProgress } from '/app/view/Loading/RemountProgress'
 import { updateCozyAppBundleInBackground } from '/libs/cozyAppBundle/cozyAppBundle'
 import { useHttpServerContext } from '/libs/httpserver/httpServerProvider'
@@ -79,6 +81,17 @@ const initHtmlContent = async ({
   dispatch,
   setHtmlContentCreationDate
 }) => {
+  const isOauthClientsLimitExeeded = await checkOauthClientsLimit(client)
+
+  if (isOauthClientsLimitExeeded) {
+    if (slug === 'home') {
+      showOauthClientsLimitExceeded()
+    } else if (slug !== 'settings') {
+      showOauthClientsLimitExceeded()
+      return
+    }
+  }
+
   const htmlContent = await httpServerContext.getIndexHtmlForSlug(slug, client)
 
   const { source: sourceActual, nativeConfig: nativeConfigActual } =

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -75,7 +75,7 @@ export const HomeScreen = ({
 
       {LauncherDialog}
 
-      <OauthClientsLimitExceeded />
+      <OauthClientsLimitExceeded navigation={navigation} />
     </View>
   )
 }

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -6,6 +6,7 @@ import {
 import React, { useState } from 'react'
 import { StatusBar, View } from 'react-native'
 
+import { OauthClientsLimitExceeded } from '/app/view/Limits/OauthClientsLimitExceeded'
 import HomeView from '/screens/home/components/HomeView'
 import LauncherView from '/screens/konnectors/LauncherView'
 import CliskDevView from '/screens/konnectors/CliskDevView'
@@ -73,6 +74,8 @@ export const HomeScreen = ({
       )}
 
       {LauncherDialog}
+
+      <OauthClientsLimitExceeded />
     </View>
   )
 }


### PR DESCRIPTION
Cozy-stack will now limit the number of registered OAuth clients based on `cozy.oauthclients.max` flag

On web, when the limit is reached and the user tries to open a cozy-app then the browser is redirected to `/settings/clients/limit-exceeded`

On Flagship app, we want to intercept this mechanism in order to keep control on how application behaves

To handle this we manually do the limit check in `CozyProxyWebView` before initializing HTML content. This would allow us to handle both Stack and HttpServer based cozy-apps

Then we display a dedicated WebView that will display the `/settings/clients/limit-exceeded` route from cozy-stack

Also we chose to always display cozy-home even if the limit is reached. This is possible because cozy-home is always served from the local HttpServer and this will ensure we don't have side effects as the Flagship app architecture has been created around the fact that the HomeView is always displayed

Related PR: https://github.com/cozy/cozy-stack/pull/4080
Related PR: https://github.com/cozy/cozy-stack/pull/4086
Related PR: https://github.com/cozy/cozy-stack/pull/4087

___

### TODO:

- [x] ~~Wait for cozy-stack related PRs to be merged before merging this PR~~ The feature is now protected by a flag
- [x] ~~Check compatibility with the sharing screen that will come with #897~~ This PR is merged before the sharing screen PR so we will have to do the verification later