### PR TITLE
feat: Upgrade Android's Target SDK to 33

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,12 +4,12 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         ndkVersion = "21.4.7075529"
         androidXBrowser = "1.4.0"
-        DocumentScanner_compileSdkVersion = 31
-        DocumentScanner_targetSdkVersion = 31
+        DocumentScanner_compileSdkVersion = 33
+        DocumentScanner_targetSdkVersion = 33
     }
     repositories {
         google()

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-native-svg": "12.3.0",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-web": "0.17.7",
-    "react-native-webview": "github:cozy/react-native-webview#1.0.2",
+    "react-native-webview": "github:cozy/react-native-webview#1.0.3",
     "react-redux": "^8.0.5",
     "react-scripts": "4.0.3",
     "redux-logger": "3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14507,9 +14507,9 @@ react-native-web@0.17.7:
     normalize-css-color "^1.0.2"
     prop-types "^15.6.0"
 
-"react-native-webview@github:cozy/react-native-webview#1.0.2":
+"react-native-webview@github:cozy/react-native-webview#1.0.3":
   version "11.18.2"
-  resolved "https://codeload.github.com/cozy/react-native-webview/tar.gz/d95f2b0a83bd2c7b8cc84c11e71effc78d8bc5ec"
+  resolved "https://codeload.github.com/cozy/react-native-webview/tar.gz/622fae7bb357a2d1ab25bf46bafdf821780b4b4b"
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
PlayStore will soon require apps to target SDK 33

Related PR: cozy/react-native-webview#6