### PR TITLE
fix: No more empty message when error before fetch

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -209,7 +209,7 @@ class ReactNativeLauncher extends Launcher {
     const { client, job } = this.getStartContext()
 
     if (message) {
-      this.log({ level: 'error', message })
+      this.log({ level: 'error', msg: message })
     }
     await sendKonnectorsLogs(client)
     if (job) {

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -299,7 +299,7 @@ class ReactNativeLauncher extends Launcher {
       await this.pilot.call('fetch', pilotContext)
       await this.stop()
     } catch (err) {
-      log.error(err, 'start error')
+      log.error(JSON.stringify(err), 'start error')
       await this.stop({ message: err.message })
     }
     this.emit('KONNECTOR_EXECUTION_END')


### PR DESCRIPTION
When an error occured in the preparation phase of a clisk konnector
(ensureAuthenticated, getUserDataFromWebsite), we got an empty error
message.

This is fixed, and we could have detected it with ts-check header in the
file. This will come in another PR, since there are many problems to
fix when ts-check is activated.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

