### PR TITLE
fix: Skip iOS configuration if white label command is not run on MacOS

### DIFF
--- a/white_label/configure-brand.ts
+++ b/white_label/configure-brand.ts
@@ -51,6 +51,11 @@ const configureAndroid = async (brand: string): Promise<void> => {
 }
 
 const configureIOS = async (brand: string): Promise<void> => {
+  if (process.platform !== 'darwin') {
+    logger.warn('Skip iOS configuration (platform !== iOS)')
+    return
+  }
+
   const config = configs[brand as keyof typeof configs]
 
   logger.info('Set iOS Bundle ID')


### PR DESCRIPTION
PlistBuddy is not accessible on Linux machine and more globally we cannot build iOS project outside of a MacOS container

So we want to skip iOS configuration on Android CI
