### PR TITLE
fix: Log `checkInitialParam` alert using `debug` level instead of `warn`

### DIFF
--- a/src/libs/functions/routeHelpers.ts
+++ b/src/libs/functions/routeHelpers.ts
@@ -64,7 +64,7 @@ export const useInitialParam = <T>(
 
       if (handledInitialParams) {
         if (value) {
-          log.warn(
+          log.debug(
             `🚨 useInitialParam detected new value for already consumed ${paramName} param, this should not happens, please verify your Router initialization`
           )
         }


### PR DESCRIPTION
The `warn` level generates too much noise on the debuging console as it outputs the entire stack trace

The 🚨 icon used in the log is enough to catch the attention so we now want to use `debug` log