### PR TITLE
fix: Load ClouderyViewSwitch's WebViews sequentially

### DIFF
--- a/src/screens/login/components/ClouderyViewSwitch.tsx
+++ b/src/screens/login/components/ClouderyViewSwitch.tsx
@@ -88,7 +88,7 @@ export const ClouderyViewSwitch = forwardRef(
     const webviewLoginRef = useRef<WebView>()
     const webviewSigninRef = useRef<WebView>()
     const [loginLoaded, setLoginLoaded] = useState(false)
-    const [signinLoaded, setSigninLoaded] = useState(false)
+    const [signinLoaded, setSigninLoaded] = useState(urls.isOnboardingPartner)
 
     useEffect(() => {
       if (loginLoaded && signinLoaded) {
@@ -112,10 +112,6 @@ export const ClouderyViewSwitch = forwardRef(
 
     const onLoginLoadEnd = (): void => {
       setLoginLoaded(true)
-
-      if (urls.isOnboardingPartner) {
-        setSigninLoaded(true)
-      }
     }
 
     const processMessage = (event: WebViewMessageEvent): void => {
@@ -149,29 +145,31 @@ export const ClouderyViewSwitch = forwardRef(
             />
           </View>
         )}
-        <View
-          style={[
-            styles.clouderyLoginView,
-            { zIndex: clouderyMode === CLOUDERY_MODE_LOGIN ? 2 : 1 }
-          ]}
-          key="ViewLogin"
-          testID="ViewLogin"
-        >
-          <ClouderyWebView
-            applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
-            ref={webviewLoginRef}
-            uri={urls.loginUrl}
-            key="WebViewLogin"
-            setCanGoBack={setCanGoBack}
-            handleNavigation={handleNavigation}
-            onLoadEnd={onLoginLoadEnd}
-            onMessage={processMessage}
-            clouderyTheme={clouderyTheme}
-            disableAutofocus={
-              disableAutofocus || clouderyMode !== CLOUDERY_MODE_LOGIN
-            }
-          />
-        </View>
+        {signinLoaded && (
+          <View
+            style={[
+              styles.clouderyLoginView,
+              { zIndex: clouderyMode === CLOUDERY_MODE_LOGIN ? 2 : 1 }
+            ]}
+            key="ViewLogin"
+            testID="ViewLogin"
+          >
+            <ClouderyWebView
+              applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
+              ref={webviewLoginRef}
+              uri={urls.loginUrl}
+              key="WebViewLogin"
+              setCanGoBack={setCanGoBack}
+              handleNavigation={handleNavigation}
+              onLoadEnd={onLoginLoadEnd}
+              onMessage={processMessage}
+              clouderyTheme={clouderyTheme}
+              disableAutofocus={
+                disableAutofocus || clouderyMode !== CLOUDERY_MODE_LOGIN
+              }
+            />
+          </View>
+        )}
       </>
     )
   }


### PR DESCRIPTION
In previous implementation, both Signing and Login WebViews were loaded in parallel

When doing this, there was a race condition on the Cloudery that would create two new sessions in parallel and so two different cookies instead on a single one

Later in the process, this would occasionally produce some CSRF issues due two the co-existence of two cookies, resulting in a 422 error from the Cloudery

To prevent that, we want both WebViews to be loaded sequentially to ensure only the first WebView will create a new session on Cloudery

This should be a bit slower, but this is acceptable