### PR TITLE
feat: (Clisk) Catch and log downloadFileInWorker errors

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -458,11 +458,25 @@ export default class Launcher {
       sourceAccount: job.message.account,
       sourceAccountIdentifier,
       // @ts-ignore
-      downloadAndFormatFile: async entry => ({
-        ...entry,
-        // @ts-ignore
-        dataUri: await this.worker.call('downloadFileInWorker', entry)
-      }),
+      downloadAndFormatFile: async entry => {
+        try {
+          // @ts-ignore
+          const dataUri = await this.worker.call('downloadFileInWorker', entry)
+          return {
+            ...entry,
+            dataUri
+          }
+        } catch (err) {
+          this.log({
+            level: 'warning',
+            // @ts-ignore
+            message: `Could not download entry: ${entry.fileurl}: ${err.message}`,
+            label: 'downloadAndFormatFile',
+            namespace: 'Launcher'
+          })
+          return entry
+        }
+      },
       existingFilesIndex
     })
     log.debug(result, 'saveFiles result')


### PR DESCRIPTION
If there was an error in the downloadFileInWorker function, it would
cause the whole clisk konnector run to fail

Now, the error is caught and a warning error will be visible in the
konnector logs.

This is also coherent with the behavior of node konnectors.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

