### PR TITLE
Create album only when a media in this album is uploaded

### DIFF
--- a/src/app/domain/backup/services/manageAlbums.spec.ts
+++ b/src/app/domain/backup/services/manageAlbums.spec.ts
@@ -1,0 +1,73 @@
+import * as manageLocalBackupConfig from '/app/domain/backup/services/manageLocalBackupConfig'
+import * as manageAlbums from '/app/domain/backup/services/manageAlbums'
+import { LocalBackupConfig } from '/app/domain/backup/models'
+
+import type CozyClient from 'cozy-client'
+
+const CAT_ALBUM_NAME = 'My beautiful cat'
+
+const CAT_ALBUM_LOCAL_ID = 'cat-album-local-id'
+const CAT_ALBUM_CREATED_ID = 'cat-album-remote-id'
+
+describe('getOrCreateAlbum', () => {
+  test('should get album locally', async () => {
+    // Given
+    jest
+      .spyOn(manageLocalBackupConfig, 'getLocalBackupConfig')
+      .mockResolvedValue({
+        backupedAlbums: [
+          {
+            name: CAT_ALBUM_NAME,
+            remoteId: CAT_ALBUM_LOCAL_ID
+          }
+        ]
+      } as LocalBackupConfig)
+
+    const createRemoteAlbumMock = jest.spyOn(manageAlbums, 'createRemoteAlbum')
+    const saveAlbumsMock = jest.spyOn(manageLocalBackupConfig, 'saveAlbums')
+
+    // When
+    const album = await manageAlbums.getOrCreateAlbum(
+      {} as CozyClient,
+      CAT_ALBUM_NAME
+    )
+
+    // Then
+    expect(createRemoteAlbumMock).not.toHaveBeenCalled()
+    expect(saveAlbumsMock).not.toHaveBeenCalled()
+    expect(album.name).toBe(CAT_ALBUM_NAME)
+    expect(album.remoteId).toBe(CAT_ALBUM_LOCAL_ID)
+  })
+
+  test('should create album and save it locally', async () => {
+    // Given
+    jest
+      .spyOn(manageLocalBackupConfig, 'getLocalBackupConfig')
+      .mockResolvedValue({
+        backupedAlbums: []
+      } as unknown as LocalBackupConfig)
+
+    const createRemoteAlbumMock = jest
+      .spyOn(manageAlbums, 'createRemoteAlbum')
+      .mockResolvedValue({
+        name: CAT_ALBUM_NAME,
+        remoteId: CAT_ALBUM_CREATED_ID
+      })
+
+    const saveAlbumsMock = jest
+      .spyOn(manageLocalBackupConfig, 'saveAlbums')
+      .mockResolvedValue()
+
+    // When
+    const album = await manageAlbums.getOrCreateAlbum(
+      {} as CozyClient,
+      CAT_ALBUM_NAME
+    )
+
+    // Then
+    expect(createRemoteAlbumMock).toHaveBeenCalled()
+    expect(saveAlbumsMock).toHaveBeenCalled()
+    expect(album.name).toBe(CAT_ALBUM_NAME)
+    expect(album.remoteId).toBe(CAT_ALBUM_CREATED_ID)
+  })
+})

--- a/src/app/domain/backup/services/manageAlbums.ts
+++ b/src/app/domain/backup/services/manageAlbums.ts
@@ -118,16 +118,24 @@ export const addMediaToAlbums = async (
       return
     }
 
-    await client.collection(DOCTYPE_FILES).addReferencesTo(
-      {
-        _id: remoteId,
-        _type: DOCTYPE_ALBUMS
-      },
-      [
-        {
-          _id: documentCreated.id
-        }
-      ]
-    )
+    await addMediaToAlbum(client, remoteId, documentCreated.id!)
   }
+}
+
+const addMediaToAlbum = async (
+  client: CozyClient,
+  albumId: string,
+  documentId: string
+): Promise<void> => {
+  await client.collection(DOCTYPE_FILES).addReferencesTo(
+    {
+      _id: albumId,
+      _type: DOCTYPE_ALBUMS
+    },
+    [
+      {
+        _id: documentId
+      }
+    ]
+  )
 }

--- a/src/app/domain/backup/services/manageAlbums.ts
+++ b/src/app/domain/backup/services/manageAlbums.ts
@@ -60,25 +60,33 @@ export const createRemoteAlbums = async (
       !backupedAlbums.find(backupedAlbum => backupedAlbum.name === album.name)
   )
 
-  const deviceId = await getDeviceId()
-
   const createdAlbums = []
 
   for (const albumToCreate of albumsToCreate) {
-    const createdAlbum = (await client.save({
-      _type: 'io.cozy.photos.albums',
-      name: albumToCreate.name,
-      created_at: new Date().toISOString(),
-      backupDeviceIds: [deviceId]
-    })) as { data: { name: string; id: string } }
-
-    createdAlbums.push({
-      name: createdAlbum.data.name,
-      remoteId: createdAlbum.data.id
-    })
+    const createdAlbum = await createRemoteAlbum(client, albumToCreate.name)
+    createdAlbums.push(createdAlbum)
   }
 
   return createdAlbums
