### PR TITLE
Feat/retry upload

### DIFF
--- a/src/app/domain/backup/helpers/error.ts
+++ b/src/app/domain/backup/helpers/error.ts
@@ -55,3 +55,14 @@ export const isCancellationError = (error: UploadError): boolean => {
     error.errors[0]?.detail === 'User cancelled upload'
   )
 }
+
+export const shouldRetryCallbackBackup = (error: Error): boolean => {
+  const notRetryableError =
+    isUploadError(error) &&
+    (isMetadataExpiredError(error) ||
+      isQuotaExceededError(error) ||
+      isFileTooBigError(error) ||
+      isCancellationError(error))
+
+  return !notRetryableError
+}

--- a/src/app/domain/backup/services/uploadMedia.android.ts
+++ b/src/app/domain/backup/services/uploadMedia.android.ts
@@ -4,8 +4,9 @@ import { t } from '/locales/i18n'
 
 import CozyClient from 'cozy-client'
 
-import { uploadFileWithConflictStrategy } from '/app/domain/upload/services'
+import { uploadFileWithRetryAndConflictStrategy } from '/app/domain/upload/services'
 import { UploadResult } from '/app/domain/upload/models'
+import { shouldRetryCallbackBackup } from '/app/domain/backup/helpers/error'
 
 export const uploadMedia = async (
   client: CozyClient,
@@ -14,7 +15,7 @@ export const uploadMedia = async (
 ): Promise<UploadResult> => {
   const filepath = media.path.replace('file://', '')
 
-  return uploadFileWithConflictStrategy({
+  return uploadFileWithRetryAndConflictStrategy({
     url: uploadUrl,
     // @ts-expect-error Type issue which will be fixed in another PR
     token: client.getStackClient().token.accessToken as string,
@@ -26,6 +27,10 @@ export const uploadMedia = async (
       onProgressMessage: t('services.backup.notifications.onProgressMessage', {
         filename: media.name
       })
+    },
+    retry: {
+      nRetry: 1,
+      shouldRetryCallback: shouldRetryCallbackBackup
     }
   })
 }

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -23,7 +23,7 @@ import { areAlbumsEnabled } from '/app/domain/backup/services/manageAlbums'
 import { t } from '/locales/i18n'
 
 import type CozyClient from 'cozy-client'
-import { IOCozyFile } from 'cozy-client'
+import type { IOCozyFile } from 'cozy-client'
 import Minilog from 'cozy-minilog'
 
 import { NetworkError } from '/app/domain/upload/models'

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -85,10 +85,10 @@ export const uploadMedias = async (
         lastUploadedDocument
       )
     } catch (error) {
-      log.debug(
+      log.warn(
         `❌ ${mediaToUpload.name} not uploaded or set as backuped correctly`
       )
-      log.debug(error)
+      log.warn(error)
 
       if (error instanceof NetworkError) {
         throw new BackupError(t('services.backup.errors.networkIssue'))

--- a/src/app/domain/upload/models/index.ts
+++ b/src/app/domain/upload/models/index.ts
@@ -16,6 +16,12 @@ export interface UploadParams {
     onProgressTitle: string
     onProgressMessage: string
   }
+  retry?: Retry
+}
+
+interface Retry {
+  nRetry: number
+  shouldRetryCallback: (error: Error) => boolean
 }
 
 // These type is incomplete there is more information in data

--- a/src/app/domain/upload/services/index.spec.ts
+++ b/src/app/domain/upload/services/index.spec.ts
@@ -1,0 +1,173 @@
+import { uploadFile } from '/app/domain/upload/services/upload'
+
+import * as UploadService from './index'
+
+import type { IOCozyFile } from 'cozy-client'
+
+jest.mock('/app/domain/upload/services/upload', () => ({
+  uploadFile: jest.fn()
+}))
+
+const mockedUploadFile = uploadFile as jest.MockedFunction<typeof uploadFile>
+
+const DEFAULT_UPLOAD_PARAMS = {
+  url: '',
+  token: '',
+  filename: '',
+  filepath: '',
+  mimetype: ''
+}
+
+const DEFAULT_UPLOAD_RESULT = {
+  statusCode: 200,
+  data: {} as IOCozyFile
+}
+
+describe('uploadFileWithRetryAndConflictStrategy', () => {
+  it('should not retry if no retry policy; and fail if request fail', async () => {
+    mockedUploadFile.mockImplementationOnce(() => {
+      throw new Error('First error')
+    })
+
+    const spy = jest.spyOn(
+      UploadService,
+      'uploadFileWithRetryAndConflictStrategy'
+    )
+
+    await expect(
+      UploadService.uploadFileWithRetryAndConflictStrategy({
+        ...DEFAULT_UPLOAD_PARAMS
+      })
+    ).rejects.toThrow()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not retry if no retry policy; and succeed if request succeed', async () => {
+    mockedUploadFile.mockImplementationOnce(() => {
+      return Promise.resolve(DEFAULT_UPLOAD_RESULT)
+    })
+
+    const spy = jest.spyOn(
+      UploadService,
+      'uploadFileWithRetryAndConflictStrategy'
+    )
+
+    await expect(
+      UploadService.uploadFileWithRetryAndConflictStrategy({
+        ...DEFAULT_UPLOAD_PARAMS
+      })
+    ).resolves.toBe(DEFAULT_UPLOAD_RESULT)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should retry if retry policy; and fail if last request fail', async () => {
+    mockedUploadFile
+      .mockImplementationOnce(() => {
+        throw new Error('First error')
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('Second error')
+      })
+
+    const spy = jest.spyOn(
+      UploadService,
+      'uploadFileWithRetryAndConflictStrategy'
+    )
+
+    await expect(
+      UploadService.uploadFileWithRetryAndConflictStrategy({
+        ...DEFAULT_UPLOAD_PARAMS,
+        retry: {
+          nRetry: 1,
+          shouldRetryCallback: () => true
+        }
+      })
+    ).rejects.toThrow()
+
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should retry if retry policy; and succeed if last request succeed', async () => {
+    mockedUploadFile
+      .mockImplementationOnce(() => {
+        throw new Error('First error')
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve(DEFAULT_UPLOAD_RESULT)
+      })
+
+    const spy = jest.spyOn(
+      UploadService,
+      'uploadFileWithRetryAndConflictStrategy'
+    )
+
+    await expect(
+      UploadService.uploadFileWithRetryAndConflictStrategy({
+        ...DEFAULT_UPLOAD_PARAMS,
+        retry: {
+          nRetry: 1,
+          shouldRetryCallback: () => true
+        }
+      })
+    ).resolves.toBe(DEFAULT_UPLOAD_RESULT)
+
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should execute complex retry callback using error argument; and fail if not retryable', async () => {
+    mockedUploadFile.mockImplementationOnce(() => {
+      throw new Error('Fatal error')
+    })
+    const spy = jest.spyOn(
+      UploadService,
+      'uploadFileWithRetryAndConflictStrategy'
+    )
+
+    await expect(
+      UploadService.uploadFileWithRetryAndConflictStrategy({
+        ...DEFAULT_UPLOAD_PARAMS,
+        retry: {
+          nRetry: 1,
+          shouldRetryCallback: error => {
+            if (error.message === 'Fatal error') return false
+            return true
+          }
+        }
+      })
+    ).rejects.toThrow()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should execute complex retry callback using error argument; and succeed if retryable', async () => {
+    mockedUploadFile
+      .mockImplementationOnce(() => {
+        throw new Error('Normal error')
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve(DEFAULT_UPLOAD_RESULT)
+      })
+
+    const spy = jest.spyOn(
+      UploadService,
+      'uploadFileWithRetryAndConflictStrategy'
+    )
+
+    await expect(
+      UploadService.uploadFileWithRetryAndConflictStrategy({
+        ...DEFAULT_UPLOAD_PARAMS,
+        retry: {
+          nRetry: 1,
+          shouldRetryCallback: error => {
+            if (error.message === 'Fatal error') return false
+            return true
+          }
+        }
+      })
+    ).resolves.toBe(DEFAULT_UPLOAD_RESULT)
+
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
 **feat: Add an upload with a retry strategy**

Allow to retry n times an upload.
Allow to specify errors triggering retry.
Default to no retry.

**feat(backup): Retry upload 1 time for some errors** 