### PR TITLE
fix: Add missing `%2F` in MaBulle Cloudery url

### DIFF
--- a/white_label/brands/mabulle/js/constants/strings.json
+++ b/white_label/brands/mabulle/js/constants/strings.json
@@ -34,8 +34,8 @@
     "devBaseUri": "https://manager-dev.cozycloud.cc",
     "cozyLoginRelativeUri": "/v2/neutral/start",
     "cozySigninRelativeUri": "/v2/postcode",
-    "iOSQueryString": "universallink_for_email=https%3A%2F%links.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%links.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
-    "androidQueryString": "universallink_for_email=https%3A%2F%links.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%links.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship"
+    "iOSQueryString": "universallink_for_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+    "androidQueryString": "universallink_for_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship"
   },
   "defaultHttpScheme": "https://",
   "emptyString": "",


### PR DESCRIPTION
In #930, we unexpectedly removed `2F` from the Cloudery url in the MaBulle version