+}
+
+export const createRemoteAlbum = async (
+  client: CozyClient,
+  albumName: string
+): Promise<BackupedAlbum> => {
+  const deviceId = await getDeviceId()
+
+  const createdAlbum = (await client.save({
+    _type: 'io.cozy.photos.albums',
+    name: albumName,
+    created_at: new Date().toISOString(),
+    backupDeviceIds: [deviceId]
+  })) as { data: { name: string; id: string } }
+
+  return {
+    name: createdAlbum.data.name,
+    remoteId: createdAlbum.data.id
+  }
 }
 
 const formatBackupedAlbum = (album: AlbumDocument): BackupedAlbum => {

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -10,16 +10,10 @@ import {
   setBackupAsRunning,
   setBackupAsDone,
   setLastBackup,
-  saveAlbums,
   updateRemoteBackupConfigLocally,
   addRemoteDuplicatesToBackupedMedias
 } from '/app/domain/backup/services/manageLocalBackupConfig'
-import {
-  areAlbumsEnabled,
-  getAlbums,
-  createRemoteAlbums,
-  fetchBackupedAlbums
-} from '/app/domain/backup/services/manageAlbums'
+import { fetchBackupedAlbums } from '/app/domain/backup/services/manageAlbums'
 import { getMediasToBackup } from '/app/domain/backup/services/getMedias'
 import {
   uploadMedias,
@@ -72,14 +66,6 @@ export const prepareBackup = async (
   await setBackupAsInitializing(client)
 
   void onProgress(await getBackupInfo(client))
-
-  if (areAlbumsEnabled()) {
-    const albums = await getAlbums()
-
-    const createdAlbums = await createRemoteAlbums(client, albums)
-
-    await saveAlbums(client, createdAlbums)
-  }
 
   const mediasToBackup = await getMediasToBackup(client, onProgress)
 

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -176,7 +176,7 @@ const prepareAndUploadMedia = async (
 
   log.debug(`✅ ${mediaToUpload.name} uploaded`)
 
-  await postUpload(client, localBackupConfig, mediaToUpload, documentCreated)
+  await postUpload(client, mediaToUpload, documentCreated)
 
   await setMediaAsBackuped(client, mediaToUpload, documentCreated)
 
@@ -187,17 +187,11 @@ const prepareAndUploadMedia = async (
 
 const postUpload = async (
   client: CozyClient,
-  localBackupConfig: LocalBackupConfig,
   mediaToUpload: Media,
   documentCreated: IOCozyFile
 ): Promise<void> => {
   if (mediaToUpload.albums.length > 0 && areAlbumsEnabled()) {
-    await addMediaToAlbums(
-      client,
-      localBackupConfig,
-      mediaToUpload,
-      documentCreated
-    )
+    await addMediaToAlbums(client, mediaToUpload, documentCreated)
   }
 }
 

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -19,7 +19,10 @@ import {
   isFileTooBigError,
   isCancellationError
 } from '/app/domain/backup/helpers/error'
-import { areAlbumsEnabled } from '/app/domain/backup/services/manageAlbums'
+import {
+  areAlbumsEnabled,
+  addMediaToAlbums
+} from '/app/domain/backup/services/manageAlbums'
 import { t } from '/locales/i18n'
 
 import type CozyClient from 'cozy-client'
@@ -31,7 +34,6 @@ import { NetworkError } from '/app/domain/upload/models'
 const log = Minilog('💿 Backup')
 
 const DOCTYPE_FILES = 'io.cozy.files'
-const DOCTYPE_ALBUMS = 'io.cozy.photos.albums'
 
 let shouldStopBackup = false
 
@@ -195,36 +197,6 @@ const postUpload = async (
       localBackupConfig,
       mediaToUpload,
       documentCreated
-    )
-  }
-}
-
-const addMediaToAlbums = async (
-  client: CozyClient,
-  localBackupConfig: LocalBackupConfig,
-  mediaToUpload: Media,
-  documentCreated: IOCozyFile
-): Promise<void> => {
-  for (const album of mediaToUpload.albums) {
-    const { remoteId } =
-      localBackupConfig.backupedAlbums.find(
-        backupedAlbum => backupedAlbum.name === album.name
-      ) ?? {}
-
-    if (remoteId === undefined) {
-      return
-    }
-
-    await client.collection(DOCTYPE_FILES).addReferencesTo(
-      {
-        _id: remoteId,
-        _type: DOCTYPE_ALBUMS
-      },
-      [
-        {
-          _id: documentCreated.id
-        }
-      ]
     )
   }
 }

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -190,7 +190,7 @@ const postUpload = async (
   documentCreated: IOCozyFile
 ): Promise<void> => {
   if (mediaToUpload.albums.length > 0 && areAlbumsEnabled()) {
-    await addMediaToAlbum(
+    await addMediaToAlbums(
       client,
       localBackupConfig,
       mediaToUpload,
@@ -199,7 +199,7 @@ const postUpload = async (
   }
 }
 
-const addMediaToAlbum = async (
+const addMediaToAlbums = async (
   client: CozyClient,
   localBackupConfig: LocalBackupConfig,
   mediaToUpload: Media,


### PR DESCRIPTION
Previously, we created every new album at beginning of backup, which
lead to two issues :
- backup preparation time was long when you had a lot of albums (and
indirectly no button was shown on front end side)
- if you stop a backup, you can have empty albums because album has
been created but media not uploaded

Now, an album is created only when a media in this album  has been
uploaded.

--- 

First commit are refactoring.