### PR TITLE
fix(backup): Avoid to throw error at startup when no backup

### DIFF
--- a/src/app/domain/backup/hooks/useInitBackup.tsx
+++ b/src/app/domain/backup/hooks/useInitBackup.tsx
@@ -20,11 +20,15 @@ export const useInitBackup = (): void => {
         return
       }
 
-      const backupConfig = await getLocalBackupConfig(client)
+      try {
+        const backupConfig = await getLocalBackupConfig(client)
 
-      if (backupConfig.currentBackup.status === 'running') {
-        log.debug('A running backup has been set as to do.')
-        await setBackupAsToDo(client)
+        if (backupConfig.currentBackup.status === 'running') {
+          log.debug('A running backup has been set as to do.')
+          await setBackupAsToDo(client)
+        }
+      } catch {
+        /* empty */
       }
     }
 


### PR DESCRIPTION
When checking at startup if a backup is running, it was throwing an error if there was no backup. We should just do nothing if there is no backup.