### PR TITLE
Improve trip segmentation

### DIFF
--- a/src/app/domain/geolocation/tracking/tracking.spec.js
+++ b/src/app/domain/geolocation/tracking/tracking.spec.js
@@ -35,11 +35,11 @@ describe('createDataBatch', () => {
 })
 
 describe('get activities', () => {
-  it('should filter the activities to keep distinct modes', async () => {
+  it('should filter the activities to remove consecutive stationary activities', async () => {
     const activity1 = { data: { cycling: true, walking: false, ts: 1 } }
-    const activity2 = { data: { walking: true, cycling: false, ts: 2 } }
-    const activity3 = { data: { walking: true, cycling: false, ts: 3 } }
-    const activity4 = { data: { walking: true, cycling: false, ts: 4 } }
+    const activity2 = { data: { walking: false, stationary: true, ts: 2 } }
+    const activity3 = { data: { walking: false, stationary: true, ts: 3 } }
+    const activity4 = { data: { walking: true, stationary: false, ts: 4 } }
 
     getActivities.mockResolvedValueOnce([
       activity1,
@@ -49,20 +49,18 @@ describe('get activities', () => {
     ])
 
     const activities = await getFilteredActivities({ beforeTs: 5 })
-    expect(activities).toEqual([activity1, activity2])
+    expect(activities).toEqual([activity1, activity2, activity4])
   })
 
-  it('should return all activities when they change', async () => {
-    const activity1 = { data: { cycling: true, walking: false, ts: 1 } }
-    const activity2 = {
-      data: { walking: false, cycling: false, in_vehicle: true, ts: 2 }
-    }
-    const activity3 = { data: { walking: true, cycling: false, ts: 3 } }
+  it('should only keep the most recent stationary activities', async () => {
+    const activity1 = { data: { stationary: true, ts: 1 } }
+    const activity2 = { data: { stationary: true, ts: 2 } }
+    const activity3 = { data: { stationary: true, ts: 3 } }
 
     getActivities.mockResolvedValueOnce([activity1, activity2, activity3])
 
-    const activities = await getFilteredActivities({ beforeTs: 5 })
-    expect(activities).toEqual([activity1, activity2, activity3])
+    const activities = await getFilteredActivities({ beforeTs: 4 })
+    expect(activities).toEqual([activity1])
   })
 
   it('should keep the only activity', async () => {

--- a/src/app/domain/geolocation/tracking/upload.js
+++ b/src/app/domain/geolocation/tracking/upload.js
@@ -4,6 +4,7 @@ import { smartSend } from '/app/domain/geolocation/tracking/tracking'
 import { getOrCreateId } from '/app/domain/geolocation/tracking/user'
 import { Log } from '/app/domain/geolocation/helpers'
 import { storeFlagFailUpload } from '/app/domain/geolocation/tracking/storage'
+import { utf8ByteSize } from '/app/domain/geolocation/tracking/utils'
 
 const serverURL = 'https://openpath.cozycloud.cc'
 const heavyLogs = false // Log points, motion changes...
@@ -11,21 +12,26 @@ const heavyLogs = false // Log points, motion changes...
 export const uploadUserCache = async (content, user) => {
   Log('Uploading content to usercache...')
   const docs = filterBadContent(content)
-  const JsonRequest = {
+  const request = {
     user: user,
     phone_to_server: docs
   }
+
+  const body = JSON.stringify(request)
 
   let response = await fetch(serverURL + '/usercache/put', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify(JsonRequest)
+    body: body
   })
 
+  const size = utf8ByteSize(body)
+  Log('Request size: ' + size)
+
   if (heavyLogs) {
-    Log('Uploaded: ' + JSON.stringify(JsonRequest))
+    Log('Uploaded: ' + JSON.stringify(request))
   }
 
   if (!response.ok) {

--- a/src/app/domain/geolocation/tracking/utils.js
+++ b/src/app/domain/geolocation/tracking/utils.js
@@ -1,0 +1,18 @@
+export const utf8ByteSize = str => {
+  var size = 0
+  for (var i = 0; i < str.length; i++) {
+    var code = str.charCodeAt(i)
+    if (code < 0x80) {
+      size += 1
+    } else if (code < 0x800) {
+      size += 2
+    } else if (code < 0xd800 || code >= 0xe000) {
+      size += 3
+    } else {
+      // Surrogate pair
+      i++
+      size += 4
+    }
+  }
+  return size
+}


### PR DESCRIPTION
- Change activities filtering strategy: we now exclude consecutive stationary activities, and when their confidence is low.
- Code refactoring to simplify the processing before upload and avoid edge cases
- Exclude network locations occuring after last stationary event, that was extending trip duration 