### PR TITLE
Add idFromLibrary and creationDateFromLibrary in io.cozy.files metadata for backup

### DIFF
--- a/patches/@react-native-camera-roll+camera-roll+5.7.2+001+return-local-id.patch
+++ b/patches/@react-native-camera-roll+camera-roll+5.7.2+001+return-local-id.patch
@@ -1,0 +1,99 @@
+diff --git a/node_modules/@react-native-camera-roll/camera-roll/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java b/node_modules/@react-native-camera-roll/camera-roll/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+index 698fcd3..1e995a2 100644
+--- a/node_modules/@react-native-camera-roll/camera-roll/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
++++ b/node_modules/@react-native-camera-roll/camera-roll/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+@@ -565,6 +565,7 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
+           Set<String> include) {
+     WritableArray edges = new WritableNativeArray();
+     media.moveToFirst();
++    int idIndex = media.getColumnIndex(Images.Media._ID);
+     int mimeTypeIndex = media.getColumnIndex(Images.Media.MIME_TYPE);
+     int groupNameIndex = media.getColumnIndex(Images.Media.BUCKET_DISPLAY_NAME);
+     int dateTakenIndex = media.getColumnIndex(Images.Media.DATE_TAKEN);
+@@ -592,7 +593,7 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
+                       mimeTypeIndex, includeFilename, includeFileSize, includeFileExtension, includeImageSize,
+                       includePlayableDuration, includeOrientation);
+       if (imageInfoSuccess) {
+-        putBasicNodeInfo(media, node, mimeTypeIndex, groupNameIndex, dateTakenIndex, dateAddedIndex, dateModifiedIndex);
++        putBasicNodeInfo(media, node, idIndex, mimeTypeIndex, groupNameIndex, dateTakenIndex, dateAddedIndex, dateModifiedIndex);
+         putLocationInfo(media, node, dataIndex, includeLocation, mimeTypeIndex, resolver);
+ 
+         edge.putMap("node", node);
+@@ -610,11 +611,13 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
+   private static void putBasicNodeInfo(
+           Cursor media,
+           WritableMap node,
++          int idIndex,
+           int mimeTypeIndex,
+           int groupNameIndex,
+           int dateTakenIndex,
+           int dateAddedIndex,
+           int dateModifiedIndex) {
++    node.putString("id", Long.toString(media.getLong(idIndex)));
+     node.putString("type", media.getString(mimeTypeIndex));
+     WritableArray subTypes = Arguments.createArray();
+     node.putArray("subTypes", subTypes);
+diff --git a/node_modules/@react-native-camera-roll/camera-roll/ios/RNCCameraRoll.mm b/node_modules/@react-native-camera-roll/camera-roll/ios/RNCCameraRoll.mm
+index c2b47d2..7bdf8a5 100644
+--- a/node_modules/@react-native-camera-roll/camera-roll/ios/RNCCameraRoll.mm
++++ b/node_modules/@react-native-camera-roll/camera-roll/ios/RNCCameraRoll.mm
+@@ -441,9 +441,11 @@ static void RCTResolvePromise(RCTPromiseResolveBlock resolve,
+       }
+ 
+       CLLocation *const loc = asset.location;
++      NSString *localIdentifier = asset.localIdentifier;
+ 
+       [assets addObject:@{
+         @"node": @{
++          @"id": localIdentifier,
+           @"type": assetMediaTypeLabel, // TODO: switch to mimeType?
+           @"subTypes":assetMediaSubtypesLabel,
+           @"group_name": albums,
+diff --git a/node_modules/@react-native-camera-roll/camera-roll/lib/typescript/CameraRoll.d.ts b/node_modules/@react-native-camera-roll/camera-roll/lib/typescript/CameraRoll.d.ts
+index 71fba8c..f1ffeda 100644
+--- a/node_modules/@react-native-camera-roll/camera-roll/lib/typescript/CameraRoll.d.ts
++++ b/node_modules/@react-native-camera-roll/camera-roll/lib/typescript/CameraRoll.d.ts
+@@ -53,6 +53,7 @@ export declare type GetPhotosParams = {
+ };
+ export declare type PhotoIdentifier = {
+     node: {
++        id: string;
+         type: string;
+         subTypes: SubTypes;
+         group_name: string | string [];
+diff --git a/node_modules/@react-native-camera-roll/camera-roll/lib/typescript/NativeCameraRollModule.d.ts b/node_modules/@react-native-camera-roll/camera-roll/lib/typescript/NativeCameraRollModule.d.ts
+index db3b502..0c5adf7 100644
+--- a/node_modules/@react-native-camera-roll/camera-roll/lib/typescript/NativeCameraRollModule.d.ts
++++ b/node_modules/@react-native-camera-roll/camera-roll/lib/typescript/NativeCameraRollModule.d.ts
+@@ -16,6 +16,7 @@ declare type Album = {
+ declare type SubTypes = 'PhotoPanorama' | 'PhotoHDR' | 'PhotoScreenshot' | 'PhotoLive' | 'PhotoDepthEffect' | 'VideoStreamed' | 'VideoHighFrameRate' | 'VideoTimelapse';
+ declare type PhotoIdentifier = {
+     node: {
++        id: string;
+         type: string;
+         subTypes: SubTypes;
+         group_name: string | string[];
+diff --git a/node_modules/@react-native-camera-roll/camera-roll/src/CameraRoll.ts b/node_modules/@react-native-camera-roll/camera-roll/src/CameraRoll.ts
+index eb0a2be..8b16459 100644
+--- a/node_modules/@react-native-camera-roll/camera-roll/src/CameraRoll.ts
++++ b/node_modules/@react-native-camera-roll/camera-roll/src/CameraRoll.ts
+@@ -114,6 +114,7 @@ export type GetPhotosParams = {
+ 
+ export type PhotoIdentifier = {
+   node: {
++    id: string;
+     type: string;
+     subTypes: SubTypes;
+     group_name: string | string[];
+diff --git a/node_modules/@react-native-camera-roll/camera-roll/src/NativeCameraRollModule.ts b/node_modules/@react-native-camera-roll/camera-roll/src/NativeCameraRollModule.ts
+index f52e7b6..67d3fc5 100644
+--- a/node_modules/@react-native-camera-roll/camera-roll/src/NativeCameraRollModule.ts
++++ b/node_modules/@react-native-camera-roll/camera-roll/src/NativeCameraRollModule.ts
+@@ -31,6 +31,7 @@ type SubTypes =
+ 
+ type PhotoIdentifier = {
+   node: {
++    id: string;
+     type: string;
+     subTypes: SubTypes;
+     group_name: string | string [];

--- a/src/app/domain/backup/helpers/error.ts
+++ b/src/app/domain/backup/helpers/error.ts
@@ -26,14 +26,6 @@ export const isUploadError = (error: unknown): error is UploadError => {
     Array.isArray(error.errors)
   )
 }
-
-export const isMetadataExpiredError = (error: UploadError): boolean => {
-  return (
-    error.statusCode === 422 &&
-    error.errors[0]?.detail === 'Invalid or expired MetadataID'
-  )
-}
-
 export const isQuotaExceededError = (error: UploadError): boolean => {
   return (
     error.statusCode === 413 &&
@@ -59,8 +51,7 @@ export const isCancellationError = (error: UploadError): boolean => {
 export const shouldRetryCallbackBackup = (error: Error): boolean => {
   const notRetryableError =
     isUploadError(error) &&
-    (isMetadataExpiredError(error) ||
-      isQuotaExceededError(error) ||
+    (isQuotaExceededError(error) ||
       isFileTooBigError(error) ||
       isCancellationError(error))
 

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -10,6 +10,7 @@ import { Album } from '/app/domain/backup/models'
  * @member {number} modificationDate  timestamp with ms set to 0
  */
 export interface Media {
+  id: string
   name: string
   uri: string
   path: string
@@ -50,4 +51,6 @@ export interface BackupedMedia {
 export interface UploadMetadata {
   backupDeviceIds: string[]
   pairedVideoId?: string
+  idFromLibrary: string
+  creationDateFromLibrary: string
 }

--- a/src/app/domain/backup/models/Media.ts
+++ b/src/app/domain/backup/models/Media.ts
@@ -41,3 +41,13 @@ export interface BackupedMedia {
   remoteId: string
   md5: string
 }
+
+/**
+ * Backup related metadata to store in an io.cozy.files
+ * @member {string[]} backupDeviceIds e.g. ["96EEA830-D697-4AB8-A6C0-1940A4EEB231"]
+ * @member {string} [pairedVideoId] for the image part of a Live Photo, the id of the video part
+ */
+export interface UploadMetadata {
+  backupDeviceIds: string[]
+  pairedVideoId?: string
+}

--- a/src/app/domain/backup/queries/index.ts
+++ b/src/app/domain/backup/queries/index.ts
@@ -12,6 +12,8 @@ export const buildAllMediasFilesQuery = (): QueryDefinition => {
     .indexFields(['class', 'type'])
     .select([
       'class',
+      'metadata.idFromLibrary',
+      'metadata.creationDateFromLibrary',
       'type',
       'name',
       'path',
@@ -33,6 +35,8 @@ export const buildFilesQuery = (deviceId: string): QueryDefinition => {
     .indexFields(['metadata.backupDeviceIds', 'type'])
     .select([
       'metadata.backupDeviceIds',
+      'metadata.idFromLibrary',
+      'metadata.creationDateFromLibrary',
       'type',
       'name',
       'path',
@@ -54,6 +58,10 @@ export interface File {
   created_at: number
   updated_at: number
   md5sum: string
+  metadata: {
+    idFromLibrary?: string
+    creationDateFromLibrary?: string
+  }
 }
 
 export type FilesQueryAllResult = File[]

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -84,6 +84,7 @@ export const formatMediasFromPhotoIdentifier = (
 ): Media[] => {
   const {
     node: {
+      id,
       image: { filename, uri, fileSize },
       type,
       subTypes,
@@ -99,6 +100,7 @@ export const formatMediasFromPhotoIdentifier = (
   if (subTypes.includes('PhotoLive')) {
     return [
       {
+        id,
         name: getPathWithoutExtension(filename) + '.MOV',
         uri: uri,
         path: uri,
@@ -111,6 +113,7 @@ export const formatMediasFromPhotoIdentifier = (
         fileSize: null
       },
       {
+        id,
         name: filename,
         uri: uri,
         path: uri,
@@ -127,6 +130,7 @@ export const formatMediasFromPhotoIdentifier = (
 
   return [
     {
+      id,
       name: filename,
       uri: uri,
       path: uri,

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.ts
@@ -239,7 +239,9 @@ export const createRemoteBackupFolder = async (
 }
 
 const isFileCorrespondingToMedia = (file: File, media: Media): boolean => {
-  const creationDate = new Date(file.created_at)
+  const creationDate = new Date(
+    file.metadata.creationDateFromLibrary ?? file.created_at
+  )
   creationDate.setMilliseconds(0)
 
   return (

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -179,7 +179,9 @@ const generateMetadataObject = async (
   const deviceId = await getDeviceId()
 
   const metadataObject: UploadMetadata = {
-    backupDeviceIds: [deviceId]
+    backupDeviceIds: [deviceId],
+    idFromLibrary: media.id,
+    creationDateFromLibrary: new Date(media.creationDate).toISOString()
   }
 
   if (


### PR DESCRIPTION
Add idFromLibrary and creationDateFromLibrary in io.cozy.files metadata for backup
=> these id and date will never be changed by the stack so we can trust them
=> it will solve issues where two identical pictures were not seen as identical by the backup because the date was changed by the stack

Also changes the way we send metadata

I will create a PR later for react-native-camera-roll