### PR TITLE
fix: Remove cases where UI was unstable in Harvest

### DIFF
--- a/src/libs/intents/setFlagshipUI.ts
+++ b/src/libs/intents/setFlagshipUI.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'events'
 
-import Minilog from 'cozy-minilog'
 import { Platform, StatusBar } from 'react-native'
 import { changeBarColors } from 'react-native-immersive-bars'
 
@@ -15,13 +14,12 @@ import {
 import { navigationRef } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
 
-const log = Minilog('SET_FLAGSHIP_UI')
-
 const isDarkMode = (bottomTheme: StatusBarStyle): boolean =>
   bottomTheme === StatusBarStyle.Light
 
 const handleLogging = (intent: FlagshipUI, name: string): void =>
-  log.info(`by ${name}`, intent)
+  themeLog.info(`setFlagshipUI by ${name}`, intent)
+
 export interface NormalisedFlagshipUI
   extends Omit<FlagshipUI, 'bottomTheme' | 'topTheme'> {
   bottomTheme?: StatusBarStyle
@@ -51,6 +49,7 @@ class Ui {
   }
 
   public set state(newState: NormalisedFlagshipUI) {
+    themeLog.info('UI state changed', newState)
     this._state = newState
   }
 }
@@ -179,7 +178,7 @@ export const setFlagshipUI = (
   intent: FlagshipUI,
   callerName?: string
 ): Promise<null> => {
-  callerName && handleLogging(intent, callerName)
+  handleLogging(intent, callerName ?? 'unknown')
 
   handleSideEffects(
     Object.fromEntries(

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -26,7 +26,7 @@ export const HomeScreen = ({
   navigation,
   route
 }: HomeScreenProps): JSX.Element => {
-  const [barStyle, setBarStyle] = useState(StatusBarStyle.Light)
+  const [barStyle, setBarStyle] = useState<StatusBarStyle>()
   const {
     LauncherDialog,
     canDisplayLauncher,
@@ -49,7 +49,7 @@ export const HomeScreen = ({
         }
       ]}
     >
-      <StatusBar barStyle={barStyle} />
+      {barStyle ? <StatusBar barStyle={barStyle} /> : null}
 
       {shouldShowCliskDevMode() ? (
         <CliskDevView setLauncherContext={trySetLauncherContext} />

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -16,7 +16,7 @@ import { handleBackPress, stopExecIfVisible } from './core/handleBackPress'
 import { withClient } from 'cozy-client'
 
 import { BackTo } from '/components/ui/icons/BackTo'
-import { getDimensions } from '/libs/dimensions'
+import { getDimensions, navbarHeight } from '/libs/dimensions'
 import ReactNativeLauncher from '/libs/ReactNativeLauncher'
 import { getColors } from '/ui/colors'
 import strings from '/constants/strings.json'
@@ -167,8 +167,14 @@ export class LauncherView extends Component {
     this.launcher = this.props.launcher || new ReactNativeLauncher()
     // made to measure the time between the launcher initialization and the display of the worker webview (when needed)
     // this is not await not to block the initialization of the launcher
+
+    // This call is important because the connection backdrop has normally set the icons to white on dark
+    // We want dark on white
     this.launcher.waitForWorkerVisible(() =>
-      setFlagshipUI({ topTheme: 'dark' })
+      setFlagshipUI(
+        { topTheme: 'dark', bottomTheme: 'dark' },
+        'LauncherView.js'
+      )
     )
     this.launcher.setLogger(this.props.onKonnectorLog)
 
@@ -234,6 +240,10 @@ export class LauncherView extends Component {
       this.launcher.removeAllListener()
     }
     this.launcher.close()
+
+    // Not strictly necessary, but to err on the side of caution we reset the flagship UI to dark
+    // In unlikely scenarios it is possible that the flagship UI is still set to light on white (connectionBackdrop)
+    setFlagshipUI({ topTheme: 'dark', bottomTheme: 'dark' }, 'LauncherView.js')
   }
 
   render() {
@@ -425,7 +435,9 @@ export class LauncherView extends Component {
 const styles = StyleSheet.create({
   workerVisible: {
     height: '100%',
-    width: '100%'
+    width: '100%',
+    paddingBottom: navbarHeight,
+    backgroundColor: '#fff'
   },
   workerHidden: {
     position: 'absolute',


### PR DESCRIPTION
We had multiple cases where white on dark or dark on white icons
were displayed.
To handle that, we:
- Removed auto light statusBar in homeScreen
- Made more explicit launcher views calls
- Improved Theme logging to detect issues with more ease
