### PR TITLE
feat: Separate the worker webview from the navigation

### DIFF
--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -32,7 +32,7 @@ import { deactivateKeepAwake } from '/app/domain/sleep/services/sleep'
 const log = Minilog('LauncherView')
 
 const colors = getColors()
-const { statusBarHeight } = getDimensions()
+const { statusBarHeight, navbarHeight } = getDimensions()
 const HEADER_PADDING_TOP = statusBarHeight + 8
 const HEADER_PADDING_BOTTOM = 8
 const HEADER_LINE_HEIGHT = 16
@@ -242,6 +242,16 @@ export class LauncherView extends Component {
       ? styles.workerVisible
       : styles.workerHidden
 
+    if (workerVisible) {
+      setFlagshipUI({
+        bottomTheme: 'dark'
+      })
+    } else {
+      setFlagshipUI({
+        bottomTheme: 'light'
+      })
+    }
+
     const debug = shouldEnableKonnectorExtensiveLog()
     const run = debug
       ? `
@@ -425,7 +435,9 @@ export class LauncherView extends Component {
 const styles = StyleSheet.create({
   workerVisible: {
     height: '100%',
-    width: '100%'
+    width: '100%',
+    paddingBottom: navbarHeight,
+    backgroundColor: '#fff'
   },
   workerHidden: {
     position: 'absolute',


### PR DESCRIPTION
When the worker webview was displayed to fill the login form, the
navigation buttons were displayed above the webview and the some
elements of the login form were not accessible in some cases.

Now the separation is done and the bottom is displayed in white with
dark navigation buttons.

![image](https://github.com/cozy/cozy-flagship-app/assets/228695/10de8bb8-619b-4297-bea0-3f73a9343541)

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

