### PR TITLE
Increase AsyncStorage read and write limits

### DIFF
--- a/android/app/src/main/java/io/cozy/flagship/mobile/MainApplication.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/MainApplication.java
@@ -21,6 +21,9 @@ import io.cozy.flagship.mobile.keyboard.KeyboardPackage;
 import io.cozy.flagship.mobile.httpserver.HttpServerPackage;
 import io.cozy.flagship.mobile.webview.WebViewPackage;
 
+import android.database.CursorWindow;
+import java.lang.reflect.Field;
+
 public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost =
@@ -61,6 +64,16 @@ public class MainApplication extends Application implements ReactApplication {
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
     WebView.setWebContentsDebuggingEnabled(true);
     OkHttpClientProvider.setOkHttpClientFactory(new UserAgentClientFactory());
+
+    try {
+      Field field = CursorWindow.class.getDeclaredField("sCursorWindowSize");
+      field.setAccessible(true);
+      field.set(null, 50 * 1024 * 1024); // 50MB
+    } catch (Exception e) {
+      if (BuildConfig.DEBUG) {
+        e.printStackTrace();
+      }
+    }
   }
 
   /**

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -30,6 +30,9 @@ FLIPPER_VERSION=0.99.0
 # Helps against out of memory errors
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError
 
+# Increase AsyncStorage db size (default to 6MB)
+AsyncStorage_db_size_in_MB=100
+
 MYAPP_UPLOAD_STORE_FILE=cozycloudkey.keystore
 MYAPP_UPLOAD_KEY_ALIAS=cozycloudkey
 MYAPP_UPLOAD_STORE_PASSWORD=REPLACE_BY_CERTIFICATE_PASS


### PR DESCRIPTION
Fix backup issues resulting in "Backup config not initialized" errors

Read limit per entry : 2MB to 50MB
Write limit per whole app: 6MB to 100MB