### PR TITLE
fix(backup): Stop background backup when not supported

### DIFF
--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -124,6 +124,20 @@ export const startBackup = async (
           postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount,
         message: partialSuccessMessage
       })
+
+      await showLocalNotification({
+        title: t('services.backup.notifications.backupPartialSuccessTitle'),
+        body: t('services.backup.notifications.backupPartialSuccessBody', {
+          backedUpMediaCount:
+            postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount -
+            postUploadLocalBackupConfig.currentBackup.mediasToBackup.length,
+          totalMediasToBackupCount:
+            postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount
+        }),
+        data: {
+          redirectLink: 'photos/#/backup'
+        }
+      })
     } else {
       await setLastBackup(client, {
         status: 'success',
@@ -133,21 +147,21 @@ export const startBackup = async (
         totalMediasToBackupCount:
           postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount
       })
-    }
 
-    await showLocalNotification({
-      title: t('services.backup.notifications.backupSuccessTitle'),
-      body: t('services.backup.notifications.backupSuccessBody', {
-        backedUpMediaCount:
-          postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount -
-          postUploadLocalBackupConfig.currentBackup.mediasToBackup.length,
-        totalMediasToBackupCount:
-          postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount
-      }),
-      data: {
-        redirectLink: 'photos/#/backup'
-      }
-    })
+      await showLocalNotification({
+        title: t('services.backup.notifications.backupSuccessTitle'),
+        body: t('services.backup.notifications.backupSuccessBody', {
+          backedUpMediaCount:
+            postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount -
+            postUploadLocalBackupConfig.currentBackup.mediasToBackup.length,
+          totalMediasToBackupCount:
+            postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount
+        }),
+        data: {
+          redirectLink: 'photos/#/backup'
+        }
+      })
+    }
   } catch (e) {
     const postUploadLocalBackupConfig = await getLocalBackupConfig(client)
     if (e instanceof BackupError) {

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -1,5 +1,7 @@
 /* eslint-disable promise/always-return */
 
+import { AppState, Platform } from 'react-native'
+
 import { uploadMedia } from '/app/domain/backup/services/uploadMedia'
 import { setMediaAsBackuped } from '/app/domain/backup/services/manageLocalBackupConfig'
 import { getDeviceId } from '/app/domain/backup/services/manageRemoteBackupConfig'
@@ -41,6 +43,14 @@ export const setShouldStopBackup = (value: boolean): void => {
   shouldStopBackup = value
 }
 
+const shouldStopBecauseBackground = (): boolean => {
+  if (Platform.OS === 'android' && Platform.Version <= 31) {
+    return false
+  }
+
+  return AppState.currentState === 'background'
+}
+
 export const uploadMedias = async (
   client: CozyClient,
   localBackupConfig: LocalBackupConfig,
@@ -60,6 +70,10 @@ export const uploadMedias = async (
     if (shouldStopBackup) {
       shouldStopBackup = false
       return t('services.backup.errors.backupStopped')
+    }
+
+    if (shouldStopBecauseBackground()) {
+      return t('services.backup.errors.appKilled')
     }
 
     try {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -86,6 +86,8 @@
         "onProgressMessage": "{{filename}} is being uploaded",
         "backupSuccessTitle": "Photo & video backup",
         "backupSuccessBody": "Your backup is complete! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} saved item(s)",
+        "backupPartialSuccessTitle": "Photo & video backup",
+        "backupPartialSuccessBody": "Your backup is stopped! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} saved item(s)",
         "backupErrorTitle": "Oops",
         "backupErrorBody":  "Your backup encountered an error. Open the app to see more details"
       },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -75,6 +75,8 @@
         "onProgressMessage": "{{filename}} se está subiendo",
         "backupSuccessTitle": "Copia de seguridad de fotos y vídeos",
         "backupSuccessBody": "¡Tu copia de seguridad ha finalizado! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} elemento(s) guardado(s)",
+        "backupPartialSuccessTitle": "Copia de seguridad de fotos y vídeos",
+        "backupPartialSuccessBody": "La copia de seguridad se ha detenido. {{backedUpMediaCount}}/{{totalMediasToBackupCount}} elemento(s) guardado(s)",
         "backupErrorTitle": "Oops",
         "backupErrorBody":  "Tu copia de seguridad ha encontrado un error. Abre la aplicación para ver más detalles"
       },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -91,6 +91,8 @@
         "onProgressMessage": "{{filename}} est en cours de sauvegarde",
         "backupSuccessTitle": "Sauvegarde photo & vidéo",
         "backupSuccessBody": "Votre sauvegarde est terminée ! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} élément(s) sauvegardé(s)",
+        "backupPartialSuccessTitle": "Sauvegarde photo & vidéo",
+        "backupPartialSuccessBody": "Votre sauvegarde est arrêtée ! {{backedUpMediaCount}}/{{totalMediasToBackupCount}} élément(s) sauvegardé(s)",
         "backupErrorTitle": "Oops",
         "backupErrorBody":  "Votre sauvegarde a rencontré une erreur. Ouvrez l'app pour obtenir plus de détails"
       },


### PR DESCRIPTION
On iOS, it is not supported.

On Android, it is supported until Android 11 because android-upload-service uses Service to start foreground task in background which is deprecated since Android 12.