### PR TITLE
fix: remove back arrow in osReceiveScreen

### DIFF
--- a/src/app/view/OsReceive/OsReceiveScreen.logic.ts
+++ b/src/app/view/OsReceive/OsReceiveScreen.logic.ts
@@ -1,8 +1,4 @@
-import {
-  Route,
-  useNavigation,
-  useNavigationState
-} from '@react-navigation/native'
+import { Route, useNavigationState } from '@react-navigation/native'
 
 import { generateWebLink, useClient } from 'cozy-client'
 import { FlagshipUI } from 'cozy-intent'
@@ -29,7 +25,7 @@ import {
 } from '/app/domain/osReceive/models/OsReceiveState'
 import { CozyAppParams } from '/constants/route-types'
 import { routes } from '/constants/routes'
-import { navigateToApp, useDefaultIconParams } from '/libs/functions/openApp'
+import { useDefaultIconParams } from '/libs/functions/openApp'
 import { setFlagshipUI } from '/libs/intents/setFlagshipUI'
 import { navigate, navigationRef } from '/libs/RootNavigation'
 
@@ -38,7 +34,6 @@ export const useOsReceiveScreenLogic = (): {
   setSelectedOption: Dispatch<SetStateAction<string | undefined>>
   canProceed: () => boolean
   proceedToWebview: () => void
-  onClose: () => void
   hasAppsForUpload: () => boolean
 } => {
   const [selectedOption, setSelectedOption] = useState<string>()
@@ -52,7 +47,6 @@ export const useOsReceiveScreenLogic = (): {
     [appsForUpload]
   )
   const currentRouteRef = useRef<Route<string, CozyAppParams>>()
-  const navigation = useNavigation()
   const navigationState = useNavigationState(state => state)
 
   // Store the current route if it's cozyapp to be able to go back to it
@@ -107,20 +101,6 @@ export const useOsReceiveScreenLogic = (): {
     })
   }, [client, appsForUpload, selectedOption, iconParams, osReceiveDispatch])
 
-  const onClose = useCallback(() => {
-    osReceiveDispatch({
-      type: OsReceiveActionType.SetInitialState
-    })
-
-    // If we were on a cozyapp before starting, we go back to it
-    if (currentRouteRef.current?.name === routes.cozyapp) {
-      void navigateToApp({
-        navigation,
-        ...currentRouteRef.current.params
-      })
-    }
-  }, [navigation, osReceiveDispatch])
-
   useEffect(() => {
     if (filesToUpload.length > 0) {
       void setFlagshipUI(
@@ -143,7 +123,6 @@ export const useOsReceiveScreenLogic = (): {
     setSelectedOption,
     canProceed,
     proceedToWebview,
-    hasAppsForUpload,
-    onClose
+    hasAppsForUpload
   }
 }

--- a/src/app/view/OsReceive/OsReceiveScreen.tsx
+++ b/src/app/view/OsReceive/OsReceiveScreen.tsx
@@ -3,7 +3,6 @@ import { StyleProp, TextStyle } from 'react-native'
 import { SvgXml } from 'react-native-svg'
 
 import { Icon } from '/ui/Icon'
-import { IconButton } from '/ui/IconButton'
 import { Container } from '/ui/Container'
 import { Grid } from '/ui/Grid'
 import { Button } from '/ui/Button'
@@ -22,7 +21,6 @@ import {
   ListItemText,
   ListSubHeader
 } from '/ui/List'
-import { ArrowLeft } from '/ui/Icons/ArrowLeft'
 import { palette } from '/ui/palette'
 import { Divider } from '/ui/Divider'
 import { useOsReceiveScreenLogic } from '/app/view/OsReceive/OsReceiveScreen.logic'
@@ -40,7 +38,6 @@ export const OsReceiveScreen = (): JSX.Element | null => {
     setSelectedOption,
     canProceed,
     proceedToWebview,
-    onClose,
     hasAppsForUpload
   } = useOsReceiveScreenLogic()
 
@@ -56,17 +53,6 @@ export const OsReceiveScreen = (): JSX.Element | null => {
     <Container style={osReceiveScreenStyles.page}>
       <Grid container direction="column" justifyContent="space-between">
         <Grid alignItems="center">
-          <IconButton
-            onPress={onClose}
-            style={osReceiveScreenStyles.goBackButton}
-          >
-            <Icon
-              size={16}
-              icon={ArrowLeft}
-              color={palette.light.text.secondary}
-            />
-          </IconButton>
-
           {isMultipleFiles ? (
             <Typography variant="h4">
               {t('services.osReceive.nElementsTitle', {


### PR DESCRIPTION
The goBack function wasn't behaving as expected
(trying to load the previous cozy-app that was in use).
In the meantime it was decided to scrap this functionality.
The user can still go back with his device controls