### PR TITLE
fix: App redirection when opening a notification was not working on iOS

### DIFF
--- a/patches/@notifee+react-native+7.8.0.patch
+++ b/patches/@notifee+react-native+7.8.0.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m b/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+index cf8020d..f44e54f 100644
+--- a/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
++++ b/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+@@ -180,10 +180,10 @@ - (void)userNotificationCenter:(UNUserNotificationCenter *)center
+   _notificationOpenedAppID = notifeeNotification[@"id"];
+ 
+   // handle notification outside of notifee
+-  if (notifeeNotification == nil) {
+-    notifeeNotification =
+-        [NotifeeCoreUtil parseUNNotificationRequest:response.notification.request];
+-  }
++  // if (notifeeNotification == nil) {
++  //   notifeeNotification =
++  //       [NotifeeCoreUtil parseUNNotificationRequest:response.notification.request];
++  // }
+ 
+   if (notifeeNotification != nil) {
+     if ([response.actionIdentifier isEqualToString:UNNotificationDismissActionIdentifier]) {


### PR DESCRIPTION
notifee, added recently with the photo backup to support creating local notification, kind of override react-native-firebase methods which allow to receive a notification on iOS (see https://github.com/invertase/notifee/blob/main/docs-react-native/react-native/docs/release-notes.md#700)

Adding the notifee.onForegroundEvent() callback to handleNotificationOpening solves the problem when the app is in background but not when it is closed. It seems that there is an issue in notifee and to make it work when it is closed, we need to put notifee.onForegroundEvent() in index.js which is impossible as is because we need the client to handle the notification. notifee.getInitialNotification(), a deprecated method, is also not working at all.

I explored multiple solutions :
- downgrade notifee to 6.0.0 => bad idea, because multiple bugs have been fixed in notifee 7.X.X
- find a way to make it work with notifee.onForegroundEvent() in index.js => bad idea, because it will complicate the app bootstrap and we want to avoid that
- [CHOSEN SOLUTION] patch-package notifee so that it does not handle react-native-firebase notifications. We are very happy for the moment with this separation of concern between remote notification and local notification.

If notifee.onForegroundEvent() is fixed one day, we will be able to remove this patch-package.

Related issues :
- https://github.com/invertase/notifee/issues/861
- https://github.com/invertase/notifee/issues/876
- https://github.com/invertase/notifee/issues/837

