### PR TITLE
fix: Add check on language files and add missing translations for en and es files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android --variant=devDebug --main-activity=MainActivitybase",
-    "brand:configure:cozy": "yarn build:whitelabel && node ./white_label/dist/configure-brand.cmd.js configure cozy",
-    "brand:configure:mabulle": "yarn build:whitelabel && node ./white_label/dist/configure-brand.cmd.js configure mabulle",
-    "brand:check": "yarn build:whitelabel && node ./white_label/dist/configure-brand.cmd.js check",
+    "brand:configure:cozy": "yarn build:whitelabel && node ./white_label/dist/white_label/configure-brand.cmd.js configure cozy",
+    "brand:configure:mabulle": "yarn build:whitelabel && node ./white_label/dist/white_label/configure-brand.cmd.js configure mabulle",
+    "brand:check": "yarn build:whitelabel && node ./white_label/dist/white_label/configure-brand.cmd.js check",
     "build": "react-app-rewired build",
     "build:android:debug": "./scripts/build-debug-offline-apk.sh",
     "build:whitelabel": "yarn tsc --project white_label",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -15,6 +15,7 @@
     "contactUs": "A problem, a suggestion? Contact us at",
     "unknown_error": "An unexpected error occurred, please try again.",
     "reset": "Return to home",
+    "showDetails": "Show error details",
     "platformNotSupported": "Platform not supported for this request",
     "serverError": "An error occurred while processing your request",
     "cacheCheckError": "An error occurred while processing your request",
