### PR TITLE
fix: Update yarn.lock after removing rn-async-storage-flipper

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15178,11 +15178,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rn-async-storage-flipper@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/rn-async-storage-flipper/-/rn-async-storage-flipper-0.0.10.tgz#c7ddeffef9f2fa0871652e4a4e09e612907ee589"
-  integrity sha512-Bp8B3oWufAHhc1okewR6EXZL7gRkMQMODYepTpsTgvFq7Iae57Ow4ZIDjumb6BxoCfipFSFBnxvfPhy3PDDBRQ==
-
 rn-flipper-async-storage-advanced@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/rn-flipper-async-storage-advanced/-/rn-flipper-async-storage-advanced-1.0.4.tgz#ca3d0c315a75f379fef3771cc6ee3bef2d774265"


### PR DESCRIPTION
I forgot to commit the yarn.lock here https://github.com/cozy/cozy-flagship-app/pull/1004/files