### PR TITLE
fix: Correctly hide lock screen when navigating to a default cozy-app

### DIFF
--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -8,6 +8,8 @@ import {
 import RnMaskInput from 'react-native-mask-input'
 import { FullWindowOverlay } from 'react-native-screens'
 
+import { routes } from '/constants/routes'
+import { navigationRef } from '/libs/RootNavigation'
 import { Button } from '/ui/Button'
 import { ConditionalWrapper } from '/components/ConditionalWrapper'
 import { ConfirmDialog } from '/ui/CozyDialogs/ConfirmDialog'
@@ -167,26 +169,30 @@ const LockView = ({
   )
 }
 
-export const LockScreen = (props: LockScreenProps): React.ReactNode => (
-  <ConditionalWrapper
-    condition={Platform.OS === 'ios'}
-    wrapper={(children): JSX.Element => (
-      <FullWindowOverlay>{children}</FullWindowOverlay>
-    )}
-  >
-    <>
-      <LockScreenBars />
+export const LockScreen = (props: LockScreenProps): React.ReactNode => {
+  const currentRouteName = navigationRef.current?.getCurrentRoute()?.name ?? ''
 
-      <TouchableWithoutFeedback
-        onPress={Keyboard.dismiss}
-        style={{ backgroundColor: palette.Primary[600], height: '100%' }}
-      >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+  return (
+    <ConditionalWrapper
+      condition={Platform.OS === 'ios' && currentRouteName === routes.lock}
+      wrapper={(children): JSX.Element => (
+        <FullWindowOverlay>{children}</FullWindowOverlay>
+      )}
+    >
+      <>
+        <LockScreenBars />
+
+        <TouchableWithoutFeedback
+          onPress={Keyboard.dismiss}
+          style={{ backgroundColor: palette.Primary[600], height: '100%' }}
         >
-          <LockView {...useLockScreenProps(props)} />
-        </KeyboardAvoidingView>
-      </TouchableWithoutFeedback>
-    </>
-  </ConditionalWrapper>
-)
+          <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          >
+            <LockView {...useLockScreenProps(props)} />
+          </KeyboardAvoidingView>
+        </TouchableWithoutFeedback>
+      </>
+    </ConditionalWrapper>
+  )
+}


### PR DESCRIPTION
On iOS and with current implementation, when the app is configured with auto-lock and when the Cozy is configured to have a default cozy-app (different than cozy-home), then the startup lock screen stays displayed and the user cannot use the app anymore

This bug only happens on startup. If the lockscreen is displayed after the app being sent to background, then everything works fine

This bug is due to the `FullWindowOverlay` component that is used on iOS. React-navigation seems not to unmount the dialog when navigating to the CozyAppScreen dialog (they seem to be stacked). The result is the LockScreen being still visible (due to the `FullWindowOverlay`) even if it should be behind the CozyAppScreen

By reading react-navigation documentation, no evident way has been found to fix this navigation issue

Instead of working on a react-navigation fix, we chose to use `FullWindowOverlay` only when the app is on the lock route, otherwise the lock screen is displayed in the main frame