### PR TITLE
fix: Discard persisted state on Android Activity restart

### DIFF
--- a/android/app/src/main/java/io/cozy/flagship/mobile/MainActivity.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/MainActivity.java
@@ -21,7 +21,7 @@ public class MainActivity extends ReactActivity {
   protected void onCreate(Bundle savedInstanceState) {
     boolean isDarkMode = true;
     ImmersiveBars.changeBarColors(this, isDarkMode);
-    super.onCreate(savedInstanceState);
+    super.onCreate(null);
     RNBootSplash.init(R.drawable.bootsplash, MainActivity.this);
   }
 }


### PR DESCRIPTION
PlayStore console reported some crashes related to react-native-screens that are related to Activity's `onCreate` method

This bug is well documented in the react-native-screens repository and the recommended action is to discard the Activity's persisted state when restarted

This is because the JS state (redux stores, in-component state etc) is not persisted the same way as the Android activity state, so there can be some inconsistencies between them when the app is restarted

Discarding the state implies that if Android kills the Activity when app is on background, then on when going back to the app it will behave like if it was a fresh start

Another impact is for foldable phones in which the app will restart when splitted into multi-window. But as the app does not support this mode, then this would not be an issue (at least for now)

Related documentation:
https://github.com/software-mansion/react-native-screens#android

Related issue:
https://github.com/software-mansion/react-native-screens/issues/17