### PR TITLE
fix: Navigate to home from notification

### DIFF
--- a/src/libs/notifications/notifications.ts
+++ b/src/libs/notifications/notifications.ts
@@ -13,6 +13,7 @@ import { navigate } from '/libs/RootNavigation'
 import { navigateToApp } from '/libs/functions/openApp'
 import { saveNotificationDeviceToken } from '/libs/client'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
+import { routes } from '/constants/routes.js'
 
 const log = Minilog('notifications')
 
@@ -37,12 +38,18 @@ export const navigateFromNotification = async (
       searchParams: []
     })
 
-    await navigateToApp({
-      navigation: { navigate },
-      slug,
-      href,
-      iconParams: undefined
-    })
+    if (slug === 'home') {
+      navigate(routes.home, {
+        href
+      })
+    } else {
+      await navigateToApp({
+        navigation: { navigate },
+        slug,
+        href,
+        iconParams: undefined
+      })
+    }
   } catch (error) {
     const errorMessage = getErrorMessage(error)
     log.error(


### PR DESCRIPTION
If we set a redirectLink to home from a notification, it was redirecting to home app in the cozy app screen. But we want home app to always be in home screen.