### PR TITLE
fix: Avoid blue screen when app is woke up by geolocation in background

### DIFF
--- a/src/libs/httpserver/httpServerProvider.js
+++ b/src/libs/httpserver/httpServerProvider.js
@@ -48,7 +48,7 @@ export const HttpServerProvider = props => {
   useLayoutEffect(() => {
     const server = new HttpServer(port, path, {
       localOnly: true,
-      keepAlive: false
+      keepAlive: true
     })
 
     const startingHttpServer = async () => {


### PR DESCRIPTION
react-native-background-geolocation can start the app in background. When the app was started in background, the httpserver was silently failing to start. So when the user opened the app, the app was already started but without the httpserver, and the user could see a blue screen.

Setting keepAlive httpserver parameter to true allow the server to start in background. Some considerations :
- it is not a security issue because we have the security key
- if the user switch between background and foreground, it still works
- if the app is suspended by the operating system, it still works
- if the app is killed by the operaring system, it still works

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [x] Tested on iOS
* [x] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

