### PR TITLE
fix: Cannot read property 'fileIdAttributes' error

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -412,7 +412,7 @@ export default class Launcher {
     const createdByApp = konnector.slug
     if (!sourceAccountIdentifier) {
       throw new Error(
-        'createExistingFileIndex: unexpected undefined sourceAccountIdentifier'
+        'getExistingFilesIndex: unexpected undefined sourceAccountIdentifier'
       )
     }
 
@@ -443,7 +443,10 @@ export default class Launcher {
     )
     // @ts-ignore
     const existingFilesIndex = existingFiles.reduce((map, file) => {
-      map.set(file.metadata.fileIdAttributes, file)
+      if (file.metadata?.fileIdAttributes) {
+        // files without metadata will be replaced
+        map.set(file.metadata.fileIdAttributes, file)
+      }
       return map
     }, new Map())
     return (this.existingFilesIndex = existingFilesIndex)

--- a/src/libs/Launcher.spec.js
+++ b/src/libs/Launcher.spec.js
@@ -233,7 +233,62 @@ describe('Launcher', () => {
           sourceAccountIdentifier: 'testsourceaccountidentifier'
         })
       )
-      //
+    })
+    it('should ignore files without metadata or fileIdAttributes in the index', async () => {
+      const launcher = new Launcher()
+      launcher.setUserData({
+        sourceAccountIdentifier: 'testsourceaccountidentifier'
+      })
+
+      const konnector = { slug: 'testkonnectorslug' }
+      const trigger = {
+        message: {
+          folder_to_save: 'testfolderid',
+          account: 'testaccountid'
+        }
+      }
+      const job = {
+        message: { account: 'testaccountid', folder_to_save: 'testfolderid' }
+      }
+      const client = {
+        queryAll: jest.fn().mockResolvedValue([
+          {
+            _id: 'tokeep',
+            metadata: {
+              fileIdAttributes: 'fileidattribute'
+            }
+          },
+          {
+            _id: 'toignore'
+          }
+        ]),
+        query: jest.fn().mockResolvedValue({ data: { path: 'folderPath' } })
+      }
+      launcher.setStartContext({
+        konnector,
+        client,
+        launcherClient: client,
+        trigger,
+        job
+      })
+
+      await launcher.saveFiles([{}], {})
+
+      expect(saveFiles).toHaveBeenCalledWith(client, [{}], 'folderPath', {
+        downloadAndFormatFile: expect.any(Function),
+        manifest: expect.any(Object),
+        existingFilesIndex: new Map([
+          [
+            'fileidattribute',
+            {
+              _id: 'tokeep',
+              metadata: { fileIdAttributes: 'fileidattribute' }
+            }
+          ]
+        ]),
+        sourceAccount: 'testaccountid',
+        sourceAccountIdentifier: 'testsourceaccountidentifier'
+      })
     })
   })
 })


### PR DESCRIPTION
This happens when some files on the cozy do not have the metadata
attribute. Now the files without metadata will be replaced.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

