### PR TITLE
Add 'ocr', 'scanner' and 'backup' features to isAvailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cozy-clisk": "^0.22.3",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
-    "cozy-intent": "^2.17.1",
+    "cozy-intent": "^2.18.0",
     "cozy-logger": "^1.10.0",
     "cozy-minilog": "3.3.0",
     "date-fns": "2.29.3",

--- a/src/components/webviews/jsInteractions/jsCozyInjection.js
+++ b/src/components/webviews/jsInteractions/jsCozyInjection.js
@@ -17,7 +17,7 @@ const makeMetadata = routeName => {
     routeName,
     statusBarHeight,
     version,
-    backup_available: true
+    backup_available: true // deprecated
   })
 }
 

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -83,6 +83,10 @@ const isAvailable = (featureName: string): Promise<boolean> => {
     return Promise.resolve(true)
   } else if (featureName === 'ocr') {
     return Promise.resolve(isOcrAvailable())
+  } else if (featureName === 'backup') {
+    return Promise.resolve(true)
+  } else if (featureName === 'scanner') {
+    return Promise.resolve(isScannerAvailable())
   }
 
   return Promise.resolve(false)
@@ -253,7 +257,7 @@ export const localMethods = (
     openAppOSSettings,
     isNativePassInstalledOnDevice,
     scanDocument,
-    isScannerAvailable: () => Promise.resolve(isScannerAvailable()),
+    isScannerAvailable: () => Promise.resolve(isScannerAvailable()), // deprecated
     ocr: processOcr,
     // For now setTheme is only used for the home theme
     setTheme: setHomeThemeIntent,

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -81,6 +81,8 @@ const backToHome = (): Promise<null> => {
 const isAvailable = (featureName: string): Promise<boolean> => {
   if (featureName === 'geolocationTracking') {
     return Promise.resolve(true)
+  } else if (featureName === 'ocr') {
+    return Promise.resolve(isOcrAvailable())
   }
 
   return Promise.resolve(false)
@@ -253,7 +255,6 @@ export const localMethods = (
     scanDocument,
     isScannerAvailable: () => Promise.resolve(isScannerAvailable()),
     ocr: processOcr,
-    isOcrAvailable: () => Promise.resolve(isOcrAvailable()),
     // For now setTheme is only used for the home theme
     setTheme: setHomeThemeIntent,
     prepareBackup: () => prepareBackupWithClient(client),

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -4,6 +4,7 @@ import { getDeviceName } from 'react-native-device-info'
 
 import CozyClient from 'cozy-client'
 import { FlagshipUI, NativeMethodsRegister } from 'cozy-intent'
+import Minilog from 'cozy-minilog'
 
 import * as RootNavigation from '/libs/RootNavigation'
 import {
@@ -54,6 +55,8 @@ import {
   checkPermissions,
   requestPermissions
 } from '/app/domain/nativePermissions'
+
+const log = Minilog('localMethods')
 
 export const asyncLogout = async (client?: CozyClient): Promise<null> => {
   if (!client) {
@@ -257,7 +260,12 @@ export const localMethods = (
     openAppOSSettings,
     isNativePassInstalledOnDevice,
     scanDocument,
-    isScannerAvailable: () => Promise.resolve(isScannerAvailable()), // deprecated
+    isScannerAvailable: (): Promise<boolean> => {
+      log.debug(
+        "Please use intent.call('isAvailable', 'scanner') instead of intent.call('isScannerAvailable')"
+      )
+      return Promise.resolve(isScannerAvailable())
+    },
     ocr: processOcr,
     // For now setTheme is only used for the home theme
     setTheme: setHomeThemeIntent,

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -189,7 +189,6 @@ interface CustomMethods {
   setGeolocationTrackingId: typeof setGeolocationTrackingId
   forceUploadGeolocationTrackingData: typeof forceUploadGeolocationTrackingData
   getDeviceInfo: typeof getDeviceInfo
-  isAvailable: typeof isAvailable
 }
 
 const prepareBackupWithClient = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6422,10 +6422,10 @@ cozy-flags@^2.11.0:
   dependencies:
     microee "^0.0.6"
 
-cozy-intent@^2.17.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.17.1.tgz#dac7a9ee5bdef19c735bc2ebd0421f3214c18c5d"
-  integrity sha512-BpeDO/bML15BoV6snSdlt1Smj84oV638NUdhxCqcfYqpiUNkNKu9Ur8zQ+OfFJpYSkeijvJvYallvcV8ZPl3dw==
+cozy-intent@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.18.0.tgz#9a1f0f3017f45d7b7c86710e01326f9b08ae69d8"
+  integrity sha512-iTt26OGLY9YwolJnu9Ylct8NCap6lE8rxF7ftK0RYEr/i2/hQHcoMZ2gEHXabyoPqLE6NynsJ9xYlKbdFUb+VA==
   dependencies:
     post-me "0.4.5"
 


### PR DESCRIPTION
 **refactor: Support 'ocr' feature in isAvailable**

We decided to move from isFeatureAvailable() to isAvailable(featureName: string) to check if a feature is available.

isOcrAvailable has not been released yet. So let's move it now before having to handle a breaking change.

 **refactor: Support 'scanner' and 'backup' feature in isAvailable**

We decided to move from isFeatureAvailable() to
isAvailable(featureName: string) to check if a feature is available.

These feature have already been released in production. So I add the
possibility here to check if they are present by calling
isAvailable('scanner') or isAvailable('backup') but I do not remove
isScannerAvailable method and backup_available injected variable.

We will need to wait that the new isAvailable is released and
distributed to all of our users before removing the deprecated
methods.