### PR TITLE
feat: Pass `flagship_app=mabulle` param to the Cloudery web page

### DIFF
--- a/white_label/brands/mabulle/js/constants/extra-strings.json
+++ b/white_label/brands/mabulle/js/constants/extra-strings.json
@@ -2,7 +2,7 @@
   "COZY_SCHEME": "mabulle://",
   "UNIVERSAL_LINK_BASE": "https://links.mabullecozy.cloud/flagship",
   "cloudery": {
-    "iOSQueryString": "universallink_for_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
-    "androidQueryString": "universallink_for_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship"
+    "iOSQueryString": "flagship_app=mabulle&universallink_for_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship",
+    "androidQueryString": "flagship_app=mabulle&universallink_for_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fmanager&redirect_after_email=https%3A%2F%2Flinks.mabullecozy.cloud%2Fflagship%2Fonboarding%3Fflagship%3Dtrue%26fallback=mabulle%253A%252F%252Fonboarding%253Fflagship%253Dtrue&redirect_after_login=https%3A%2F%2Floginflagship"
   }
 }


### PR DESCRIPTION
We want the Cloudery to be able to display info specific to current brand

So when the Flagship app differs from the Cozy version we add the `flagship_app` param with the brand name

If the parameter is not provided, then the Cloudery defaults to Cozy version
