### PR TITLE
feat: Do not show an error in harvest on stopped by user

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -207,10 +207,11 @@ class ReactNativeLauncher extends Launcher {
    * Finish the execution of the konnector. Sending logs and update current job state
    *
    * @param {object} options - options object
-   * @param {String} [options.message] - options object
+   * @param {String} [options.message] - Error message
+   * @param {Boolean} [options.invisible] - should harvest display an error message or not
    * @returns {Promise<void>}
    */
-  async stop({ message } = {}) {
+  async stop({ message, invisible = false } = {}) {
     deactivateKeepAwake('clisk')
     const { client, job } = this.getStartContext()
 
@@ -229,8 +230,12 @@ class ReactNativeLauncher extends Launcher {
         await this.updateJobResult()
       }
       this.emit('STOPPED_JOB')
-    } else {
+    } else if (!invisible) {
       launcherEvent.emit('launchResult', { errorMessage: message })
+    } else {
+      // we don't want to display this error message in harvest probably because
+      // the user stopped the execution himself
+      launcherEvent.emit('launchResult', { cancel: true })
     }
     this.close()
   }

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -389,6 +389,24 @@ describe('ReactNativeLauncher', () => {
       })
       expect(launcherEvent.emit).not.toHaveBeenCalledWith('loginSuccess')
     })
+    it('should not send an error message to harvest when the user stops the execution of the konnector himself', async () => {
+      const { launcher, client } = setup()
+      launcher.setStartContext({
+        client,
+        konnector: { slug: 'konnectorslug', clientSide: true },
+        launcherClient: {
+          setAppMetadata: () => null
+        }
+      })
+      launcher.pilot.call.mockImplementation(async () => {
+        launcher.stop({ message: 'stopped by user', invisible: true })
+      })
+      await launcher.start()
+
+      expect(launcherEvent.emit).toHaveBeenCalledWith('launchResult', {
+        cancel: true
+      })
+    })
     it('should run ensureNotAuthenticated when an account has been removed from database', async () => {
       const { launcher, client, launch } = setup()
       launcher.setStartContext({

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -69,7 +69,7 @@ export class LauncherView extends Component {
    * Run when the job is stopped by the user
    */
   onStopExecution() {
-    this.launcher.stop({ message: 'stopped by user' })
+    this.launcher.stop({ message: 'stopped by user', invisible: true })
     this.props.setLauncherContext({ state: 'default' })
   }
 


### PR DESCRIPTION
No error in harvest will be shown in harvest when the user stops the
execution of the konnector himself.

An error log will still be generated to keep a trace of those execution
stops which may result from multiple causes :

- the user has wrong identifiers
- the konnector does not detect authentication correctly
- or any other unpredicted cause

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

