### PR TITLE
feat: Set missing translations for Ma Bulle

### DIFF
--- a/white_label/brands/mabulle/js/locales/extra-en.json
+++ b/white_label/brands/mabulle/js/locales/extra-en.json
@@ -1,5 +1,23 @@
 {
+  "logout_dialog": {
+    "content": "Are you sure you want to disconnect this app from your personal space?"
+  },
   "screens": {
+    "cozyBlocked": {
+      "title": "Your personal space has been suspended"
+    },
+    "cozyNotFound": {
+      "body": "This address doesn't seem to exist. This may be a typing error. To find out, check the address in the e-mail you received when it was created.",
+      "title": "This address does not exist."
+    },
+    "SecureScreen": {
+      "passwordprompt_body": "As access to your device is not secure, choose a password to secure access to your personal space.",
+      "passwordprompt_title": "Secure access",
+      "pinprompt_body": "Get faster access to your application by enabling PIN unlocking"
+    },
+    "login": {
+      "invalidMagicCode": "The link to access your personal space is truncated or has expired"
+    },
     "welcome": {
       "body": "Access your Personal Cloud now, the digital home to gather all your data",
       "buttonLogin": "I already have a Cozy Personal Cloud",
@@ -9,6 +27,9 @@
   "modals": {
     "IconChangedModal": {
       "description": "The icon of the 'Ma Bulle' application has been modified."
+    },
+    "ErrorToken": {
+      "body": "You seem to have revoked access to this device. To access your data again, please log in again. If this action does not come from you, please do not hesitate to contact us at <linkTag>email</linkTag>."
     }
   },
   "software": {

--- a/white_label/brands/mabulle/js/locales/extra-es.json
+++ b/white_label/brands/mabulle/js/locales/extra-es.json
@@ -1,5 +1,23 @@
 {
+  "logout_dialog": {
+    "content": "¿Estás seguro de que quieres desconectar esta aplicación de tu cuenta?"
+  },
   "screens": {
+    "cozyBlocked": {
+      "title": "Su cuenta ha sido suspendido"
+    },
+    "cozyNotFound": {
+      "body": "Esta dirección no parece existir. Puede tratarse de un error tipográfico. Para averiguarlo, compruebe la dirección en el correo electrónico que recibió cuando se creó.",
+      "title": "Esta dirección no existe."
+    },
+    "SecureScreen": {
+      "passwordprompt_body": "Como el acceso a tu dispositivo no es seguro, elige una contraseña para asegurar el acceso a tu cuenta.",
+      "passwordprompt_title": "Asegurar este acceso",
+      "pinprompt_body": "Acceda más rápidamente a su aplicación activando el desbloqueo con el código PIN"
+    },
+    "login": {
+      "invalidMagicCode": "El enlace a su cuenta está cortado o ha caducado"
+    },
     "welcome": {
       "body": "Accede a tu Nube Personal ahora, el hogar digital para reunir todos tus datos",
       "buttonLogin": "Ya tengo una Nube Personal",
@@ -9,6 +27,9 @@
   "modals": {
     "IconChangedModal": {
       "description": "El ícono de la aplicación 'Ma Bulle' ha sido modificado."
+    },
+    "ErrorToken": {
+      "body": "Parece que has revocado el acceso a este dispositivo. Para volver a acceder a tus datos, inicia sesión de nuevo. Si esta acción no procede de usted, no dude en ponerse en contacto con nosotros en <linkTag>email</linkTag>."
     }
   },
   "software": {


### PR DESCRIPTION
In #936 we added some custom texts for french version of Ma Bulle that were not declared on english and spanish versions

When this is the case, then the Cozy version of those texts is used

Here we want to have Ma Bulle specific texts for those languages

> **Warning**
> Those are auto-translated versions. I checked the English result, but I can't check the spanish version as I don't speak spanish