### PR TITLE
feat: Remove not useful anymore rn-async-storage-flipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,27 +89,25 @@ Use [flipper](https://fbflipper.com/docs/features/react-native/) to
 have access to a React Native Debuguer.
 If you are running MacOS on a M1 or M2 computer, use [this optimized version](https://github.com/chiragramani/FlipperReleases) instead.
 
-To have access to the AsyncStorage content you can install those
-2 plugins:
-async-storage and async-storage-advanced (see https://github.com/cozy/cozy-react-native/pull/270
-for more information)
+To have access to the AsyncStorage content you can install async-storage-advanced plugin (see https://github.com/cozy/cozy-react-native/pull/270
+for more information).
 
 A guide for debugging in release mode can be found here: [How to retrieve logs in release mode](docs/how-to-retrieve-logs-in-release.md)
 
 ### Inspecting a webview
 
-#### Android 
+#### Android
 
-In order to inspect the content of the webview & get access to the console: 
+In order to inspect the content of the webview & get access to the console:
 In chrome: `chrome://inspect/#devices`
 
 (you can read https://github.com/cozy/react-native-webview/blob/cozy_main/docs/Debugging.md#android--chrome for more informations)
 
-#### iOS 
+#### iOS
 
-If you have an iOS >= 16.4 you need to do the following: 
+If you have an iOS >= 16.4 you need to do the following:
 
-Add : 
+Add :
 ```
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130300 || \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400 || \

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "react-scripts": "4.0.3",
     "redux-logger": "3.0.6",
     "redux-persist": "^6.0.0",
-    "rn-async-storage-flipper": "^0.0.10",
     "rn-flipper-async-storage-advanced": "^1.0.4",
     "semver": "^7.3.2"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,9 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { NavigationContainer } from '@react-navigation/native'
 import { decode, encode } from 'base-64'
 import React, { useEffect, useState } from 'react'
 import { StatusBar, StyleSheet, View } from 'react-native'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
-import RNAsyncStorageFlipper from 'rn-async-storage-flipper'
 import FlipperAsyncStorage from 'rn-flipper-async-storage-advanced'
 
 import { CozyProvider, useClient } from 'cozy-client'
@@ -177,11 +175,6 @@ const WrappedApp = () => {
 
 const Wrapper = () => {
   const [hasCrypto, setHasCrypto] = useState(false)
-  useEffect(() => {
-    if (__DEV__) {
-      RNAsyncStorageFlipper(AsyncStorage)
-    }
-  }, [])
 
   return (
     <>


### PR DESCRIPTION
2 plugins were installed to debug AsyncStorage with flipper : rn-async-storage-flipper to view and
rn-flipper-async-storage-advanced to edit.

When updating to rn-flipper-async-storage-advanced to 1.0.8 (see https://github.com/lbaldy/flipper-plugin-async-storage-advanced/pull/9), we do not need anymore both plugins.

You need to update rn-flipper-async-storage-advanced on Flipper side.