### PR TITLE
fix: Do not set the size of the worker to 0 when hidden

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -50,6 +50,8 @@ export class LauncherView extends Component {
     this.onCreatedAccount = this.onCreatedAccount.bind(this)
     this.onCreatedJob = this.onCreatedJob.bind(this)
     this.onStoppedJob = this.onStoppedJob.bind(this)
+    this.onPilotWebviewKilled = this.onPilotWebviewKilled.bind(this)
+    this.onWorkerWebviewKilled = this.onWorkerWebviewKilled.bind(this)
     this.pilotWebView = null
     this.workerWebview = null
     this.state = {
@@ -261,6 +263,8 @@ export class LauncherView extends Component {
                 }}
                 useWebKit={true}
                 javaScriptEnabled={true}
+                onContentProcessDidTerminate={this.onPilotWebviewKilled}
+                onRenderProcessGone={this.onPilotWebviewKilled}
                 sharedCookiesEnabled={true}
                 onMessage={this.onPilotMessage}
                 onError={this.onPilotError}
@@ -290,6 +294,8 @@ export class LauncherView extends Component {
                 onLoad={this.onWorkerLoad}
                 useWebKit={true}
                 javaScriptEnabled={true}
+                onContentProcessDidTerminate={this.onWorkerWebviewKilled}
+                onRenderProcessGone={this.onWorkerWebviewKilled}
                 userAgent={this.state.userAgent}
                 source={{
                   uri: this.state.worker.url
@@ -351,6 +357,30 @@ export class LauncherView extends Component {
     if (this.launcher) {
       this.launcher.onPilotMessage(event)
     }
+  }
+  /**
+   * When the pilot webview is killed
+   *
+   * @param {Object} event
+   */
+  onPilotWebviewKilled(syntheticEvent) {
+    const { nativeEvent } = syntheticEvent
+    this.launcher.log({
+      level: 'error',
+      msg: 'Pilot webview terminated: ' + JSON.stringify(nativeEvent)
+    })
+  }
+  /**
+   * When the worker webview is killed
+   *
+   * @param {Object} event
+   */
+  onWorkerWebviewKilled(syntheticEvent) {
+    const { nativeEvent } = syntheticEvent
+    this.launcher.log({
+      level: 'error',
+      msg: 'Worker webview terminated: ' + JSON.stringify(nativeEvent)
+    })
   }
   /**
    * Postmessage relay from the worker to  the launcher

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -397,8 +397,8 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: -2000,
     top: -2000,
-    height: 0,
-    width: 0,
+    height: '100%',
+    width: '100%',
     flex: 0
   },
   headerStyle: {


### PR DESCRIPTION
We had a problem with the MGEN clisk which, when we set with and height to 0, caused the website to loop infinitely. Because of this loop, the worker could be killed.

In order to stay as close as possible to the user experience when a clisk is launched, we decided to set the with and height to 100%.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [X] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

