### PR TITLE
feat: Allow Flagship app to intall git source apps or konnectors

### DIFF
--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -141,7 +141,7 @@ export const fetchCozyDataForSlug = async (slug, client, cookie) => {
 
 /**
  * @param {CozyClient} client - CozyClient instance
- * 
+ *
  * @description  Get The uri, fqdn and normalizedFqdn of a cozy instance
  *
  * @returns {getInstanceAndFqdnFromClient}
@@ -168,20 +168,24 @@ export const getInstanceAndFqdnFromClient = client => {
 /**
  * @param {string} slug - The slug of the cozy-app to update
  * @param {CozyClient} client - CozyClient instance
- * @returns {Promise<string>} - The version of the cozy-app
+ * @returns {Promise<{stackVersion: string, stackSource: string}>>} - The version of the cozy-app
  */
-export const fetchCozyAppVersion = async (slug, client, type = 'apps') => {
+export const fetchCozyAppStackInfos = async (slug, client, type = 'apps') => {
   const stackClient = client.getStackClient()
 
   const result = await stackClient.fetchJSON('GET', `/${type}/${slug}`)
 
-  const version = result?.data?.attributes?.version
+  const stackVersion = result?.data?.attributes?.version
+  const stackSource = result?.data?.attributes?.source
 
-  if (!version) {
+  if (!stackVersion) {
     throw new Error(`No version found for app ${slug}`)
   }
+  if (!stackSource) {
+    throw new Error(`No source found for app ${slug}`)
+  }
 
-  return version
+  return { stackVersion, stackSource }
 }
 
 const isClientErrorResponse = error =>

--- a/src/libs/cozyAppBundle/cozyAppBundle.ts
+++ b/src/libs/cozyAppBundle/cozyAppBundle.ts
@@ -4,7 +4,7 @@ import RNFS from 'react-native-fs'
 import { logger } from '/libs/functions/logger'
 import {
   fetchCozyAppArchiveInfoForVersion,
-  fetchCozyAppVersion,
+  fetchCozyAppStackInfos,
   getInstanceAndFqdnFromClient
 } from '/libs/client'
 import { getBaseFolderForFqdnAndSlug } from '/libs/httpserver/httpPaths'
@@ -76,7 +76,11 @@ export const updateCozyAppBundle = async ({
 
   const { version: currentVersion } =
     (await getCurrentAppConfigurationForFqdnAndSlug(fqdn, slug)) ?? {}
-  const stackVersion = await fetchCozyAppVersion(slug, client, type)
+  const { stackVersion, stackSource } = await fetchCozyAppStackInfos(
+    slug,
+    client,
+    type
+  )
 
   const destinationPath = getCozyAppFolderPathForVersion({
     client,
@@ -113,7 +117,8 @@ export const updateCozyAppBundle = async ({
     destinationPath,
     slug,
     type,
-    version: stackVersion
+    version: stackVersion,
+    source: stackSource
   })
 
   await setCurrentAppVersionForFqdnAndSlug({
@@ -183,11 +188,13 @@ const downloadAndExtractCozyAppVersion = async ({
   destinationPath,
   slug,
   type,
-  version
+  version,
+  source
 }: AppInfo & {
   destinationPath: string
   type: AppType
   version: string
+  source: string
 }): Promise<void> => {
   log.debug(`Downloading '${slug}' version '${version}' from stack`)
 
@@ -206,7 +213,6 @@ const downloadAndExtractCozyAppVersion = async ({
   })
 
   await extractCozyAppArchive(archivePath, destinationPath)
-
   await removeCozyAppArchive(archivePath)
 }
 


### PR DESCRIPTION
Indeed apps or konnectors with source with the form (git://...) are not
installable by the flagship app since it tries to extract it with gzip
and the git clone done by the stack is not compressed see [the stack source code](https://github.com/cozy/cozy-stack/blob/0d175fbf82df7533964f918c12c3d53b767c64e8/model/app/fetcher_git.go#L261-L267)

This kind of source will be especially handy to debug clisk konnectors

Still a draft since I did not fix unit tests and still have typescript issues.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

