### PR TITLE
fix: Ensure sourceAccountIdentifier is present in getUserDataFromWebsite return value

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -273,7 +273,13 @@ class ReactNativeLauncher extends Launcher {
       }
       await this.pilot.call('ensureAuthenticated', { account: prevAccount })
 
-      this.setUserData(await this.pilot.call('getUserDataFromWebsite'))
+      const userDataResult = await this.pilot.call('getUserDataFromWebsite')
+      if (!userDataResult?.sourceAccountIdentifier) {
+        throw new Error(
+          'getUserDataFromWebsite did not return any sourceAccountIdentifier. Cannot continue the execution.'
+        )
+      }
+      this.setUserData(userDataResult)
 
       const ensureResult = await this.ensureAccountTriggerAndLaunch()
       await this.createTimeoutTrigger()

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -285,6 +285,31 @@ describe('ReactNativeLauncher', () => {
         cancel: true
       })
     })
+    it('should display a specific error when UserData sent by the konnector is incorrect', async () => {
+      const { launcher, client, launch } = setup()
+      const konnector = { slug: 'konnectorslug', clientSide: true }
+      launcher.setStartContext({
+        client,
+        account: fixtures.account,
+        trigger: fixtures.trigger,
+        konnector,
+        manifest: konnector,
+        launcherClient: {
+          setAppMetadata: () => null
+        }
+      })
+      client.query.mockResolvedValue({ data: fixtures.account })
+      client.save.mockImplementation(async doc => ({ data: doc }))
+      launch.mockResolvedValue({ data: fixtures.job })
+      launcher.pilot.call
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(null) // getUserDataFromWebsite
+      await launcher.start()
+      expect(launcherEvent.emit).toHaveBeenCalledWith('launchResult', {
+        errorMessage: `getUserDataFromWebsite did not return any sourceAccountIdentifier. Cannot continue the execution.`
+      })
+    })
     it('should update job with error message on error', async () => {
       const { launcher, client, launch } = setup()
       launcher.setStartContext({


### PR DESCRIPTION
Or else, if the konnector does not return any sourceAccountIdentifier,
the account and trigger will be created and the execution will fail when
trying to create the desination folder, which makes it harder to link
with the missing sourceAccountIdentifier.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

