### PR TITLE
feat: Hide `See offers` button on `OauthClientsLimitExceeded` popup

### DIFF
--- a/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
+++ b/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
@@ -48,7 +48,7 @@ export const useOAuthClientsLimitExceeded = (
       setPopupUrl(
         current =>
           current ??
-          `${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}?redirect=${encodedRedirect}`
+          `${rootURL}${OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH}?isFlagship=true&redirect=${encodedRedirect}`
       )
     }
 


### PR DESCRIPTION
This button should not be displayed until we enable InAppPurchase

To hide it we want to pass the `isFlagship=true` parameter to the `/settings/clients/limit-exceeded` page. Then the cozy-stack will not render the button until we enable InAppPurchase

Related commit: 299968d43914066c3147276eea2463ebb292d527
