### PR TITLE
feat: Check log allowed level

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
     "cozy-client": "^40.0.1",
-    "cozy-clisk": "^0.22.2",
+    "cozy-clisk": "^0.22.3",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
     "cozy-intent": "^2.14.0",

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -97,10 +97,17 @@ class ReactNativeLauncher extends Launcher {
    *
    * @param  {ContentScriptLogMessage} message - log message
    */
-  log({ timestamp, ...logContent }) {
+  log({ timestamp, level, ...logContent }) {
     const context = this.getStartContext()
     const slug = context.konnector.slug // konnector attribute is available before manifest one
+    let newLevel = level
     let jobId
+
+    const allowedLevels = ['debug', 'info', 'warn', 'error']
+    if (!allowedLevels.includes(level)) {
+      newLevel = 'debug'
+    }
+
     if (context.job) {
       jobId = context.job.id
     }
@@ -108,6 +115,7 @@ class ReactNativeLauncher extends Launcher {
       ...logContent,
       slug,
       jobId,
+      level: newLevel,
       timestamp: timestamp ?? new Date().toISOString()
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6385,10 +6385,10 @@ cozy-client@^40.0.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-clisk@^0.22.2:
-  version "0.22.2"
-  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.22.2.tgz#b8dd36cf2e026f50b35933fa260a8a949121d9a0"
-  integrity sha512-TgM3U5W6PdFB/DIz8hVyAo51v0AsbOW9KGBW/VC33A4oKP3tir75zYeKwSC/HvWILbkWoYRGoQqMnkVjOLCUgg==
+cozy-clisk@^0.22.3:
+  version "0.22.3"
+  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.22.3.tgz#32a0fcf9e5a564e5caf3c213715c5258f96972a2"
+  integrity sha512-zyx2MJHMF1fn+UjhEMErNhXd5b0OeF7jU5K9nRM7ziJMYlMT9xzhcQBc4lOPQBszIiJGuNC0VWY26qLHY8mxrg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     bluebird-retry "^0.11.0"


### PR DESCRIPTION
See https://github.com/konnectors/libs/pull/964, this check was done at
contentscript level at first but we also need this check at the launcher
level.
If this check is not done, the flagship app will be stuck trying to send logs and get an error from the stack because the log level is unknown

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

