### PR TITLE
feat: Implement email login for OIDC accounts

### DIFF
--- a/src/app/view/Manager/useManagerScreen.ts
+++ b/src/app/view/Manager/useManagerScreen.ts
@@ -23,6 +23,10 @@ import {
   showSplashScreen
 } from '/app/theme/SplashScreenService'
 import { useHomeStateContext } from '/screens/home/HomeStateProvider'
+import {
+  isOidcNavigationRequest,
+  processOIDC
+} from '/screens/login/components/functions/oidc'
 
 const log = Minilog('useManagerScreen')
 
@@ -119,6 +123,25 @@ export const useManagerScreenProps = (
       )
       return false
     }
+
+    const isOidc = isOidcNavigationRequest(initialRequest)
+    if (isOidc) {
+      processOIDC(initialRequest)
+        .then(oidcResult => {
+          reset(routes.authenticate, oidcResult)
+          return
+        })
+        .catch(error => {
+          if (error === 'USER_CANCELED') {
+            reset(routes.welcome)
+          } else {
+            void hideSplashScreen()
+            reset(routes.error, { type: strings.errorScreens.managerError })
+          }
+        })
+      return false
+    }
+
     return true
   }
 

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -105,6 +105,8 @@ const LoginSteps = ({
   useEffect(() => {
     const fqdn = consumeRouteParameter('fqdn', route, navigation)
     const magicCode = consumeRouteParameter('magicCode', route, navigation)
+    const oauthCode = consumeRouteParameter('code', route, navigation)
+    const onboardUrl = consumeRouteParameter('onboardUrl', route, navigation)
     if (fqdn) {
       const instanceData = getInstanceDataFromFqdn(fqdn)
 
@@ -121,9 +123,24 @@ const LoginSteps = ({
 
       if (magicCode) {
         startMagicLinkOAuth(instanceData.fqdn, magicCode)
+      } else if (oauthCode) {
+        startOidcOAuth(instanceData.fqdn, oauthCode)
       } else {
         setInstanceData(instanceData)
       }
+    } else if (onboardUrl && oauthCode) {
+      // when receiving fqdn from route parameter, we don't have access to partner context
+      // so we enforce default Cozy color as background
+      setClouderyTheme({
+        backgroundColor: colors.primaryColor
+      })
+
+      setState(oldState => ({
+        ...oldState,
+        step: LOADING_STEP
+      }))
+
+      startOidcOnboarding(onboardUrl, oauthCode)
     }
   }, [
     navigation,

--- a/src/screens/login/components/functions/oidc.spec.js
+++ b/src/screens/login/components/functions/oidc.spec.js
@@ -38,7 +38,7 @@ jest.mock('/libs/intents/InAppBrowser', () => {
   }
 })
 
-describe('ClouderyView', () => {
+describe('OIDC', () => {
   describe('isOidcNavigationRequest', () => {
     it(`Should return true if url has 'oidc=true' param`, async () => {
       const request = {
@@ -121,14 +121,14 @@ describe('ClouderyView', () => {
 
       act(() => {
         Linking.emit('url', {
-          url: 'https://links.mycozy.cloud/flagship/oidc_result?code=SOME_OIDC_CODE&onboard_url=https%3A%2F%2Fmanager.cozycloud.cc%2Fsomepartner%2Fonboard%3Fonboarding_id%3DSOME_ONBOARDING_ID'
+          url: 'cozy://oidc_result?code=SOME_OIDC_CODE&onboard_url=https%3A%2F%2Fmanager.cozycloud.cc%2Fsomepartner%2Fonboard%3Fonboarding_id%3DSOME_ONBOARDING_ID'
         })
       })
 
       const result = await promise
 
       expect(showInAppBrowser).toHaveBeenCalledWith({
-        url: 'http://some-oidc-server.fr/oidc?offer=ecolyo&oidc=true&redirect_after_oidc=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Foidc_result'
+        url: 'http://some-oidc-server.fr/oidc?offer=ecolyo&oidc=true&redirect_after_oidc=cozy%3A%2F%2Fflagship%2Foidc_result'
       })
       expect(result).toStrictEqual({
         code: 'SOME_OIDC_CODE',
@@ -150,14 +150,14 @@ describe('ClouderyView', () => {
 
       act(() => {
         Linking.emit('url', {
-          url: 'https://links.mycozy.cloud/flagship/oidc_result?code=SOME_OIDC_CODE&fqdn=claude.somepartner.fr'
+          url: 'cozy://oidc_result?code=SOME_OIDC_CODE&fqdn=claude.somepartner.fr'
         })
       })
 
       const result = await promise
 
       expect(showInAppBrowser).toHaveBeenCalledWith({
-        url: 'http://some-oidc-server.fr/oidc?offer=ecolyo&oidc=true&redirect_after_oidc=https%3A%2F%2Flinks.mycozy.cloud%2Fflagship%2Foidc_result'
+        url: 'http://some-oidc-server.fr/oidc?offer=ecolyo&oidc=true&redirect_after_oidc=cozy%3A%2F%2Fflagship%2Foidc_result'
       })
       expect(result).toStrictEqual({
         code: 'SOME_OIDC_CODE',
@@ -179,7 +179,7 @@ describe('ClouderyView', () => {
 
       act(() => {
         Linking.emit('url', {
-          url: 'https://links.mycozy.cloud/flagship/some_bad_url'
+          url: 'cozy://some_bad_url'
         })
       })
 

--- a/src/screens/login/components/functions/oidc.ts
+++ b/src/screens/login/components/functions/oidc.ts
@@ -1,4 +1,5 @@
 import Minilog from 'cozy-minilog'
+
 import { Linking, Platform } from 'react-native'
 import type { WebViewNavigation } from 'react-native-webview'
 
@@ -30,6 +31,16 @@ interface OidcOnboardingStartCallback {
 }
 
 type OidcCallback = OidcLoginCallback | OidcOnboardingStartCallback
+
+export const isOidcOnboardingStartCallback = (
+  callback: unknown
+): callback is OidcOnboardingStartCallback => {
+  return (
+    typeof callback === 'object' &&
+    callback !== null &&
+    'onboardUrl' in callback
+  )
+}
 
 /**
  * Check if the given NavigationRequest should trigger the OIDC scenario

--- a/src/screens/login/components/functions/oidc.ts
+++ b/src/screens/login/components/functions/oidc.ts
@@ -1,6 +1,6 @@
 import Minilog from 'cozy-minilog'
 
-import { Linking, Platform } from 'react-native'
+import { Linking } from 'react-native'
 import type { WebViewNavigation } from 'react-native-webview'
 
 import strings from '/constants/strings.json'
@@ -14,8 +14,7 @@ const USER_CANCELED = 'USER_CANCELED'
 const INVALID_CALLBACK = 'INVALID_CALLBACK'
 
 const OIDC_CALLBACK_URL_PARAM = 'redirect_after_oidc'
-const OIDC_CALLBACK_URL = `${strings.UNIVERSAL_LINK_BASE}/oidc_result`
-const OIDC_CALLBACK_URL_ANDROID = `${strings.COZY_SCHEME}flagship/oidc_result`
+const OIDC_CALLBACK_URL = `${strings.COZY_SCHEME}flagship/oidc_result`
 
 export const LOGIN_FLAGSHIP_URL = 'https://loginflagship'
 
@@ -123,9 +122,7 @@ export const processOIDC = (
 ): Promise<OidcCallback> => {
   return new Promise((resolve, reject) => {
     const oidcUrl = new URL(request.url)
-    const urlParam =
-      Platform.OS === 'ios' ? OIDC_CALLBACK_URL : OIDC_CALLBACK_URL_ANDROID
-    oidcUrl.searchParams.append(OIDC_CALLBACK_URL_PARAM, urlParam)
+    oidcUrl.searchParams.append(OIDC_CALLBACK_URL_PARAM, OIDC_CALLBACK_URL)
 
     void showInAppBrowser({ url: oidcUrl.toString() }).then(result => {
       if (result.type === 'cancel') {


### PR DESCRIPTION
When entering an email linked to an OIDC Cozy, the received email will open the Manager that will then redirect to OIDC Oauth

Previous implementation did not support this scenario

When this scenario is detected, then the Manager should redirect to the Authentication screen that will trigger the OAuth process