### PR TITLE
Fix/errors handling backup

### DIFF
--- a/src/app/domain/backup/helpers/error.ts
+++ b/src/app/domain/backup/helpers/error.ts
@@ -4,7 +4,7 @@ export class BackupError extends Error {
   textMessage: string
   statusCode: number | undefined
 
-  constructor(message: string, statusCode: number | undefined) {
+  constructor(message: string, statusCode?: number) {
     const stringifiedMessage = JSON.stringify({
       message,
       statusCode
@@ -41,6 +41,17 @@ export const isQuotaExceededError = (error: UploadError): boolean => {
   )
 }
 
-export const isFatalError = (error: UploadError): boolean => {
-  return isQuotaExceededError(error)
+export const isFileTooBigError = (error: UploadError): boolean => {
+  return (
+    error.statusCode === 413 &&
+    error.errors[0]?.detail ===
+      'The file is too big and exceeds the filesystem maximum file size'
+  )
+}
+
+export const isCancellationError = (error: UploadError): boolean => {
+  return (
+    error.statusCode === -1 &&
+    error.errors[0]?.detail === 'User cancelled upload'
+  )
 }

--- a/src/app/domain/backup/hooks/useInitBackup.tsx
+++ b/src/app/domain/backup/hooks/useInitBackup.tsx
@@ -4,8 +4,10 @@ import { useClient } from 'cozy-client'
 
 import {
   getLocalBackupConfig,
-  setBackupAsToDo
+  setBackupAsDone,
+  setLastBackup
 } from '/app/domain/backup/services/manageLocalBackupConfig'
+import { t } from '/locales/i18n'
 
 import Minilog from 'cozy-minilog'
 
@@ -24,8 +26,17 @@ export const useInitBackup = (): void => {
         const backupConfig = await getLocalBackupConfig(client)
 
         if (backupConfig.currentBackup.status === 'running') {
-          log.debug('A running backup has been set as to do.')
-          await setBackupAsToDo(client)
+          log.debug('A running backup has been found at startup.')
+          await setBackupAsDone(client)
+          await setLastBackup(client, {
+            status: 'error',
+            backedUpMediaCount:
+              backupConfig.currentBackup.totalMediasToBackupCount -
+              backupConfig.currentBackup.mediasToBackup.length,
+            totalMediasToBackupCount:
+              backupConfig.currentBackup.totalMediasToBackupCount,
+            message: t('services.backup.errors.appKilled')
+          })
         }
       } catch {
         /* empty */

--- a/src/app/domain/backup/models/Backup.ts
+++ b/src/app/domain/backup/models/Backup.ts
@@ -2,18 +2,21 @@ import { Media, BackupedMedia, BackupedAlbum } from '/app/domain/backup/models'
 
 type BackupStatus = 'to_do' | 'initializing' | 'ready' | 'running' | 'done'
 
-interface LastBackupSuccess {
-  status: 'success'
+/**
+ * A local backup config representing the current backup of the device
+ * @member {string} status
+ * @member {number} code
+ * @member {string} message Translated message to display to the user
+ * @member {number} backedUpMediaCount
+ * @member {number} totalMediasToBackupCount
+ */
+export interface LastBackup {
+  status: 'success' | 'partial_success' | 'error'
+  code?: number
+  message?: string
   backedUpMediaCount: number
   totalMediasToBackupCount: number
 }
-
-interface LastBackupError {
-  status: 'error'
-  errorMessage: string
-}
-
-type LastBackup = LastBackupSuccess | LastBackupError
 
 /**
  * A local backup config representing the current backup of the device

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -6,7 +6,8 @@ import {
   LocalBackupConfig,
   RemoteBackupConfig,
   BackupedMedia,
-  BackupedAlbum
+  BackupedAlbum,
+  LastBackup
 } from '/app/domain/backup/models'
 import { buildFileQuery } from '/app/domain/backup/queries'
 import {
@@ -224,45 +225,15 @@ export const setBackupAsDone = async (client: CozyClient): Promise<void> => {
   log.debug('Backup set as done')
 }
 
-interface SetLastBackupAsSuccessParams {
-  remainingMediaCount: number
-  totalMediasToBackupCount: number
-}
-
-export const setLastBackupAsSuccess = async (
+export const setLastBackup = async (
   client: CozyClient,
-  params: SetLastBackupAsSuccessParams
+  lastBackup: LastBackup
 ): Promise<void> => {
   const localBackupConfig = await getLocalBackupConfig(client)
 
-  localBackupConfig.lastBackup = {
-    status: 'success',
-    backedUpMediaCount:
-      params.totalMediasToBackupCount - params.remainingMediaCount,
-    totalMediasToBackupCount: params.totalMediasToBackupCount
-  }
+  localBackupConfig.lastBackup = lastBackup
 
   await setLocalBackupConfig(client, localBackupConfig)
 
-  log.debug('Backup success')
-}
-
-interface SetLastBackupAsErrorParams {
-  errorMessage: string
-}
-
-export const setLastBackupAsError = async (
-  client: CozyClient,
-  params: SetLastBackupAsErrorParams
-): Promise<void> => {
-  const localBackupConfig = await getLocalBackupConfig(client)
-
-  localBackupConfig.lastBackup = {
-    status: 'error',
-    errorMessage: params.errorMessage
-  }
-
-  await setLocalBackupConfig(client, localBackupConfig)
-
-  log.debug('Backup error')
+  log.debug('Last backup set')
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -91,10 +91,13 @@
         "onCancelledTitle": "Backup canceled",
         "onCancelledMessage": "Open the app to resume the process",
         "backupSuccessTitle": "Photo & video backup",
-        "backupSuccessBody": "Your backup is complete! {{count}} saved item(s) "
+        "backupSuccessBody": "Your backup is complete! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} saved item(s) "
       },
       "errors": {
+        "appKilled": "App killed",
+        "backupStopped": "Backup stopped",
         "fileNotFound": "File not found",
+        "fileTooBig": "File too big",
         "fileNotSupported": "File not supported for backup",
         "platformNotSupported": "Platform not supported for backup",
         "configNotInitialized": "Local backup config not initialized",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -91,7 +91,7 @@
         "onCancelledTitle": "Backup canceled",
         "onCancelledMessage": "Open the app to resume the process",
         "backupSuccessTitle": "Photo & video backup",
-        "backupSuccessBody": "Your backup is complete! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} saved item(s) "
+        "backupSuccessBody": "Your backup is complete! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} saved item(s)"
       },
       "errors": {
         "appKilled": "App killed",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -70,8 +70,23 @@
   "services": {
     "backup": {
       "backupRootName": "Copiado desde mi móvil",
+      "notifications": {
+        "onProgressTitle": "Subiendo",
+        "onProgressMessage": "{{filename}} se está subiendo",
+        "onCompleteTitle": "Subida finalizada",
+        "onCompleteMessage": "{{filename}} se ha subido",
+        "onErrorTitle": "Oops",
+        "onErrorMessage": "Tu copia de seguridad ha encontrado un error. Abre la aplicación para ver más detalles",
+        "onCancelledTitle": "Copia de seguridad cancelada",
+        "onCancelledMessage": "Abre la app para reanudar el proceso",
+        "backupSuccessTitle": "Copia de seguridad de fotos y vídeos",
+        "backupSuccessBody": "¡Tu copia de seguridad ha finalizado! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} elemento(s) guardado(s)"
+      },
       "errors": {
+        "appKilled": "App asesinada",
+        "backupStopped": "Copia de seguridad detenida",
         "fileNotFound": "Archivo no encontrado",
+        "fileTooBig": "Fichero demasiado grande",
         "fileNotSupported": "Archivo no compatible con la copia de seguridad",
         "platformNotSupported": "Plataforma no compatible con la copia de seguridad",
         "configNotInitialized": "Configuración de copia de seguridad local no inicializada",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -96,10 +96,13 @@
         "onCancelledTitle": "Sauvegarde arrêtée",
         "onCancelledMessage": "Votre sauvegarde a été arrêtée. Ouvrez l'app pour la reprendre",
         "backupSuccessTitle": "Sauvegarde photo & vidéo",
-        "backupSuccessBody": "Votre sauvegarde est terminée ! {{count}} élément(s) sauvegardé(s)"
+        "backupSuccessBody": "Votre sauvegarde est terminée ! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} élément(s) sauvegardé(s)"
       },
       "errors": {
+        "appKilled": "Application arrêtée",
+        "backupStopped": "Sauvegarde arrêtée",
         "fileNotFound": "Fichier non trouvé",
+        "fileTooBig": "Fichier trop volumineux",
         "fileNotSupported": "Fichier non supporté pour la sauvegarde",
         "platformNotSupported": "Plateforme non supportée pour la sauvegarde",
         "configNotInitialized": "Configuration locale de sauvegarde non initialisée",


### PR DESCRIPTION
 refactor(backup): Better error handling

3 last backup possibilities :
- success : success notification + success message
- partial success : success notification + partial success message with reason
- error : no notification + error message with reason

Manage "file too big" error.

Clearer: Backup is now always set as 'done' when finished, even if there was an error or it if was manually stopped (no more sneaky set as 'ready').

Linked to https://github.com/cozy/cozy-drive/pull/2976