### PR TITLE
feat: Allow to customize tracking config for geolocation tracking

### DIFF
--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -18,7 +18,8 @@ export enum StorageKeys {
   LastPointUploadedAdress = 'CozyGPSMemory.LastPointUploaded',
   ShouldBeTrackingFlagStorageAdress = 'CozyGPSMemory.ShouldBeTrackingFlag',
   LastStopTransitionTsKey = 'CozyGPSMemory.LastStopTransitionTsKey',
-  LastStartTransitionTsKey = 'CozyGPSMemory.LastStartTransitionTsKey'
+  LastStartTransitionTsKey = 'CozyGPSMemory.LastStartTransitionTsKey',
+  GeolocationTrackingConfig = 'CozyGPSMemory.TrackingConfig'
 }
 
 export type IconsCache = Record<string, { version: string; xml: string }>


### PR DESCRIPTION
Allow to set custom values for three geolocation tracking parameters. Store them in local storage.

No breaking change.