@@ -54,6 +55,10 @@
     "cozyNotOnboarded": {
       "body": "You must click on the email sent at the end of your registration to complete it. If you can't find this email, please contact us at <a id=\"mailto\" href=\"#\">contact@cozycloud.cc</a>.",
       "title": "You have not completed your registration"
+    },
+    "genericError": {
+      "defaultBody": "The app encountered an unexpected error",
+      "title": "A problem occurred"
     },
     "managerError": {
       "body": "An error occurred while processing your login link",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,4 +1,7 @@
 {
+  "support": {
+    "email": "support@cozycloud.cc"
+  },
   "konnectors": {
     "errorDoubleRun": {
       "title": "Ya hay una cuenta en ejecución",
@@ -12,7 +15,11 @@
     "contactUs": "¿Un problema, una sugerencia? Contáctanos en",
     "unknown_error": "Ha ocurrido un error inesperado, por favor inténtalo de nuevo.",
     "reset": "Volver al inicio",
+    "showDetails": "Ver detalles del error",
     "platformNotSupported": "Plataforma no compatible con esta solicitud",
+    "serverError": "Se ha producido un error al procesar su solicitud",
+    "cacheCheckError": "Se ha producido un error al procesar su solicitud",
+    "print": "No se ha podido imprimir, inténtelo de nuevo.",
     "shareFiles_other": "No pudimos compartir tus archivos, por favor intenta de nuevo.",
     "shareFiles_interval": "(1)[No pudimos compartir tu archivo, por favor intenta de nuevo.]||||(2-inf)[No pudimos compartir tus archivos, por favor intenta de nuevo.]"
   },
@@ -37,9 +44,21 @@
         "close": "Cerrar"
       }
     },
+    "cozyBlocked": {
+      "body": "Póngase en contacto con nosotros, si desea más información, en <a id=\"mailto\" href=\"#\">contact@cozycloud.cc</a>.",
+      "title": "Tu Cozy ha sido bloqueado"
+    },
     "cozyNotFound": {
       "body": "No hemos encontrado ningún Cozy en esta dirección. Puede que sea un error de tipeo. Para saberlo, verifica la dirección de tu Cozy en el correo electrónico que te enviamos cuando se creó.",
       "title": "La dirección de este Cozy no existe."
+    },
+    "cozyNotOnboarded": {
+      "body": "Debe hacer clic en el correo electrónico enviado al final de su inscripción para completarla. Si no encuentra este correo electrónico, póngase en contacto con nosotros en <a id=\"mailto\" href=\"#\">contact@cozycloud.cc</a>.",
+      "title": "No ha completado su registro"
+    },
+    "genericError": {
+      "defaultBody": "La aplicación ha encontrado un error inesperado",
+      "title": "Ha ocurrido un problema"
     },
     "managerError": {
       "body": "Ha ocurrido un error al procesar tu enlace de conexión",
@@ -150,6 +169,11 @@
     }
   },
   "modals": {
+    "ErrorToken": {
+      "title": "Acceso revocado",
+      "body": "Parece que has revocado este dispositivo de tu Cozy. Para volver a acceder a tus datos, inicia sesión de nuevo. Si esta acción no procede de usted, no dude en ponerse en contacto con nosotros en <linkTag>{{email}}</linkTag>.",
+      "button": "Iniciar sesión de nuevo"
+    },
     "IconChangedModal": {
       "description": "El ícono de la aplicación 'Cozy' ha sido modificado."
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -17,6 +17,9 @@
     "reset": "Revenir à l'accueil",
     "showDetails": "Voir les détails de l'erreur",
     "platformNotSupported": "Plateforme non supportée pour cette demande",
+    "serverError": "Une erreur est survenue pendant le traitement de votre requête",
+    "cacheCheckError": "Une erreur est survenue pendant le traitement de votre requête",
+    "print": "Échec de l'impression, merci de ressayer.",
     "shareFiles_other": "Nous n'avons pas pu partager vos fichiers, veuillez réessayer.",
     "shareFiles_interval": "(1)[Nous n'avons pas pu partager votre fichier, veuillez réessayer.]||||(2-inf)[Nous n'avons pas pu partager vos fichiers, veuillez réessayer.]"
   },

--- a/src/utils/jsonUtils.spec.ts
+++ b/src/utils/jsonUtils.spec.ts
@@ -1,0 +1,91 @@
+import { diffJsonStructure, getJsonStructureFlat } from '/utils/jsonUtils'
+
+describe('getJsonStructureFlat', () => {
+  it('Should return flat object', () => {
+    const object = {
+      item1: 'foo',
+      item2: 1,
+      item3: {
+        subItem: 'bar'
+      }
+    }
+
+    const result = getJsonStructureFlat(object)
+
+    expect(result).toStrictEqual(['item1', 'item2', 'item3.subItem'])
+  })
+})
+
+describe('diffJsonStructure', () => {
+  it('Should return items that are in first JSON but not in second one', () => {
+    const firstJson = {
+      item1: 'foo'
+    }
+
+    const secondJson = {}
+
+    const result = diffJsonStructure(firstJson, secondJson)
+
+    expect(result).toStrictEqual({
+      notIn1: [],
+      notIn2: ['item1']
+    })
+  })
+
+  it('Should return items that are in second JSON but not in first one', () => {
+    const firstJson = {}
+
+    const secondJson = {
+      item1: 'foo'
+    }
+
+    const result = diffJsonStructure(firstJson, secondJson)
+
+    expect(result).toStrictEqual({
+      notIn1: ['item1'],
+      notIn2: []
+    })
+  })
+
+  it('Should return items that are in one of the JSON items but not in the other', () => {
+    const firstJson = {
+      onlyInFirst: 'foo',
+      inBoth: 'both'
+    }
+
+    const secondJson = {
+      onlyInSecond: 'bar',
+      inBoth: 'both'
+    }
+
+    const result = diffJsonStructure(firstJson, secondJson)
+
+    expect(result).toStrictEqual({
+      notIn1: ['onlyInSecond'],
+      notIn2: ['onlyInFirst']
+    })
+  })
+
+  it('Should handle sub items', () => {
+    const firstJson = {
+      item1: 'foo',
+      item2: 1,
+      item3: {
+        subItem: 'bar'
+      }
+    }
+
+    const secondJson = {
+      item1: 'foo',
+      item2: 1,
+      item3: {}
+    }
+
+    const result = diffJsonStructure(firstJson, secondJson)
+
+    expect(result).toStrictEqual({
+      notIn1: [],
+      notIn2: ['item3.subItem']
+    })
+  })
+})

--- a/src/utils/jsonUtils.ts
+++ b/src/utils/jsonUtils.ts
@@ -1,0 +1,36 @@
+import _ from 'lodash'
+
+export const getJsonStructureFlat = (
+  object: Record<string, unknown>,
+  parent = ''
+): string[] => {
+  const result = Object.entries(object).flatMap(([key, value]) => {
+    if (typeof value === 'object') {
+      return getJsonStructureFlat(value as Record<string, unknown>, `${key}.`)
+    }
+    return `${parent}${key}`
+  })
+
+  return result
+}
+
+interface JsonStructureDiff {
+  notIn1: string[]
+  notIn2: string[]
+}
+
+export const diffJsonStructure = (
+  json1: Record<string, unknown>,
+  json2: Record<string, unknown>
+): JsonStructureDiff => {
+  const json1Flat = getJsonStructureFlat(json1)
+  const json2Flat = getJsonStructureFlat(json2)
+
+  const notIn1 = _.difference(json2Flat, json1Flat)
+  const notIn2 = _.difference(json1Flat, json2Flat)
+
+  return {
+    notIn1,
+    notIn2
+  }
+}

--- a/white_label/brands/cozy/js/locales/extra-en.json
+++ b/white_label/brands/cozy/js/locales/extra-en.json
@@ -1,10 +1,28 @@
 {
+  "logout_dialog": {
+    "content": "Are you sure you want to logout from your Cozy?"
+  },
   "screens": {
     "clouderyOffer": {
       "backButton": "BACK TO MY COZY",
       "success": {
         "body": "Your Cozy is being updated.\nYou will receive a notification as soon as your purchase is finalized."
       }
+    },
+    "cozyBlocked": {
+      "title": "Your Cozy has been blocked"
+    },
+    "cozyNotFound": {
+      "body": "We could not find any Cozy at this address. It may be a typo. To know, check the address of your Cozy in the email we sent you when it was created.",
+      "title": "This Cozy address does not exist."
+    },
+    "SecureScreen": {
+      "passwordprompt_body": "Access to your device is not secure. Choose a password to secure access to your Cozy.",
+      "passwordprompt_title": "Secure access to your Cozy",
+      "pinprompt_body": "Access your app faster by enabling app unlock with PIN code"
+    },
+    "login": {
+      "invalidMagicCode": "The link to access your Cozy is truncated or has expired"
     },
     "welcome": {
       "body": "Access your Personal Cloud now, the digital home to gather all your data",
@@ -15,6 +33,9 @@
   "modals": {
     "IconChangedModal": {
       "description": "The icon of the 'Cozy' application has been modified."
+    },
+    "ErrorToken": {
+      "body": "It seems you have revoked this device from your Cozy. To access your data again, please log in again. If you did not perform this action, please feel free to contact us at <linkTag>{{email}}</linkTag>."
     }
   },
   "services": {

--- a/white_label/brands/cozy/js/locales/extra-es.json
+++ b/white_label/brands/cozy/js/locales/extra-es.json
@@ -1,10 +1,28 @@
 {
+  "logout_dialog": {
+    "content": "¿Estás seguro de que quieres desconectarte de tu Cozy?"
+  },
   "screens": {
     "clouderyOffer": {
       "backButton": "VOLVER A MI COZY",
       "success": {
         "body": "Tu Cozy está siendo actualizado.\nRecibirás una notificación en cuanto finalice tu compra."
       }
+    },
+    "cozyBlocked": {
+      "title": "Tu Cozy ha sido bloqueado"
+    },
+    "cozyNotFound": {
+      "body": "No hemos encontrado ningún Cozy en esta dirección. Puede que sea un error de tipeo. Para saberlo, verifica la dirección de tu Cozy en el correo electrónico que te enviamos cuando se creó.",
+      "title": "La dirección de este Cozy no existe."
+    },
+    "SecureScreen": {
+      "passwordprompt_body": "El acceso a tu dispositivo no es seguro. Elige una contraseña para asegurar el acceso a tu Cozy.",
+      "passwordprompt_title": "Asegurar el acceso a tu Cozy",
+      "pinprompt_body": "Accede a tu aplicación más rápido activando el desbloqueo de la aplicación con código PIN"
+    },
+    "login": {
+      "invalidMagicCode": "El enlace para acceder a tu Cozy está truncado o ha expirado"
     },
     "welcome": {
       "body": "Accede a tu Nube Personal ahora, el hogar digital para reunir todos tus datos",
@@ -15,6 +33,9 @@
   "modals": {
     "IconChangedModal": {
       "description": "El ícono de la aplicación 'Cozy' ha sido modificado."
+    },
+    "ErrorToken": {
+      "body": "Parece que has revocado este dispositivo de tu Cozy. Para volver a acceder a tus datos, inicia sesión de nuevo. Si esta acción no procede de usted, no dude en ponerse en contacto con nosotros en <linkTag>{{email}}</linkTag>."
     }
   },
   "services": {

--- a/white_label/configure-brand.cmd.ts
+++ b/white_label/configure-brand.cmd.ts
@@ -5,7 +5,8 @@ import Minilog from 'cozy-minilog'
 import {
   configureBrand,
   checkCozyBrandIso,
-  checkGitStatus
+  checkGitStatus,
+  checkLanguages
 } from './configure-brand'
 
 export const logger = Minilog('Configure Brand CLI')
@@ -73,7 +74,9 @@ async function main(): Promise<void> {
 
   program
     .command('check')
-    .description('Check that Cozy brand mirrors root files')
+    .description(
+      'Check that Cozy brand mirrors root files and that languages files are good'
+    )
     .action(
       handleErrors(async () => {
         logger.info(`Check Cozy brand`)
@@ -82,6 +85,12 @@ async function main(): Promise<void> {
 
         if (!isISO) {
           program.error('Cozy brand is not sync with original files')
+        }
+
+        const areLanguageOk = checkLanguages()
+
+        if (!areLanguageOk) {
+          program.error('Language files are not sync with each other')
         }
       })
     )


### PR DESCRIPTION
Some languages files were missing translations and also extra languages were not in sync with each other in white labels

Those new checks should ensure that all langages files contain the same keys and that all extra language override the same keys