### PR TITLE
Fix blank screen after notification request

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,6 @@ import { CozyProvider, useClient } from 'cozy-client'
 import { NativeIntentProvider } from 'cozy-intent'
 
 import { RootNavigator } from '/AppRouter'
-import { useSecureBackgroundSplashScreen } from '/hooks/useSplashScreen'
 import * as RootNavigation from '/libs/RootNavigation'
 import NetStatusBoundary from '/libs/services/NetStatusBoundary'
 import { IconChangedModal } from '/libs/icon/IconChangedModal'
@@ -36,6 +35,7 @@ import { useNetService } from '/libs/services/NetService'
 import { withSentry } from '/libs/monitoring/Sentry'
 import { ThemeProvider } from '/app/theme/ThemeProvider'
 import { useInitI18n } from '/locales/useInitI18n'
+import { SecureBackgroundSplashScreenWrapper } from '/app/theme/SecureBackgroundSplashScreenWrapper'
 
 // Polyfill needed for cozy-client connection
 if (!global.btoa) {
@@ -57,7 +57,6 @@ const App = ({ setClient }) => {
   const { initialRoute, isLoading } = useAppBootstrap(client)
 
   useGlobalAppState()
-  useSecureBackgroundSplashScreen()
   useCookieResyncOnResume()
   useNotifications()
   useCozyEnvironmentOverride()
@@ -156,11 +155,13 @@ const Wrapper = () => {
             <HttpServerProvider>
               <HomeStateProvider>
                 <SplashScreenProvider>
-                  <NetStatusBoundary>
-                    <ThemeProvider>
-                      <WrappedApp />
-                    </ThemeProvider>
-                  </NetStatusBoundary>
+                  <SecureBackgroundSplashScreenWrapper>
+                    <NetStatusBoundary>
+                      <ThemeProvider>
+                        <WrappedApp />
+                      </ThemeProvider>
+                    </NetStatusBoundary>
+                  </SecureBackgroundSplashScreenWrapper>
                 </SplashScreenProvider>
               </HomeStateProvider>
             </HttpServerProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ import { withSentry } from '/libs/monitoring/Sentry'
 import { ThemeProvider } from '/app/theme/ThemeProvider'
 import { useInitI18n } from '/locales/useInitI18n'
 import { SecureBackgroundSplashScreenWrapper } from '/app/theme/SecureBackgroundSplashScreenWrapper'
+import { PermissionsChecker } from '/app/domain/nativePermissions/components/PermissionsChecker'
 
 // Polyfill needed for cozy-client connection
 if (!global.btoa) {
@@ -158,7 +159,9 @@ const Wrapper = () => {
                   <SecureBackgroundSplashScreenWrapper>
                     <NetStatusBoundary>
                       <ThemeProvider>
-                        <WrappedApp />
+                        <PermissionsChecker>
+                          <WrappedApp />
+                        </PermissionsChecker>
                       </ThemeProvider>
                     </NetStatusBoundary>
                   </SecureBackgroundSplashScreenWrapper>

--- a/src/app/domain/nativePermissions/components/PermissionsChecker.ts
+++ b/src/app/domain/nativePermissions/components/PermissionsChecker.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react'
+
+import { requestNotifications } from '/app/domain/nativePermissions'
+
+interface PermissionsCheckerProps {
+  children: JSX.Element
+}
+
+export const PermissionsChecker = ({
+  children
+}: PermissionsCheckerProps): JSX.Element | null => {
+  const [notificationPermissionAnswered, setNotificationPermissionAnswered] =
+    useState(false)
+
+  useEffect(() => {
+    const askNotificationPermission = async (): Promise<void> => {
+      await requestNotifications()
+      setNotificationPermissionAnswered(true)
+    }
+
+    void askNotificationPermission()
+  })
+
+  if (notificationPermissionAnswered) {
+    return children
+  }
+
+  return null
+}

--- a/src/app/domain/nativePermissions/services/nativePermissions.ts
+++ b/src/app/domain/nativePermissions/services/nativePermissions.ts
@@ -1,6 +1,7 @@
 import {
   check,
   request,
+  checkNotifications as RNPCheckNotifications,
   requestNotifications as RNPRequestNotifications,
   PermissionStatus,
   RESULTS
@@ -22,6 +23,12 @@ export const requestNativePermission = async (
   const result = await request(permission)
 
   return formatResult(result)
+}
+
+export const checkNotifications = async (): Promise<NativePermissionStatus> => {
+  const result = await RNPCheckNotifications()
+
+  return formatResult(result.status)
 }
 
 export const requestNotifications =

--- a/src/app/theme/SecureBackgroundSplashScreenWrapper.ts
+++ b/src/app/theme/SecureBackgroundSplashScreenWrapper.ts
@@ -1,0 +1,13 @@
+import { useSecureBackgroundSplashScreen } from '/hooks/useSplashScreen'
+
+interface SecureBackgroundSplashScreenWrapperProps {
+  children: JSX.Element
+}
+
+export const SecureBackgroundSplashScreenWrapper = ({
+  children
+}: SecureBackgroundSplashScreenWrapperProps): JSX.Element => {
+  useSecureBackgroundSplashScreen()
+
+  return children
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -9,7 +9,7 @@ import {
   handleInitialNotification,
   handleNotificationOpening
 } from '/libs/notifications/notifications'
-import { requestNotifications } from '/app/domain/nativePermissions'
+import { checkNotifications } from '/app/domain/nativePermissions'
 
 export const useNotifications = (): void => {
   const client = useClient()
@@ -20,7 +20,7 @@ export const useNotifications = (): void => {
     const initializeNotifications = async (): Promise<void> => {
       if (!client) return
 
-      const permission = await requestNotifications()
+      const permission = await checkNotifications()
 
       if (permission.granted) {
         setAreNotificationsEnabled(true)


### PR DESCRIPTION
 refactor: Create a wrapper for useSecureBackgroundSplashScreen and move it
 fix: Solve blank screen when asking notification permission during webview loading