### PR TITLE
fix: Avoid multiple app instances creation

### DIFF
--- a/android/app/src/main/java/io/cozy/flagship/mobile/MainActivity.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/MainActivity.java
@@ -27,6 +27,23 @@ public class MainActivity extends ReactActivity {
     ImmersiveBars.changeBarColors(this, isDarkMode);
     super.onCreate(null);
     RNBootSplash.init(R.drawable.bootsplash, MainActivity.this);
+
+    /**
+     * We want to prevent the app from opening inside another app's task.
+     * Some apps (like Google Files) will open the app inside their own task, even if the app is already running,
+     * And ignore the launchMode="singleTask" in the AndroidManifest.xml.
+     * 
+     * See:
+     * https://stackoverflow.com/questions/57750124/launchmode-being-overriden-by-google-files-app-when-sharing-new-instance-of-a-s
+     * https://github.com/facebook/react-native/issues/39553
+     * https://developer.android.com/guide/components/activities/tasks-and-back-stack#IntentFlagsForTasks
+     * */ 
+    if (!isTaskRoot()) {
+        Intent newIntent = new Intent(getIntent());
+        newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(newIntent);
+        finish();
+    }
   }
 
   @Override


### PR DESCRIPTION
Some apps like "Files by Google" were opening the app
multiple times through intent creation, this led to huge issues.
We now check on create how the app was launched and force it
to stay in main activity at all times