### PR TITLE
 feat: Read user agent value from react-native-config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # Only the SENTRY_AUTH_TOKEN is mandatory when developing locally. 
 # You will need more credentials if you need to produce actual signed builds.
 
+# Please run `pod install` after editing this file. Otherwise react-native-config
+# won't see the changes on iOS
+
 # --- ANDROID BUILD ---
 
 # ANDROID_ALIAS="Alias of the signing key"

--- a/.env.example
+++ b/.env.example
@@ -29,4 +29,5 @@
 
 # --- OTHER SECRETS ---
 
+# USER_AGENT="User agent used by cozy-client and WebView (this value is writen by `yarn brand:configure:<brand_name>` command)"
 SENTRY_AUTH_TOKEN="Auth token for Sentry - MANDATORY"

--- a/.github/workflows/build-android-dev.yml
+++ b/.github/workflows/build-android-dev.yml
@@ -78,13 +78,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-caches-
 
-      - name: Set white label brand
-        run: yarn brand:configure:${{ inputs.brand }} --force
-        
       - name: 'Create env file'
         run: |
           touch .env
           echo ANDROID_SAFETY_NET_API_KEY=${{ secrets.ANDROID_SAFETY_NET_API_KEY }} >> .env
+
+      - name: Set white label brand
+        run: yarn brand:configure:${{ inputs.brand }} --force
 
       - name: Make Gradlew Executable
         run: cd android && chmod +x ./gradlew

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -70,13 +70,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-caches-
 
-      - name: Set white label brand
-        run: yarn brand:configure:${{ inputs.brand }} --force
-
       - name: 'Create env file'
         run: |
           touch .env
           echo ANDROID_SAFETY_NET_API_KEY=${{ secrets.ANDROID_SAFETY_NET_API_KEY }} >> .env
+
+      - name: Set white label brand
+        run: yarn brand:configure:${{ inputs.brand }} --force
 
       - name: Make Gradlew Executable
         run: cd android && chmod +x ./gradlew

--- a/.github/workflows/build-ios-dev.yml
+++ b/.github/workflows/build-ios-dev.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Install Pods
         run: cd ios && pod install --repo-update && cd ..
 
+      - name: 'Create env file'
+        run: |
+          touch .env
+
       - name: Set white label brand
         run: yarn brand:configure:${{ inputs.brand }} --force
 

--- a/.github/workflows/build-ios-dev.yml
+++ b/.github/workflows/build-ios-dev.yml
@@ -60,15 +60,15 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --network-timeout 300000
 
-      - name: Install Pods
-        run: cd ios && pod install --repo-update && cd ..
-
       - name: 'Create env file'
         run: |
           touch .env
 
       - name: Set white label brand
         run: yarn brand:configure:${{ inputs.brand }} --force
+
+      - name: Install Pods
+        run: cd ios && pod install --repo-update && cd ..
 
       - name: Build IOS App
         env:

--- a/.github/workflows/build-ios-prod.yml
+++ b/.github/workflows/build-ios-prod.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Install Pods
         run: cd ios && pod install --repo-update && cd ..
 
+      - name: 'Create env file'
+        run: |
+          touch .env
+
       - name: Set white label brand
         run: yarn brand:configure:${{ inputs.brand }} --force
 

--- a/.github/workflows/build-ios-prod.yml
+++ b/.github/workflows/build-ios-prod.yml
@@ -60,15 +60,15 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --network-timeout 300000
 
-      - name: Install Pods
-        run: cd ios && pod install --repo-update && cd ..
-
       - name: 'Create env file'
         run: |
           touch .env
 
       - name: Set white label brand
         run: yarn brand:configure:${{ inputs.brand }} --force
+
+      - name: Install Pods
+        run: cd ios && pod install --repo-update && cd ..
 
       - name: Build IOS App
         env:

