### PR TITLE
Dedup first version

### DIFF
--- a/src/app/domain/backup/queries/index.ts
+++ b/src/app/domain/backup/queries/index.ts
@@ -3,6 +3,24 @@ import { Q, QueryDefinition } from 'cozy-client'
 const DOCTYPE_FILES = 'io.cozy.files'
 const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
 
+export const buildAllMediasFilesQuery = (): QueryDefinition => {
+  return Q(DOCTYPE_FILES)
+    .where({
+      type: 'file',
+      class: { $or: ['image', 'video'] }
+    })
+    .indexFields(['class', 'type'])
+    .select([
+      'class',
+      'type',
+      'name',
+      'path',
+      'created_at',
+      'updated_at',
+      'md5sum'
+    ])
+}
+
 export const buildFilesQuery = (deviceId: string): QueryDefinition => {
   return Q(DOCTYPE_FILES)
     .where({

--- a/src/app/domain/backup/queries/index.ts
+++ b/src/app/domain/backup/queries/index.ts
@@ -19,6 +19,7 @@ export const buildAllMediasFilesQuery = (): QueryDefinition => {
       'updated_at',
       'md5sum'
     ])
+    .limitBy(1000)
 }
 
 export const buildFilesQuery = (deviceId: string): QueryDefinition => {
@@ -39,6 +40,7 @@ export const buildFilesQuery = (deviceId: string): QueryDefinition => {
       'updated_at',
       'md5sum'
     ])
+    .limitBy(1000)
 }
 
 export const buildFileQuery = (id: string): QueryDefinition => {

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -247,10 +247,7 @@ const initializeBackup = async (
     if (deviceRemoteBackupConfig) {
       log.debug('Backup will be restored')
 
-      backupedMedias = await fetchBackupedMedias(
-        client,
-        deviceRemoteBackupConfig
-      )
+      backupedMedias = await fetchBackupedMedias(client)
       backupedAlbums = await fetchBackupedAlbums(client)
     } else {
       log.debug('Backup will be created')

--- a/src/app/domain/backup/services/manageLocalBackupConfig.spec.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.spec.ts
@@ -1,0 +1,82 @@
+import * as manageRemoteBackupConfig from '/app/domain/backup/services/manageRemoteBackupConfig'
+import * as manageLocalBackupConfig from '/app/domain/backup/services/manageLocalBackupConfig'
+import { LocalBackupConfig } from '/app/domain/backup/models'
+
+import type CozyClient from 'cozy-client'
+
+const IMG_0001 = {
+  creationDate: 1299975445000,
+  md5: 'Y0VRfq0vJ3b2gOxZjk31WQ==',
+  modificationDate: 1441224147000,
+  name: 'IMG_0001.JPG',
+  remoteId: 'c3843c5245f8a47c56a185d13f8483c6',
+  uri: 'ph://106E99A1-4F6A-45A2-B320-B0AD4A8E8473/L0/001'
+}
+
+const IMG_0002 = {
+  creationDate: 1255122560000,
+  md5: 'LcGi/CqoM7ALktxDiKhhOQ==',
+  modificationDate: 1441224147000,
+  name: 'IMG_0002.JPG',
+  remoteId: 'c3843c5245f8a47c56a185d13f848d27',
+  uri: 'ph://B84E8479-475C-4727-A4A4-B77AA9980897/L0/001'
+}
+
+describe('addRemoteDuplicatesToBackupedMedias', () => {
+  test('should merge previous backuped medias with new remote duplicates found', async () => {
+    // Given
+    jest
+      .spyOn(manageLocalBackupConfig, 'getLocalBackupConfig')
+      .mockResolvedValue(
+        Promise.resolve({
+          backupedMedias: [IMG_0001]
+        } as LocalBackupConfig)
+      )
+
+    jest
+      .spyOn(manageRemoteBackupConfig, 'fetchBackupedMedias')
+      .mockResolvedValue(Promise.resolve([IMG_0002]))
+
+    const setLocalBackupConfigMock = jest
+      .spyOn(manageLocalBackupConfig, 'setLocalBackupConfig')
+      .mockResolvedValue(Promise.resolve())
+
+    // When
+    await manageLocalBackupConfig.addRemoteDuplicatesToBackupedMedias(
+      {} as CozyClient
+    )
+
+    const newLocalBackupConfig = setLocalBackupConfigMock.mock.calls[0][1]
+
+    // Then
+    expect(newLocalBackupConfig.backupedMedias.length).toBe(2)
+  })
+
+  test('should not create duplicates in backuped media list when remote duplicate is already in backuped media list', async () => {
+    // Given
+    jest
+      .spyOn(manageLocalBackupConfig, 'getLocalBackupConfig')
+      .mockResolvedValue(
+        Promise.resolve({
+          backupedMedias: [IMG_0001]
+        } as LocalBackupConfig)
+      )
+
+    jest
+      .spyOn(manageRemoteBackupConfig, 'fetchBackupedMedias')
+      .mockResolvedValue(Promise.resolve([IMG_0001]))
+
+    const setLocalBackupConfigMock = jest
+      .spyOn(manageLocalBackupConfig, 'setLocalBackupConfig')
+      .mockResolvedValue(Promise.resolve())
+
+    // When
+    await manageLocalBackupConfig.addRemoteDuplicatesToBackupedMedias(
+      {} as CozyClient
+    )
+    const newLocalStorage = setLocalBackupConfigMock.mock.calls[0][1]
+
+    // Then
+    expect(newLocalStorage.backupedMedias.length).toBe(1)
+  })
+})

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -10,6 +10,7 @@ import {
   LastBackup
 } from '/app/domain/backup/models'
 import { buildFileQuery } from '/app/domain/backup/queries'
+import { fetchBackupedMedias } from '/app/domain/backup/services/manageRemoteBackupConfig'
 import { isSameMedia } from '/app/domain/backup/helpers'
 import {
   getUserPersistedData,
@@ -238,4 +239,29 @@ export const setLastBackup = async (
   await setLocalBackupConfig(client, localBackupConfig)
 
   log.debug('Last backup set')
+}
+
+export const addRemoteDuplicatesToBackupedMedias = async (
+  client: CozyClient
+): Promise<void> => {
+  log.debug('Trying to find remote duplicates')
+
+  const localBackupConfig = await getLocalBackupConfig(client)
+
+  const remoteDuplicates = await fetchBackupedMedias(client)
+
+  const remoteDuplicatesNotAlreadyConsideredAsBackuped =
+    remoteDuplicates.filter(
+      m => !localBackupConfig.backupedMedias.find(a => isSameMedia(a, m))
+    )
+
+  log.debug(
+    `${remoteDuplicatesNotAlreadyConsideredAsBackuped.length} medias found remotely that are present locally but not in local backuped medias`
+  )
+
+  localBackupConfig.backupedMedias = localBackupConfig.backupedMedias.concat(
+    remoteDuplicatesNotAlreadyConsideredAsBackuped
+  )
+
+  await setLocalBackupConfig(client, localBackupConfig)
 }

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.ts
@@ -247,7 +247,6 @@ const isFileCorrespondingToMedia = (file: File, media: Media): boolean => {
 
 const formatBackupedMedia = (
   allMedias: Media[],
-  deviceRemoteBackupConfig: RemoteBackupConfig,
   file: File
 ): BackupedMedia | undefined => {
   const correspondingMedia = allMedias.find(media =>
@@ -271,8 +270,7 @@ const removeUndefined = (
 ): backupedMedia is NonNullable<BackupedMedia> => !!backupedMedia
 
 export const fetchBackupedMedias = async (
-  client: CozyClient,
-  deviceRemoteBackupConfig: RemoteBackupConfig
+  client: CozyClient
 ): Promise<BackupedMedia[]> => {
   const deviceId = await getDeviceId()
 
@@ -284,7 +282,7 @@ export const fetchBackupedMedias = async (
 
   const backupedMedias = data
     .filter(file => !isInTrash(file.path))
-    .map(file => formatBackupedMedia(allMedias, deviceRemoteBackupConfig, file))
+    .map(file => formatBackupedMedia(allMedias, file))
     .filter(removeUndefined)
 
   return backupedMedias


### PR DESCRIPTION
Goal : add a backup which upload only what is NOT already in the whole cozy. This is a first version we want to try on real data/user.

Technically, before all backup :
- fetch all media from Cozy
- compare them with local media with name and creation date
- if media exists on phone AND is not already considered as backup, we considered it as backup

=> avoid to upload media already present it cozy

Behind a flag('flagship.backup.dedup')