### PR TITLE
feat: Add OCR support for cozy-apps

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         androidXBrowser = "1.4.0"
         DocumentScanner_compileSdkVersion = 33
         DocumentScanner_targetSdkVersion = 33
+        kotlinVersion="1.6.0"
     }
     repositories {
         google()

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -48,6 +48,9 @@ target 'CozyReactNative' do
             config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
         end
       end
+      target.build_configurations.each do |config|
+        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = "arm64"
+      end
     end
   end
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -107,6 +107,23 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleMLKit/MLKitCore (2.6.0):
+    - MLKitCommon (~> 5.0.0)
+  - GoogleMLKit/TextRecognition (2.6.0):
+    - GoogleMLKit/MLKitCore
+    - MLKitTextRecognition (~> 1.4.0-beta3)
+  - GoogleToolboxForMac/DebugUtils (2.3.2):
+    - GoogleToolboxForMac/Defines (= 2.3.2)
+  - GoogleToolboxForMac/Defines (2.3.2)
+  - GoogleToolboxForMac/Logger (2.3.2):
+    - GoogleToolboxForMac/Defines (= 2.3.2)
+  - "GoogleToolboxForMac/NSData+zlib (2.3.2)":
+    - GoogleToolboxForMac/Defines (= 2.3.2)
+  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.3.2)":
+    - GoogleToolboxForMac/DebugUtils (= 2.3.2)
+    - GoogleToolboxForMac/Defines (= 2.3.2)
+    - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.2)"
+  - "GoogleToolboxForMac/NSString+URLArguments (2.3.2)"
   - GoogleUtilities/AppDelegateSwizzler (7.11.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -124,8 +141,35 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (7.11.0):
     - GoogleUtilities/Logger
+  - GoogleUtilitiesComponents (1.1.0):
+    - GoogleUtilities/Logger
+  - GTMSessionFetcher/Core (1.7.2)
   - hermes-engine (0.9.0)
   - libevent (2.1.12)
+  - MLImage (1.0.0-beta2)
+  - MLKitCommon (5.0.0):
+    - GoogleDataTransport (~> 9.0)
+    - GoogleToolboxForMac/Logger (~> 2.1)
+    - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
+    - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
+    - GoogleUtilities/UserDefaults (~> 7.0)
+    - GoogleUtilitiesComponents (~> 1.0)
+    - GTMSessionFetcher/Core (~> 1.1)
+    - Protobuf (~> 3.12)
+  - MLKitTextRecognition (1.4.0-beta3):
+    - MLKitCommon (~> 5.0)
+    - MLKitTextRecognitionCommon (= 1.0.0-beta3)
+    - MLKitVision (~> 3.0)
+  - MLKitTextRecognitionCommon (1.0.0-beta3):
+    - MLKitCommon (~> 5.0)
+    - MLKitVision (~> 3.0)
+  - MLKitVision (3.0.0):
+    - GoogleToolboxForMac/Logger (~> 2.1)
+    - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
+    - GTMSessionFetcher/Core (~> 1.1)
+    - MLImage (= 1.0.0-beta2)
+    - MLKitCommon (~> 5.0)
+    - Protobuf (~> 3.12)
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
     - nanopb/encode (= 2.30908.0)
@@ -134,6 +178,7 @@ PODS:
   - NVHTarGzip (1.0.1)
   - OpenSSL-Universal (1.1.180)
   - PromisesObjC (2.1.1)
+  - Protobuf (3.24.3)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -372,6 +417,9 @@ PODS:
     - React
   - react-native-idle-timer (2.2.1):
     - React-Core
+  - react-native-mlkit-ocr (0.3.0):
+    - GoogleMLKit/TextRecognition (= 2.6.0)
+    - React
   - react-native-netinfo (9.3.7):
     - React-Core
   - react-native-safe-area-context (4.5.0):
@@ -551,6 +599,7 @@ DEPENDENCIES:
   - react-native-flipper (from `../node_modules/react-native-flipper`)
   - "react-native-gzip (from `../node_modules/@fengweichong/react-native-gzip`)"
   - react-native-idle-timer (from `../node_modules/react-native-idle-timer`)
+  - react-native-mlkit-ocr (from `../node_modules/react-native-mlkit-ocr`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -605,13 +654,23 @@ SPEC REPOS:
     - fmt
     - GCDWebServer
     - GoogleDataTransport
+    - GoogleMLKit
+    - GoogleToolboxForMac
     - GoogleUtilities
+    - GoogleUtilitiesComponents
+    - GTMSessionFetcher
     - hermes-engine
     - libevent
+    - MLImage
+    - MLKitCommon
+    - MLKitTextRecognition
+    - MLKitTextRecognitionCommon
+    - MLKitVision
     - nanopb
     - NVHTarGzip
     - OpenSSL-Universal
     - PromisesObjC
+    - Protobuf
     - Sentry
     - YogaKit
 
@@ -672,6 +731,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@fengweichong/react-native-gzip"
   react-native-idle-timer:
     :path: "../node_modules/react-native-idle-timer"
+  react-native-mlkit-ocr:
+    :path: "../node_modules/react-native-mlkit-ocr"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
@@ -763,13 +824,23 @@ SPEC CHECKSUMS:
   GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
   glog: 5337263514dd6f09803962437687240c5dc39aa4
   GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
+  GoogleMLKit: 755661c46990a85e42278015f26400286d98ad95
+  GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
   GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
+  GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
+  GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
   hermes-engine: bf7577d12ac6ccf53ab8b5af3c6ccf0dd8458c5c
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
+  MLImage: a454f9f8ecfd537783a12f9488f5be1a68820829
+  MLKitCommon: 3bc17c6f7d25ce3660f030350b46ae7ec9ebca6e
+  MLKitTextRecognition: 8b0e0023a4babc66ca83d8b82864e57931164445
+  MLKitTextRecognitionCommon: 3e84602c928fe2b775fae81376f2136324cbd763
+  MLKitVision: e87dc3f2e456a6ab32361ebd985e078dd2746143
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   NVHTarGzip: 74cc227b902e5725900d37eb6d79b57e93005a73
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
+  Protobuf: 970f7ee93a3a08e3cf64859b8efd95ee32b4f87f
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 4bf86c70714490bca4bf2696148638284622644b
   RCTTypeSafety: c475a7059eb77935fa53d2c17db299893f057d5d
@@ -793,6 +864,7 @@ SPEC CHECKSUMS:
   react-native-flipper: 4bfe0a324e663f1ae2f76ad0da75673de6895efe
   react-native-gzip: 5ffb84bf191c7cd135338eca748317bc466d41a1
   react-native-idle-timer: f1920a59fe776340d004ff9de13c4a6eedcc8807
+  react-native-mlkit-ocr: 72cdbde86f8d29cba26cf9fa0a1865fe45c8f8d6
   react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-webview: 8ec7ddf9eb4ddcd92b32cee7907efec19a9ec7cb

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cozy-clisk": "^0.22.3",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
-    "cozy-intent": "^2.14.0",
+    "cozy-intent": "^2.17.0",
     "cozy-logger": "^1.10.0",
     "cozy-minilog": "3.3.0",
     "date-fns": "2.29.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cozy-intent": "^2.14.0",
     "cozy-logger": "^1.10.0",
     "cozy-minilog": "3.3.0",
+    "date-fns": "2.29.3",
     "html-entities": "^2.3.3",
     "i18next": "23.2.10",
     "intl": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-native-keychain": "^8.0.0",
     "react-native-localize": "2.2.6",
     "react-native-mask-input": "1.2.1",
+    "react-native-mlkit-ocr": "^0.3.0",
     "react-native-permissions": "^3.8.4",
     "react-native-play-install-referrer": "^1.1.8",
     "react-native-safe-area-context": "^4.5.0",

--- a/src/app/domain/ocr/services/ocr.ts
+++ b/src/app/domain/ocr/services/ocr.ts
@@ -1,0 +1,94 @@
+import { format } from 'date-fns'
+import { Image, Platform } from 'react-native'
+import RNFS from 'react-native-fs'
+import MlkitOcr, { MlkitOcrResult } from 'react-native-mlkit-ocr'
+
+import Minilog from 'cozy-minilog'
+
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+const log = Minilog('OCR')
+
+interface ImageSize {
+  width: number
+  height: number
+}
+
+export interface ProcessOcrResult {
+  OCRResult: MlkitOcrResult
+  imgSize: ImageSize
+}
+
+export const processOcr = async (
+  base64: string
+): Promise<ProcessOcrResult | undefined> => {
+  const path = getTemporaryOcrFilePath()
+
+  try {
+    const imgSize = await getBase64ImageSize(base64)
+
+    await ensureOCRFolder()
+    await RNFS.writeFile(path, base64, 'base64')
+
+    const OCRResult = await MlkitOcr.detectFromFile(path)
+
+    return {
+      OCRResult,
+      imgSize
+    }
+  } catch (err) {
+    log.error(
+      `Something went wront while processing OCR: ${getErrorMessage(err)}`
+    )
+    return undefined
+  } finally {
+    await safeDeleteFile(path)
+  }
+}
+
+export const isOcrAvailable = (): boolean => {
+  return true
+}
+
+const getOCRFolderPath = (): string => {
+  return `${RNFS.TemporaryDirectoryPath}/OCR/`
+}
+
+const getTemporaryOcrFilePath = (): string => {
+  const date = format(new Date(), 'yyyyMMddHHmmssSSS')
+  const tempFileName = `temp_ocr_${date}.ocrfile`
+
+  const pathPrefix = Platform.OS === 'android' ? 'file://' : ''
+
+  const path = `${pathPrefix}${getOCRFolderPath()}${tempFileName}`
+
+  return path
+}
+
+const ensureOCRFolder = async (): Promise<void> => {
+  await RNFS.mkdir(getOCRFolderPath())
+}
+
+const safeDeleteFile = async (path: string): Promise<void> => {
+  try {
+    if (await RNFS.exists(path)) {
+      await RNFS.unlink(path)
+    }
+  } catch (err) {
+    log.error(
+      `Something went wront while deleting OCR file: ${getErrorMessage(err)}`
+    )
+  }
+}
+
+const getBase64ImageSize = (base64: string): Promise<ImageSize> => {
+  return new Promise((resolve, reject) => {
+    try {
+      Image.getSize(`data:image/png;base64,${base64}`, (width, height) => {
+        resolve({ width, height })
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -9,6 +9,7 @@ import {
   scanDocument,
   isScannerAvailable
 } from '/app/domain/scanner/services/scanner'
+import { processOcr, isOcrAvailable } from '/app/domain/ocr/services/ocr'
 
 import { setHomeThemeIntent } from './setHomeThemeIntent'
 
@@ -209,6 +210,8 @@ export const localMethods = (
     isNativePassInstalledOnDevice,
     scanDocument,
     isScannerAvailable: () => Promise.resolve(isScannerAvailable()),
+    ocr: processOcr,
+    isOcrAvailable: () => Promise.resolve(isOcrAvailable()),
     // For now setTheme is only used for the home theme
     setTheme: setHomeThemeIntent,
     prepareBackup: () => prepareBackupWithClient(client),

--- a/yarn.lock
+++ b/yarn.lock
@@ -14468,6 +14468,11 @@ react-native-mask-input@1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-mask-input/-/react-native-mask-input-1.2.1.tgz#2f01683844ded3693d0d845bd1beeb2b8367f2e2"
   integrity sha512-OsVKhdJjljWIt373CPmsyTAjynlMpQKPkz3UQJ0Y48ZTVQa8zyejb9nmwoe15Zvi0uC49RxggDRACgkUxOjt3w==
 
+react-native-mlkit-ocr@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-mlkit-ocr/-/react-native-mlkit-ocr-0.3.0.tgz#b5b65dbe1fffdca0ca2012b1cab56cca6ea1bf58"
+  integrity sha512-8oNJwNMGsUup41nWlKA01iW6xiNkCcXM3ANDsOKKijvsrd3eWNs7kL0Yhpt3Cq64zSyjoeqkdTdOCDiI6Pv6KA==
+
 react-native-permissions@^3.8.4:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.8.4.tgz#20f203f1dd659c28fb770fc26bbbf0126faa797e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6422,10 +6422,10 @@ cozy-flags@^2.11.0:
   dependencies:
     microee "^0.0.6"
 
-cozy-intent@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.14.0.tgz#c2733abe08f8cf5d6b053b4a051cbde0f417d5d4"
-  integrity sha512-7OkXrfQcH5gM0AWIAODFYZbMTDprTeYS4eJe9OQKUEnQra52MNIpmUqOMozyl6nyBYcESKfdb+rBKK4++3vbrg==
+cozy-intent@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.17.0.tgz#98818a1c71d903c3f82d22754bf4ea770a0d7339"
+  integrity sha512-Snt5LkIq28BoLBQJISZg2JTIL/XO8jgVRpihgBWhVmLI185zqMl1T19roT0VNAtfCyfoCqRx2/y4fV7dkTf3Yg==
   dependencies:
     post-me "0.4.5"
 


### PR DESCRIPTION
We want cozy-apps to be able to call OCR on a base64 image

The flagship now exposes two new methods through cozy-intent:
- `isOcrAvailable`: Check if the OCR feature is supported by the current app
- `ocr`: Process OCR on the given base64 image and return the OCR result + the image size

Related PR: cozy/cozy-libs#2297


___

TODO:

- [x] Upgrade cozy-intent when cozy/cozy-libs#2297 is merged
- [x] Check that no request is made by the ocr library to the Google servers