### PR TITLE
Feat/update local data backup

### DIFF
--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -120,8 +120,12 @@ declare module 'cozy-client' {
     }[]
   }
 
+  interface MissingFileDocumentAttributes {
+    md5sum: string
+  }
+
   type IOCozyFile = {
-    attributes: FileDocument
+    attributes: MissingFileDocumentAttributes & FileDocument
   } & CozyClientDocument
 
   interface Collection {

--- a/src/app/domain/backup/helpers/index.ts
+++ b/src/app/domain/backup/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from '/app/domain/backup/helpers/error'
 export * from '/app/domain/backup/helpers/file'
+export * from '/app/domain/backup/helpers/media'

--- a/src/app/domain/backup/helpers/media.ts
+++ b/src/app/domain/backup/helpers/media.ts
@@ -1,0 +1,8 @@
+import { Media, BackupedMedia } from '/app/domain/backup/models'
+
+export const isSameMedia = (
+  a: Media | BackupedMedia,
+  b: Media | BackupedMedia
+): boolean => {
+  return a.uri === b.uri
+}

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -10,6 +10,7 @@ import { Album } from '/app/domain/backup/models'
  */
 export interface Media {
   name: string
+  uri: string
   path: string
   remotePath: string
   type: 'image' | 'video'
@@ -23,12 +24,18 @@ export interface Media {
 
 /**
  * A selection of media metadata stored locally to identify if a media has already been backuped
- * @member {string} name
- * @member {string} remotePath e.g. /Sauvegardé depuis mon mobile/My Android/Download
- * @member {string} remoteName e.g. IMG_001 (1).jpg (added only if different from name)
+ * @member {string} name e.g. "IMG_50.jpg"
+ * @member {string} uri e.g. "file:///storage/emulated/0/Download/IMG_50.jpg" on Android or "ph://0E75CF5E-4587-4BD7-AB07-E940BB627C4B/L0/001" on iOS
+ * @member {number} creationDate e.g. 1694523521000
+ * @member {number} modificationDate e.g. 1694172391000
+ * @member {string} remoteId e.g. "d78a3c84139d173dde3b87df0003b32e"
+ * @member {string} remotePath e.g. "/Sauvegardé depuis mon mobile/My Android/Download"
  */
 export interface BackupedMedia {
   name: string
+  uri: string
+  creationDate: number
+  modificationDate: number
+  remoteId: string
   remotePath: string
-  remoteName?: string
 }

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -30,7 +30,6 @@ export interface Media {
  * @member {number} creationDate timestamp with ms set to 0, e.g. 1694523521000
  * @member {number} modificationDate timestamp with ms set to 0, e.g. 1694172391000
  * @member {string} remoteId e.g. "d78a3c84139d173dde3b87df0003b32e"
- * @member {string} remotePath e.g. "/Sauvegardé depuis mon mobile/My Android/Download"
  */
 export interface BackupedMedia {
   name: string
@@ -38,5 +37,4 @@ export interface BackupedMedia {
   creationDate: number
   modificationDate: number
   remoteId: string
-  remotePath: string
 }

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -6,7 +6,8 @@ import { Album } from '/app/domain/backup/models'
  * @member {number} path
  * @member {string} remotePath e.g. /Sauvegardé depuis mon mobile/My Android/Download
  * @member {string} type
- * @member {number} creationDate
+ * @member {number} creationDate timestamp with ms set to 0
+ * @member {number} modificationDate  timestamp with ms set to 0
  */
 export interface Media {
   name: string
@@ -26,8 +27,8 @@ export interface Media {
  * A selection of media metadata stored locally to identify if a media has already been backuped
  * @member {string} name e.g. "IMG_50.jpg"
  * @member {string} uri e.g. "file:///storage/emulated/0/Download/IMG_50.jpg" on Android or "ph://0E75CF5E-4587-4BD7-AB07-E940BB627C4B/L0/001" on iOS
- * @member {number} creationDate e.g. 1694523521000
- * @member {number} modificationDate e.g. 1694172391000
+ * @member {number} creationDate timestamp with ms set to 0, e.g. 1694523521000
+ * @member {number} modificationDate timestamp with ms set to 0, e.g. 1694172391000
  * @member {string} remoteId e.g. "d78a3c84139d173dde3b87df0003b32e"
  * @member {string} remotePath e.g. "/Sauvegardé depuis mon mobile/My Android/Download"
  */

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -30,6 +30,7 @@ export interface Media {
  * @member {number} creationDate timestamp with ms set to 0, e.g. 1694523521000
  * @member {number} modificationDate timestamp with ms set to 0, e.g. 1694172391000
  * @member {string} remoteId e.g. "d78a3c84139d173dde3b87df0003b32e"
+ * @member {string} md5 e.g. "anQfyi/m1NIso1mHyYIzPA=="
  */
 export interface BackupedMedia {
   name: string
@@ -37,4 +38,5 @@ export interface BackupedMedia {
   creationDate: number
   modificationDate: number
   remoteId: string
+  md5: string
 }

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -25,6 +25,7 @@ export interface Media {
 
 /**
  * A selection of media metadata stored locally to identify if a media has already been backuped
+ * When it is not prefixed by remote, it means that it is the local value, or at least the local value when we backed up the media
  * @member {string} name e.g. "IMG_50.jpg"
  * @member {string} uri e.g. "file:///storage/emulated/0/Download/IMG_50.jpg" on Android or "ph://0E75CF5E-4587-4BD7-AB07-E940BB627C4B/L0/001" on iOS
  * @member {number} creationDate timestamp with ms set to 0, e.g. 1694523521000

--- a/src/app/domain/backup/queries/index.ts
+++ b/src/app/domain/backup/queries/index.ts
@@ -18,7 +18,8 @@ export const buildFilesQuery = (deviceId: string): QueryDefinition => {
       'name',
       'path',
       'created_at',
-      'updated_at'
+      'updated_at',
+      'md5sum'
     ])
 }
 
@@ -32,6 +33,7 @@ export interface File {
   path: string
   created_at: number
   updated_at: number
+  md5sum: string
 }
 
 export type FilesQueryAllResult = File[]

--- a/src/app/domain/backup/queries/index.ts
+++ b/src/app/domain/backup/queries/index.ts
@@ -12,7 +12,14 @@ export const buildFilesQuery = (deviceId: string): QueryDefinition => {
       }
     })
     .indexFields(['metadata.backupDeviceIds', 'type'])
-    .select(['metadata.backupDeviceIds', 'type', 'name', 'path'])
+    .select([
+      'metadata.backupDeviceIds',
+      'type',
+      'name',
+      'path',
+      'created_at',
+      'updated_at'
+    ])
 }
 
 export const buildFileQuery = (id: string): QueryDefinition => {
@@ -23,6 +30,8 @@ export interface File {
   id: string
   name: string
   path: string
+  created_at: number
+  updated_at: number
 }
 
 export type FilesQueryAllResult = File[]

--- a/src/app/domain/backup/services/getMedias.spec.ts
+++ b/src/app/domain/backup/services/getMedias.spec.ts
@@ -66,12 +66,13 @@ describe('formatMediasFromPhotoIdentifier', () => {
     expect(media).toEqual([
       {
         name: 'IMG_20230519_204453.jpg',
+        uri: 'file:///storage/emulated/0/Pictures/IMG_20230519_204453.jpg',
         path: 'file:///storage/emulated/0/Pictures/IMG_20230519_204453.jpg',
         remotePath: '/Pictures',
         type: 'image',
         mimeType: 'image/jpeg',
         fileSize: 1234,
-        creationDate: 1684521894234,
+        creationDate: 1684521894000,
         modificationDate: 1684521894000,
         albums: [{ name: 'Pictures' }]
       }
@@ -108,13 +109,14 @@ describe('formatMediasFromPhotoIdentifier', () => {
     expect(media).toEqual([
       {
         name: 'IMG_0744.HEIC',
+        uri: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
         path: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
         remotePath: '/',
         type: 'image',
         fileSize: 1234,
         mimeType: undefined,
-        creationDate: 1682604478599,
-        modificationDate: 1688756699463.186,
+        creationDate: 1682604478000,
+        modificationDate: 1688756699000,
         albums: [{ name: 'Pictures' }]
       }
     ])
@@ -150,26 +152,28 @@ describe('formatMediasFromPhotoIdentifier', () => {
     expect(media).toEqual([
       {
         name: 'IMG_0744.MOV',
+        uri: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
         path: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
         remotePath: '/',
         type: 'video',
         subType: 'PhotoLive',
         mimeType: undefined,
-        creationDate: 1682604478599,
-        modificationDate: 1688756699463.186,
+        creationDate: 1682604478000,
+        modificationDate: 1688756699000,
         albums: [{ name: 'Pictures' }],
         fileSize: null
       },
       {
         name: 'IMG_0744.HEIC',
+        uri: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
         path: 'ph://5FD84686-207F-40F1-BCE8-3A837275B0E3/L0/001',
         remotePath: '/',
         type: 'image',
         subType: 'PhotoLive',
         mimeType: undefined,
         fileSize: 1234,
-        creationDate: 1682604478599,
-        modificationDate: 1688756699463.186,
+        creationDate: 1682604478000,
+        modificationDate: 1688756699000,
         albums: [{ name: 'Pictures' }]
       }
     ])

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -19,7 +19,8 @@ import {
 import { getLocalBackupConfig } from '/app/domain/backup/services/manageLocalBackupConfig'
 import {
   getPathWithoutExtension,
-  getPathWithoutFilename
+  getPathWithoutFilename,
+  isSameMedia
 } from '/app/domain/backup/helpers'
 import { getBackupInfo } from '/app/domain/backup/services/manageBackup'
 import { t } from '/locales/i18n'
@@ -204,10 +205,8 @@ const isMediaAlreadyBackuped = (
   mediaToCheck: Media,
   backupedMedias: BackupedMedia[]
 ): boolean => {
-  const isAlreadyBackuped = backupedMedias.some(
-    backupedMedia =>
-      mediaToCheck.name === backupedMedia.name &&
-      mediaToCheck.remotePath === backupedMedia.remotePath
+  const isAlreadyBackuped = backupedMedias.some(backupedMedia =>
+    isSameMedia(mediaToCheck, backupedMedia)
   )
 
   return isAlreadyBackuped

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -163,11 +163,15 @@ const getAlbums = (photoIdentifier: PhotoIdentifier): Album[] => {
 
 export const getAllMedias = async (
   client: CozyClient,
-  onProgress: ProgressCallback
+  onProgress?: ProgressCallback
 ): Promise<Media[]> => {
   const allMedias = []
 
-  const backupInfo = await getBackupInfo(client)
+  let backupInfo
+
+  if (onProgress) {
+    backupInfo = await getBackupInfo(client)
+  }
 
   let hasNextPage = true
   let endCursor: CameraRollCursor
@@ -180,9 +184,11 @@ export const getAllMedias = async (
       .flat()
     allMedias.push(...newMedias)
 
-    backupInfo.currentBackup.mediasLoadedCount = allMedias.length
+    if (onProgress && backupInfo) {
+      backupInfo.currentBackup.mediasLoadedCount = allMedias.length
 
-    void onProgress(backupInfo)
+      void onProgress(backupInfo)
+    }
 
     hasNextPage = photoIdentifiersPage.page_info.has_next_page
     endCursor = photoIdentifiersPage.page_info.end_cursor
@@ -206,7 +212,7 @@ const isMediaAlreadyBackuped = (
 
 export const getMediasToBackup = async (
   client: CozyClient,
-  onProgress: ProgressCallback
+  onProgress?: ProgressCallback
 ): Promise<Media[]> => {
   const allMedias = await getAllMedias(client, onProgress)
 

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -99,6 +99,7 @@ export const formatMediasFromPhotoIdentifier = (
     return [
       {
         name: getPathWithoutExtension(filename) + '.MOV',
+        uri: uri,
         path: uri,
         remotePath: getRemotePath(uri),
         type: 'video',
@@ -110,6 +111,7 @@ export const formatMediasFromPhotoIdentifier = (
       },
       {
         name: filename,
+        uri: uri,
         path: uri,
         remotePath: getRemotePath(uri),
         type: 'image',
@@ -125,6 +127,7 @@ export const formatMediasFromPhotoIdentifier = (
   return [
     {
       name: filename,
+      uri: uri,
       path: uri,
       remotePath: getRemotePath(uri),
       type: type.includes('image') ? 'image' : 'video',

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -104,8 +104,8 @@ export const formatMediasFromPhotoIdentifier = (
         remotePath: getRemotePath(uri),
         type: 'video',
         subType: 'PhotoLive',
-        creationDate: timestamp * 1000,
-        modificationDate: modificationTimestamp * 1000,
+        creationDate: Math.trunc(timestamp) * 1000,
+        modificationDate: Math.trunc(modificationTimestamp) * 1000,
         albums,
         fileSize: null
       },
@@ -116,8 +116,8 @@ export const formatMediasFromPhotoIdentifier = (
         remotePath: getRemotePath(uri),
         type: 'image',
         subType: 'PhotoLive',
-        creationDate: timestamp * 1000,
-        modificationDate: modificationTimestamp * 1000,
+        creationDate: Math.trunc(timestamp) * 1000,
+        modificationDate: Math.trunc(modificationTimestamp) * 1000,
         albums,
         fileSize
       }
@@ -132,8 +132,8 @@ export const formatMediasFromPhotoIdentifier = (
       remotePath: getRemotePath(uri),
       type: type.includes('image') ? 'image' : 'video',
       mimeType: Platform.OS == 'android' ? type : undefined,
-      creationDate: timestamp * 1000,
-      modificationDate: modificationTimestamp * 1000,
+      creationDate: Math.trunc(timestamp) * 1000,
+      modificationDate: Math.trunc(modificationTimestamp) * 1000,
       albums,
       fileSize
     }

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -113,13 +113,12 @@ export const setMediaAsBackuped = async (
   )
 
   if (!backupedMedia) {
-    const newBackupedMedia = {
+    const newBackupedMedia: BackupedMedia = {
       name: media.name,
       uri: media.uri,
       creationDate: media.creationDate,
       modificationDate: media.modificationDate,
-      remoteId: documentCreated.id as string,
-      remotePath: media.remotePath
+      remoteId: documentCreated.id as string
     }
 
     localBackupConfig.backupedMedias.push(newBackupedMedia)

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -10,6 +10,7 @@ import {
   LastBackup
 } from '/app/domain/backup/models'
 import { buildFileQuery } from '/app/domain/backup/queries'
+import { isSameMedia } from '/app/domain/backup/helpers'
 import {
   getUserPersistedData,
   storeUserPersistedData,
@@ -107,10 +108,8 @@ export const setMediaAsBackuped = async (
   const localBackupConfig = await getLocalBackupConfig(client)
 
   // add media to backuped medias
-  const backupedMedia = localBackupConfig.backupedMedias.find(
-    backupedMedia =>
-      backupedMedia.name === media.name &&
-      backupedMedia.remotePath === media.remotePath
+  const backupedMedia = localBackupConfig.backupedMedias.find(backupedMedia =>
+    isSameMedia(backupedMedia, media)
   )
 
   if (!backupedMedia) {

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -116,11 +116,11 @@ export const setMediaAsBackuped = async (
   if (!backupedMedia) {
     const newBackupedMedia = {
       name: media.name,
+      uri: media.uri,
+      creationDate: media.creationDate,
+      modificationDate: media.modificationDate,
+      remoteId: documentCreated.id as string,
       remotePath: media.remotePath
-    } as BackupedMedia
-
-    if (documentCreated.attributes.name !== media.name) {
-      newBackupedMedia.remoteName = documentCreated.attributes.name
     }
 
     localBackupConfig.backupedMedias.push(newBackupedMedia)

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -118,7 +118,8 @@ export const setMediaAsBackuped = async (
       uri: media.uri,
       creationDate: media.creationDate,
       modificationDate: media.modificationDate,
-      remoteId: documentCreated.id as string
+      remoteId: documentCreated.id as string,
+      md5: documentCreated.attributes.md5sum
     }
 
     localBackupConfig.backupedMedias.push(newBackupedMedia)

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.ts
@@ -261,7 +261,8 @@ const formatBackupedMedia = (
     uri: correspondingMedia.uri,
     creationDate: correspondingMedia.creationDate,
     modificationDate: correspondingMedia.modificationDate,
-    remoteId: file.id
+    remoteId: file.id,
+    md5: file.md5sum
   }
 }
 

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.ts
@@ -18,7 +18,6 @@ import {
   File,
   FilesQueryAllResult
 } from '/app/domain/backup/queries'
-import { getPathWithoutFilename } from '/app/domain/backup/helpers'
 import { getAllMedias } from '/app/domain/backup/services/getMedias'
 import { t } from '/locales/i18n'
 
@@ -257,22 +256,12 @@ const formatBackupedMedia = (
 
   if (!correspondingMedia) return undefined
 
-  const pathWithBackupFolderRemoved = file.path.replace(
-    deviceRemoteBackupConfig.backupFolder.path,
-    ''
-  )
-
-  const pathWithFilenameRemoved = getPathWithoutFilename(
-    pathWithBackupFolderRemoved
-  )
-
   return {
     name: correspondingMedia.name,
     uri: correspondingMedia.uri,
     creationDate: correspondingMedia.creationDate,
     modificationDate: correspondingMedia.modificationDate,
-    remoteId: file.id,
-    remotePath: pathWithFilenameRemoved || '/'
+    remoteId: file.id
   }
 }
 


### PR DESCRIPTION
This PR has 3 goals : 
- store more data in local storage for backed up media to be more future proof
- change the way we compare local media and backed up media
  - now we just compare local uri (which is saved when a file is uploaded or a restoration is done)
- change the way we consider an external media restored from Cozy Drive to be identical to a local media (instead of _name + path_ we use _name + creation date + modification date_)

