### PR TITLE
fix: Restore pod cache before installing node_modules on IOS CI

### DIFF
--- a/.github/workflows/build-ios-dev.yml
+++ b/.github/workflows/build-ios-dev.yml
@@ -9,13 +9,19 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
       - name: Set NodeJS version
         uses: actions/setup-node@v3
         with:
           node-version: 16
 
-      - name: Check out Git repository
-        uses: actions/checkout@v3
+      - name: Setup Ruby (bundle)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.6
+          bundler-cache: true
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -30,15 +36,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --network-timeout 300000
-
-      - name: Setup Ruby (bundle)
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7.6
-          bundler-cache: true
-
       - name: Restore Pods cache
         uses: actions/cache@v3
         with:
@@ -49,6 +46,9 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --network-timeout 300000
 
       - name: Install Pods
         run: cd ios && pod install --repo-update && cd ..

--- a/.github/workflows/build-ios-prod.yml
+++ b/.github/workflows/build-ios-prod.yml
@@ -9,13 +9,19 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
       - name: Set NodeJS version
         uses: actions/setup-node@v3
         with:
           node-version: 16
 
-      - name: Check out Git repository
-        uses: actions/checkout@v3
+      - name: Setup Ruby (bundle)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.6
+          bundler-cache: true
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -30,15 +36,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --network-timeout 300000
-
-      - name: Setup Ruby (bundle)
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7.6
-          bundler-cache: true
-
       - name: Restore Pods cache
         uses: actions/cache@v3
         with:
@@ -49,6 +46,9 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --network-timeout 300000
 
       - name: Install Pods
         run: cd ios && pod install --repo-update && cd ..


### PR DESCRIPTION
In 3b14bdb041d659addd79aa4883249f55cbf2acba we triggered the pods installation from yarn's `postinstall` event

The impact is that the pod cache should now be restored before calling `yarn install`

This would reduce the worlkflow duration by 5 to 10 min

This commit also move the Ruby installation before the `yarn install` so the CI steps are grouped in the following order:
- Environment installation
- Cache restoration
- Dependencies (node and pods) installation
- Build phase

Related commit: 3b14bdb041d659addd79aa4883249f55cbf2acba