### PR TITLE
fix: Hide `secure_background` SplashScreen on app start

### DIFF
--- a/src/hooks/useSplashScreen.ts
+++ b/src/hooks/useSplashScreen.ts
@@ -21,6 +21,8 @@ export const useSecureBackgroundSplashScreen = (): void => {
       }
     })
 
+    safePromise(hideSplashScreen)('secure_background')
+
     return () => {
       subscription.remove()
     }


### PR DESCRIPTION
The `secure_background` SplashScreen is meant to be displayed when the app is sent to OS background, then to be hidden when the app becomes active again

When starting the app, the `secure_background` should not be displayed, so we did not try to hide it when implementing this feature

But we encountered a bug that would happen when the "change icon" mechanism occurs on Android

When this happen, if the app is sent to background, then the `secure_background` is displayed and then the app is killed (or maybe it is just the app's main activity but not the entire app?). Then when the user re-open the app, the react-native code is executed like if it was an app's startup, but in fact the app is still in the previous state with the `secure_background` SplashScreen is displayed. And because the app did start from scratch, the
`useSecureBackgroundSplashScreen()` hook was not listening any event yet and so did not hide it

To fix this we need to call `hideSplashScreen('secure_background')` on startup. This would do nothing 99% of the time, but would fix this bug the rare cases when it happens