### PR TITLE
fix(geolocation): Do not ask for ACTIVITY_RECOGNITION permission in Android < 10

### DIFF
--- a/src/app/domain/geolocation/services/permissions.ts
+++ b/src/app/domain/geolocation/services/permissions.ts
@@ -25,7 +25,7 @@ export const checkLocationPermissions =
       }
     }
 
-    if (Platform.OS === 'android') {
+    if (Platform.OS === 'android' && Platform.Version >= 29) {
       const fineLocationPermission = await checkNativePermission(
         NATIVE_PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION
       )
@@ -40,6 +40,17 @@ export const checkLocationPermissions =
         canRequest:
           fineLocationPermission.canRequest &&
           activityRecognitionPermission.canRequest
+      }
+    }
+
+    if (Platform.OS === 'android' && Platform.Version < 29) {
+      const fineLocationPermission = await checkNativePermission(
+        NATIVE_PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION
+      )
+
+      return {
+        granted: fineLocationPermission.granted,
+        canRequest: fineLocationPermission.canRequest
       }
     }
 
@@ -63,7 +74,7 @@ export const requestLocationPermissions =
       }
     }
 
-    if (Platform.OS === 'android') {
+    if (Platform.OS === 'android' && Platform.Version >= 29) {
       const fineLocationPermission = await requestNativePermission(
         NATIVE_PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION
       )
@@ -78,6 +89,17 @@ export const requestLocationPermissions =
         canRequest:
           fineLocationPermission.canRequest &&
           activityRecognitionPermission.canRequest
+      }
+    }
+
+    if (Platform.OS === 'android' && Platform.Version < 29) {
+      const fineLocationPermission = await requestNativePermission(
+        NATIVE_PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION
+      )
+
+      return {
+        granted: fineLocationPermission.granted,
+        canRequest: fineLocationPermission.canRequest
       }
     }
 


### PR DESCRIPTION
ACTIVITY_RECOGNITION permission has been added in Android 10. So asking it result to an "Permission unavailable" error on Android < 10.
