### PR TITLE
fix: Intercept redirection to `/settings/clients/limit-exceeded` page

### DIFF
--- a/src/app/domain/limits/OauthClientsLimitService.ts
+++ b/src/app/domain/limits/OauthClientsLimitService.ts
@@ -17,6 +17,9 @@ import { navigate, navigationRef } from '/libs/RootNavigation'
 
 const log = Minilog('⛔ OAuth Clients Limit Service')
 
+export const OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH =
+  '/settings/clients/limit-exceeded'
+
 export const OAUTH_CLIENTS_LIMIT_EXCEEDED = 'OAUTH_CLIENTS_LIMIT_EXCEEDED'
 
 export const oauthClientLimitEventHandler = new EventEmitter()
@@ -24,6 +27,10 @@ export const oauthClientLimitEventHandler = new EventEmitter()
 export const showOauthClientsLimitExceeded = (href: string): void => {
   navigate('home')
   oauthClientLimitEventHandler.emit(OAUTH_CLIENTS_LIMIT_EXCEEDED, href)
+}
+
+export const isOauthClientLimitExceededUrl = (url: string): boolean => {
+  return url.includes(OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH)
 }
 
 export const interceptNavigation =

--- a/src/app/domain/navigation/webviews/UrlService.ts
+++ b/src/app/domain/navigation/webviews/UrlService.ts
@@ -16,6 +16,10 @@ import {
 } from '/libs/functions/filePreviewHelper'
 import { safePromise } from '/utils/safePromise'
 import {
+  isOauthClientLimitExceededUrl,
+  showOauthClientsLimitExceeded
+} from '/app/domain/limits/OauthClientsLimitService'
+import {
   InterceptNavigationProps,
   InterceptOpenWindowProps,
   webviewUrlLog
@@ -49,6 +53,11 @@ export const interceptNavigation = ({
   client,
   setDownloadProgress
 }: InterceptNavigationProps): boolean => {
+  if (isOauthClientLimitExceededUrl(initialRequest.url)) {
+    showOauthClientsLimitExceeded(targetUri)
+    return false
+  }
+
   const isPreviewableLink = checkIsPreviewableLink(initialRequest.url, client)
   // We don't want to intecerpt iframe navigation excepts for iOS and the download
   // Since we can download file from an iframe (intents)

--- a/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
+++ b/src/app/view/Limits/hooks/useOAuthClientsLimitExceeded.ts
@@ -10,14 +10,13 @@ import Minilog from 'cozy-minilog'
 
 import {
   OAUTH_CLIENTS_LIMIT_EXCEEDED,
+  OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH,
   interceptNavigation,
   interceptOpenWindow,
   oauthClientLimitEventHandler
 } from '/app/domain/limits/OauthClientsLimitService'
 
 const log = Minilog('⛔ OAuth Clients Limit Exceeded')
-
-const OAUTH_CLIENTS_LIMIT_EXCEEDED_URL_PATH = '/settings/clients/limit-exceeded'
 
 interface OAuthClientsLimitExceededState {
   popupUrl: string | null


### PR DESCRIPTION
In some edge-case scenario, the app may incorrectly open a cozy-app even if the OAuth client limit is exceeded

This may happen if the `cozy.oauthclients.max` flag is not set when the app starts but it is set just after that. In that case, the limit check won't be done when the user tries to open a cozy-app because flags are not updated after the app start. This is an edge case of a8ad127b0349715db75b11b6c411df6feb2ff1fe

This may also happen if some network errors occur when querying the cozy-stack for doing the check. In that case the app will fallback to an "under the limit" scenario

In those cases, the app will tries to open the cozy-app and then the cozy-stack will return a `302` to `/settings/clients/limit-exceeded`

With current implementation, this `302` will be intercepted by the `ReloadInterceptorWebView` and redirected to an InAppBrowser instead of the `OauthClientsLimitExceeded` popup

Note that this happens only if app is served by the cozy-stack and not by the HttpServer

To prevent this we want to detect this scenario in the `ReloadInterceptorWebView` and open the `OauthClientsLimitExceeded` popup