--- a/android/app/src/main/java/io/cozy/flagship/mobile/UserAgentInterceptor.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/UserAgentInterceptor.java
@@ -16,7 +16,7 @@ public class UserAgentInterceptor implements Interceptor {
     Request originalRequest = chain.request();
     Request requestWithUserAgent = originalRequest.newBuilder()
       .removeHeader("User-Agent")
-      .addHeader("User-Agent", BuildConfig.APPLICATION_ID + "-" + BuildConfig.VERSION_NAME)
+      .addHeader("User-Agent", BuildConfig.USER_AGENT + "-" + BuildConfig.VERSION_NAME)
       .build();
 
     return chain.proceed(requestWithUserAgent);

--- a/ios/CozyReactNative/AppDelegate.m
+++ b/ios/CozyReactNative/AppDelegate.m
@@ -9,6 +9,7 @@
 #import <React/RCTHTTPRequestHandler.h>
 
 #import "RNBootSplash.h" // <- add the header import
+#import "RNCConfig.h"
 
 #import <Firebase.h>
 
@@ -36,8 +37,8 @@ static void SetCustomNSURLSessionConfiguration() {
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
 
     NSString * appVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-    NSString * bundleIdentifier = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
-    NSString * userAgent = [NSString stringWithFormat:@"%@-%@", bundleIdentifier, appVersionString];
+    NSString * userAgentNamespace = [RNCConfig envFor:@"USER_AGENT"];
+    NSString * userAgent = [NSString stringWithFormat:@"%@-%@", userAgentNamespace, appVersionString];
     configuration.HTTPAdditionalHeaders = @{ @"User-Agent": userAgent };
 
     return configuration;

--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -10,7 +10,6 @@
   "REDIRECT": "redirect",
   "SESSION_CODE": "session_code",
   "SESSION_CREATED_FLAG": "@cozy_AmiralAppSessionCreated",
-  "USER_AGENT": "io.cozy.flagship.mobile",
   "ORIGIN_WHITELIST": [
     "http://*",
     "https://*",

--- a/src/constants/userAgent.ts
+++ b/src/constants/userAgent.ts
@@ -1,9 +1,11 @@
+import Config from 'react-native-config'
+
 import { version } from '../../package.json'
 
-import strings from '/constants/strings.json'
+const userAgentNamespace = Config.USER_AGENT ?? 'io.cozy.unknown.mobile'
 
 // This is the User-Agent that is globally used in the application.
-export const USER_AGENT = `${strings.USER_AGENT}-${version}`
+export const USER_AGENT = `${userAgentNamespace}-${version}`
 
 // This is User-Agent that is used in the application for the webviews.
 export const APPLICATION_NAME_FOR_USER_AGENT = USER_AGENT

--- a/white_label/brands/cozy/js/constants/extra-strings.json
+++ b/white_label/brands/cozy/js/constants/extra-strings.json
@@ -1,7 +1,6 @@
 {
   "COZY_SCHEME": "cozy://",
   "UNIVERSAL_LINK_BASE": "https://links.mycozy.cloud/flagship",
-  "USER_AGENT": "io.cozy.flagship.mobile",
   "cloudery": {
     "iOSQueryString": "universallink_for_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=cozy%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
     "androidQueryString": "universallink_for_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=cozy%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship"

--- a/white_label/brands/mabulle/js/constants/extra-strings.json
+++ b/white_label/brands/mabulle/js/constants/extra-strings.json
@@ -1,7 +1,6 @@
 {
   "COZY_SCHEME": "mabulle://",
   "UNIVERSAL_LINK_BASE": "https://links.mabullecozy.cloud/flagship",
-  "USER_AGENT": "io.cozy.flagship.mobile",
   "cloudery": {
     "iOSQueryString": "universallink_for_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
     "androidQueryString": "universallink_for_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship"

--- a/white_label/config.json
+++ b/white_label/config.json
@@ -4,13 +4,15 @@
     "bundleId": "io.cozy.flagship.mobile",
     "provisionningProfile": "amiral-ci-profile",
     "provisionningDevProfile": "amiral-dev-profile",
-    "scheme": "cozy"
+    "scheme": "cozy",
+    "userAgent": "io.cozy.flagship.mobile"
   },
   "mabulle": {
     "appName": "Ma Bulle",
     "bundleId": "io.cozy.flagship.mobile.mabulle",
     "provisionningProfile": "amiral-mabulle-ci-profile",
     "provisionningDevProfile": "amiral-mabulle-dev-profile",
-    "scheme": "mabulle"
+    "scheme": "mabulle",
+    "userAgent": "io.cozy.mabulle.mobile"
   }
 }

--- a/white_label/configure-brand.ts
+++ b/white_label/configure-brand.ts
@@ -37,6 +37,7 @@ export const configureBrand = async (brand: string): Promise<void> => {
     await configureAndroid(brand)
     await configureIOS(brand)
     await configureJS(brand)
+    await configureEnv(brand)
   } catch (error) {
     logger.error('Could not apply changes:', error)
   }
@@ -109,6 +110,30 @@ const configureJS = async (brand: string): Promise<void> => {
       await fs.copy(file, originalFile)
     }
   }
+}
+
+const configureEnv = async (brand: string): Promise<void> => {
+  logger.info('Edit .env file')
+  const config = configs[brand as keyof typeof configs]
+  const envContent = await fs.readFile('.env', 'utf8')
+  let newEnvContent = envContent
+
+  const userAgentRegex = /^USER_AGENT=".*"/m
+  const newUserAgent = `USER_AGENT="${config.userAgent}"`
+
+  if (userAgentRegex.test(newEnvContent)) {
+    newEnvContent = newEnvContent.replace(userAgentRegex, newUserAgent)
+  } else {
+    newEnvContent += `\n${newUserAgent}\n`
+  }
+
+  if (envContent !== newEnvContent) {
+    logger.warn(
+      '.env file has been modified, please run `pod install` to apply changes'
+    )
+  }
+
+  await fs.writeFile('.env', newEnvContent)
 }
 
 const executeCommand = async (command: string): Promise<string> => {


### PR DESCRIPTION
We want react-native-config to be able to read the user agent value so
we can configure it for HTTP queries in both JS, Android and iOS sides

The user agent value should now be set in `white_label/config.json`
file

Then the `yarn brand:configure:<brand_name>` command will add/replace
the user agent environment variable in `.env` file