### PR TITLE
fix: Make cozy-apps responsive to keyboard on Android

### DIFF
--- a/src/components/webviews/CozyProxyWebView.js
+++ b/src/components/webviews/CozyProxyWebView.js
@@ -1,6 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native'
 import React, { useCallback, useState, useEffect } from 'react'
-import { AppState, View } from 'react-native'
+import { AppState, KeyboardAvoidingView, Platform, View } from 'react-native'
 
 import { useClient } from 'cozy-client'
 import Minilog from 'cozy-minilog'
@@ -101,8 +101,10 @@ export const CozyProxyWebView = ({
     }
   })
 
+  const Wrapper = Platform.OS === 'ios' ? View : KeyboardAvoidingView
+
   return (
-    <View style={{ ...styles.view, ...style }}>
+    <Wrapper style={{ ...styles.view, ...style }} behavior="height">
       {state.source ? (
         <CozyWebView
           source={state.source}
@@ -117,6 +119,6 @@ export const CozyProxyWebView = ({
         />
       ) : null}
       {state.isLoading && <RemountProgress />}
-    </View>
+    </Wrapper>
   )
 }

--- a/src/screens/home/HomeScreen.styles.ts
+++ b/src/screens/home/HomeScreen.styles.ts
@@ -2,7 +2,6 @@ import { StyleSheet } from 'react-native'
 
 export const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    justifyContent: 'center'
+    flex: 1
   }
 })

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -52,7 +52,9 @@ export const HomeScreen = ({
       <StatusBar barStyle={barStyle} />
 
       {shouldShowCliskDevMode() ? (
-        <CliskDevView setLauncherContext={trySetLauncherContext} />
+        launcherContext.state === 'default' ? (
+          <CliskDevView setLauncherContext={trySetLauncherContext} />
+        ) : null
       ) : (
         <HomeView
           navigation={navigation}


### PR DESCRIPTION
On Android and on small screen, some cozy-app fields may be hidden behind the keyboard when it is open

This can happen on Harvest unlock form, in MesPapiers when adding some documents, or in cozy-notes when editing a text on the bottom of a note

To prevent this we want to add a `KeyboardAvoidingView` around cozy-app WebViews like it is already done for login, onboarding and lock screens

Also, in the addition of `KeyboardAvoidingView`, we need to remove the `justifyContent: 'center'` on the HomeScreen. With this value the HomeView would stay center in the screen referential when the keyboard is open, so the HomeView would become partially hidden by the keyboard and would have a large padding on its top

Removing `justifyContent: 'center'` on the HomeScreen seems to have no side effect. This value is here since the beginning of the project and it seems not to be useful anymore


# Before/after on Harvest unlock form
![Screenshot_1698065209b](https://github.com/cozy/cozy-flagship-app/assets/1884255/d0678a15-997a-4f62-b507-0d9cbaa9ad8f) ![Screenshot_1698065164b](https://github.com/cozy/cozy-flagship-app/assets/1884255/55b6feed-9dce-4c33-aba2-58cc26f92255)

# Before/after on cozy-notes
![Screenshot_1698065450b](https://github.com/cozy/cozy-flagship-app/assets/1884255/32cc9662-d791-40d3-9144-af1b25265466) ![Screenshot_1698065431b](https://github.com/cozy/cozy-flagship-app/assets/1884255/ad1695e6-d84e-4f47-ab59-3e6d2bfea298)

> **Warning**
> on cozy-notes, the bottom tool panel is still hidden. This seems to be an issue on the cozy-notes side. So this should be fixed in another PR

# Before/after on MesPapiers
![Screenshot_1698065325b](https://github.com/cozy/cozy-flagship-app/assets/1884255/6398683f-1992-42bc-9e1a-651221bb2e85) ![Screenshot_1698065364b](https://github.com/cozy/cozy-flagship-app/assets/1884255/21540c64-ecb1-4f08-b944-46e7d02aaa2b)



