### PR TITLE
Improve trip segmentation

### DIFF
--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -5,6 +5,7 @@ import BackgroundGeolocation from 'react-native-background-geolocation'
  */
 export const STILL_ACTIVITY = 'still'
 export const WALKING_ACTIVITY = 'walking'
+export const UNKNOWN_ACTIVITY = 'unknown'
 
 /**
  * Tracking plugin config

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -24,7 +24,7 @@ export const WAIT_BEFORE_STOP_MOTION_EVENT = 10 // In minutes
  * Tracking processing
  */
 export const LOW_CONFIDENCE_THRESHOLD = 0.5 // Threshold for low activity confidence
-export const LARGE_TEMPORAL_DELTA = 30 * 60 // 30min, in seconds. Shouldn't have longer breaks without siginificant motion
+export const LARGE_TEMPORAL_DELTA = 60 * 60 // 60min, in seconds. Shouldn't have longer breaks without siginificant motion
 export const MAX_TEMPORAL_DELTA = 12 * 60 * 60 // 18h, in seconds. See https://github.com/e-mission/e-mission-server/blob/f6bf89a274e6cd10353da8f17ebb327a998c788a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py#L194
 export const MIN_SPEED_BETWEEN_DISTANT_POINTS = 0.1 // In m/s. Note the average walking speed is ~1.4 m/s
 export const MAX_DOCS_PER_BATCH = 30000 // Should be less than 10 MB. Should never reach 15 MB.

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -24,11 +24,15 @@ export const WAIT_BEFORE_STOP_MOTION_EVENT = 10 // In minutes
  * Tracking processing
  */
 export const LOW_CONFIDENCE_THRESHOLD = 0.5 // Threshold for low activity confidence
-export const LARGE_TEMPORAL_DELTA = 30 * 60 // In seconds. Shouldn't have longer breaks without siginificant motion
-export const MAX_TEMPORAL_DELTA = 12 * 60 * 60 // In seconds. See https://github.com/e-mission/e-mission-server/blob/f6bf89a274e6cd10353da8f17ebb327a998c788a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py#L194
+export const LARGE_TEMPORAL_DELTA = 30 * 60 // 30min, in seconds. Shouldn't have longer breaks without siginificant motion
+export const MAX_TEMPORAL_DELTA = 12 * 60 * 60 // 18h, in seconds. See https://github.com/e-mission/e-mission-server/blob/f6bf89a274e6cd10353da8f17ebb327a998c788a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py#L194
 export const MIN_SPEED_BETWEEN_DISTANT_POINTS = 0.1 // In m/s. Note the average walking speed is ~1.4 m/s
 export const MAX_DOCS_PER_BATCH = 30000 // Should be less than 10 MB. Should never reach 15 MB.
+export const WALKING_SPEED_AVG = 1.34 // In m/s
+export const MIN_DISTANCE_TO_USE_LAST_POINT = 50 // In meters.
+export const MAX_DISTANCE_TO_USE_LAST_POINT = 6000 // In meters. This value is quite high, but we noticed on iOS + Android that it can take this far to wake up when network data is disabled
 
+export const AVG_WALKING_SPEED = 1.34
 /**
  * Trace server
  */

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -5,7 +5,11 @@ import BackgroundGeolocation from 'react-native-background-geolocation'
  */
 export const STILL_ACTIVITY = 'still'
 export const WALKING_ACTIVITY = 'walking'
+export const ON_FOOT_ACTIVITY = 'on_foot'
 export const UNKNOWN_ACTIVITY = 'unknown'
+export const RUNNING_ACTIVITY = 'running'
+export const BICYCLE_ACTIVITY = 'on_bicycle'
+export const VEHICLE_ACTIVITY = 'in_vehicle'
 
 /**
  * Tracking plugin config
@@ -27,13 +31,18 @@ export const WAIT_BEFORE_STOP_MOTION_EVENT = 10 // In minutes
 export const LOW_CONFIDENCE_THRESHOLD = 0.5 // Threshold for low activity confidence
 export const LARGE_TEMPORAL_DELTA = 60 * 60 // 60min, in seconds. Shouldn't have longer breaks without siginificant motion
 export const MAX_TEMPORAL_DELTA = 12 * 60 * 60 // 18h, in seconds. See https://github.com/e-mission/e-mission-server/blob/f6bf89a274e6cd10353da8f17ebb327a998c788a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py#L194
-export const MIN_SPEED_BETWEEN_DISTANT_POINTS = 0.1 // In m/s. Note the average walking speed is ~1.4 m/s
+export const MIN_SPEED_BETWEEN_DISTANT_POINTS = 0.5 // In m/s. Note the average walking speed is ~1.4 m/s
 export const MAX_DOCS_PER_BATCH = 30000 // Should be less than 10 MB. Should never reach 15 MB.
-export const WALKING_SPEED_AVG = 1.34 // In m/s
 export const MIN_DISTANCE_TO_USE_LAST_POINT = 50 // In meters.
 export const MAX_DISTANCE_TO_USE_LAST_POINT = 6000 // In meters. This value is quite high, but we noticed on iOS + Android that it can take this far to wake up when network data is disabled
 
+// All speed values in m/s
 export const AVG_WALKING_SPEED = 1.34
+export const MAX_WALKING_SPEED = 1.7 // https://github.com/e-mission/e-mission-server/blob/978a7199f5577e44ff3174cbf6507ff6d42a7367/emission/analysis/intake/domain_assumptions.py#L15
+export const MAX_RUNNING_SPEED = 3.1
+export const MAX_BICYCLING_SPEED = 8.5 // https://github.com/e-mission/e-mission-server/blob/978a7199f5577e44ff3174cbf6507ff6d42a7367/emission/analysis/intake/domain_assumptions.py#L23
+export const AUTOMOTIVE_SPEED = 13.9
+
 /**
  * Trace server
  */

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -4,6 +4,7 @@ import BackgroundGeolocation from 'react-native-background-geolocation'
  * Motion activities
  */
 export const STILL_ACTIVITY = 'still'
+export const WALKING_ACTIVITY = 'walking'
 
 /**
  * Tracking plugin config

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -1,0 +1,1 @@
+export const STILL_ACTIVITY = 'still'

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -9,7 +9,7 @@ export const WALKING_ACTIVITY = 'walking'
 /**
  * Tracking plugin config
  */
-export const DISTANCE_FILTER = 10
+export const DISTANCE_FILTER = 20
 export const ELASTICITY_MULTIPLIER = 4
 export const ACCURACY = BackgroundGeolocation.DESIRED_ACCURACY_HIGH
 export const DEFAULT_TRACKING_CONFIG = {

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -1,1 +1,34 @@
+import BackgroundGeolocation from 'react-native-background-geolocation'
+
+/**
+ * Motion activities
+ */
 export const STILL_ACTIVITY = 'still'
+
+/**
+ * Tracking plugin config
+ */
+export const DISTANCE_FILTER = 10
+export const ELASTICITY_MULTIPLIER = 4
+export const ACCURACY = BackgroundGeolocation.DESIRED_ACCURACY_HIGH
+export const DEFAULT_TRACKING_CONFIG = {
+  distanceFilter: DISTANCE_FILTER,
+  elasticityMultiplier: ELASTICITY_MULTIPLIER,
+  desiredAccuracy: ACCURACY
+}
+// Align with openpath: https://github.com/e-mission/e-mission-server/blob/master/emission/analysis/intake/segmentation/trip_segmentation.py#L59
+export const WAIT_BEFORE_STOP_MOTION_EVENT = 10 // In minutes
+
+/**
+ * Tracking processing
+ */
+export const LOW_CONFIDENCE_THRESHOLD = 0.5 // Threshold for low activity confidence
+export const LARGE_TEMPORAL_DELTA = 30 * 60 // In seconds. Shouldn't have longer breaks without siginificant motion
+export const MAX_TEMPORAL_DELTA = 12 * 60 * 60 // In seconds. See https://github.com/e-mission/e-mission-server/blob/f6bf89a274e6cd10353da8f17ebb327a998c788a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py#L194
+export const MIN_SPEED_BETWEEN_DISTANT_POINTS = 0.1 // In m/s. Note the average walking speed is ~1.4 m/s
+export const MAX_DOCS_PER_BATCH = 30000 // Should be less than 10 MB. Should never reach 15 MB.
+
+/**
+ * Trace server
+ */
+export const SERVER_URL = 'https://openpath.cozycloud.cc'

--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -26,8 +26,8 @@ export {
 const waitBeforeStopMotionEventMin = 10 // Align with openpath: https://github.com/e-mission/e-mission-server/blob/master/emission/analysis/intake/segmentation/trip_segmentation.py#L59
 
 const DEFAULT_TRACKING_CONFIG = {
-  distanceFilter: 20,
-  elasticityMultiplier: 3,
+  distanceFilter: 10,
+  elasticityMultiplier: 4,
   desiredAccuracy: BackgroundGeolocation.DESIRED_ACCURACY_HIGH
 }
 
@@ -48,7 +48,7 @@ export const startTracking = async () => {
       distanceFilter: trackingConfig.distanceFilter,
       elasticityMultiplier: trackingConfig.elasticityMultiplier,
       locationUpdateInterval: 10000, // Only used if on Android and if distanceFilter is 0
-      stationaryRadius: 50, // Minimum is 25, but still usually takes 200m
+      stationaryRadius: 30, // Minimum is 25, but still usually takes 200m
       // Activity Recognition
       stopTimeout: waitBeforeStopMotionEventMin,
       // Application config

--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -39,8 +39,7 @@ export const startTracking = async () => {
     Log('Starting')
 
     const trackingConfig = await getTrackingConfig()
-
-    Log(trackingConfig.toString())
+    Log('Config : ' + JSON.stringify(trackingConfig))
 
     await BackgroundGeolocation.ready({
       // Geolocation Config

--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -17,7 +17,8 @@ import {
   DISTANCE_FILTER,
   ELASTICITY_MULTIPLIER,
   STILL_ACTIVITY,
-  WAIT_BEFORE_STOP_MOTION_EVENT
+  WAIT_BEFORE_STOP_MOTION_EVENT,
+  WALKING_ACTIVITY
 } from '/app/domain/geolocation/tracking/consts'
 
 export { Log, getAllLogs, sendLogFile } from '/app/domain/geolocation/helpers'
@@ -155,9 +156,13 @@ const disableElasticity = async () => {
 
 export const handleActivityChange = async event => {
   Log('[ACTIVITY CHANGE] - ' + JSON.stringify(event))
-  if (event?.activity !== STILL_ACTIVITY) {
+  if (
+    event?.activity !== STILL_ACTIVITY &&
+    event?.activity !== WALKING_ACTIVITY
+  ) {
     // Force fetching current position to ensure there is a location corresponding to an activity change
-    // Skip still activities as it could artifically extend a trip
+    // Skip still activities as it could artifically extend a trip, and walk activity as it might capture
+    // noisy locations, e.g. at home
     const location = await BackgroundGeolocation.getCurrentPosition({
       persist: true, // Persist location in SQLite storage
       maximumAge: 5 * 60 * 1000, // 5min. Accept the last-recorded-location if no older than supplied value in ms. Default is 0.

--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -61,6 +61,8 @@ export const startTracking = async () => {
         stopOnTerminate: false, // Allow the background-service to continue tracking when user closes the app, for Android. Maybe also useful for ios https://transistorsoft.github.io/react-native-background-geolocation/interfaces/config.html#stoponterminate
         enableHeadless: true,
         foregroundService: true,
+        logMaxDays: 5, // Default is 3
+        maxDaysToPersist: 10, // The maximum retention days for local location data. Default is 1 day, which can result in removal of local points in case of upload failures.
         backgroundPermissionRationale: {
           message: t(
             'services.geolocationTracking.androidBackgroundPermissionMessage'

--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -160,17 +160,7 @@ export const handleActivityChange = async event => {
     event?.activity !== STILL_ACTIVITY &&
     event?.activity !== WALKING_ACTIVITY
   ) {
-    // Force fetching current position to ensure there is a location corresponding to an activity change
-    // Skip still activities as it could artifically extend a trip, and walk activity as it might capture
-    // noisy locations, e.g. at home
-    const location = await BackgroundGeolocation.getCurrentPosition({
-      persist: true, // Persist location in SQLite storage
-      maximumAge: 5 * 60 * 1000, // 5min. Accept the last-recorded-location if no older than supplied value in ms. Default is 0.
-      desiredAccuracy: 20,
-      samples: 6
-    })
-    Log('Forced location: ' + JSON.stringify(location))
-    // Motion activity: enable elasticity after first location to reduce battery impact
+    // Enable elasticity after first fast-enough location to reduce battery impact
     enableElasticity()
   }
 

--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -38,52 +38,41 @@ export const startTracking = async () => {
     const trackingConfig = await getTrackingConfig()
     Log('Config : ' + JSON.stringify(trackingConfig))
 
-    await BackgroundGeolocation.ready(
-      {
-        // Geolocation Config
-        desiredAccuracy: trackingConfig.desiredAccuracy || ACCURACY,
-        showsBackgroundLocationIndicator: false, // Displays a blue pill on the iOS status bar when the location services are in use in the background (if the app doesn't have 'always' permission, the blue pill will always appear when location services are in use while the app isn't focused)
-        distanceFilter: trackingConfig.distanceFilter || DISTANCE_FILTER,
-        elasticityMultiplier: 1,
-        stationaryRadius: 30, // Minimum is 25, but still usually takes 200m
-        // Activity Recognition
-        stopTimeout: WAIT_BEFORE_STOP_MOTION_EVENT,
-        // Application config
-        debug: false, // <-- enable this hear sounds for background-geolocation life-cycle and notifications
-        logLevel: BackgroundGeolocation.LOG_LEVEL_DEBUG,
-        startOnBoot: true, // <-- Auto start tracking when device is powered-up.
-        batchSync: false, // <-- [Default: false] Set true to sync locations to server in a single HTTP request.
-        autoSync: false, // <-- [Default: true] Set true to sync each location to server as it arrives.
-        stopOnTerminate: false, // Allow the background-service to continue tracking when user closes the app, for Android. Maybe also useful for ios https://transistorsoft.github.io/react-native-background-geolocation/interfaces/config.html#stoponterminate
-        enableHeadless: true,
-        foregroundService: true,
-        logMaxDays: 5, // Default is 3
-        maxDaysToPersist: 10, // The maximum retention days for local location data. Default is 1 day, which can result in removal of local points in case of upload failures.
-        backgroundPermissionRationale: {
-          message: t(
-            'services.geolocationTracking.androidBackgroundPermissionMessage'
-          )
-        },
-        notification: {
-          title: t('services.geolocationTracking.androidNotificationTitle'),
-          text: t(
-            'services.geolocationTracking.androidNotificationDescription'
-          ),
-          smallIcon: 'mipmap/ic_stat_ic_notification'
-        }
+    await BackgroundGeolocation.ready({
+      // Geolocation Config
+      desiredAccuracy: trackingConfig.desiredAccuracy || ACCURACY,
+      showsBackgroundLocationIndicator: false, // Displays a blue pill on the iOS status bar when the location services are in use in the background (if the app doesn't have 'always' permission, the blue pill will always appear when location services are in use while the app isn't focused)
+      distanceFilter: trackingConfig.distanceFilter || DISTANCE_FILTER,
+      elasticityMultiplier: 1,
+      stationaryRadius: 30, // Minimum is 25, but still usually takes 200m
+      // Activity Recognition
+      stopTimeout: WAIT_BEFORE_STOP_MOTION_EVENT,
+      // Application config
+      debug: false, // <-- enable this hear sounds for background-geolocation life-cycle and notifications
+      logLevel: BackgroundGeolocation.LOG_LEVEL_DEBUG,
+      startOnBoot: true, // <-- Auto start tracking when device is powered-up.
+      batchSync: false, // <-- [Default: false] Set true to sync locations to server in a single HTTP request.
+      autoSync: false, // <-- [Default: true] Set true to sync each location to server as it arrives.
+      stopOnTerminate: false, // Allow the background-service to continue tracking when user closes the app, for Android. Maybe also useful for ios https://transistorsoft.github.io/react-native-background-geolocation/interfaces/config.html#stoponterminate
+      enableHeadless: true,
+      foregroundService: true,
+      logMaxDays: 5, // Default is 3
+      maxDaysToPersist: 10, // The maximum retention days for local location data. Default is 1 day, which can result in removal of local points in case of upload failures.
+      backgroundPermissionRationale: {
+        message: t(
+          'services.geolocationTracking.androidBackgroundPermissionMessage'
+        )
       },
-      state => {
-        if (!state.enabled) {
-          // Start tracking only if it's not already started
-          BackgroundGeolocation.start(() => {
-            Log('Tracking started')
-            storeData(StorageKeys.ShouldBeTrackingFlagStorageAdress, true)
-          })
-        } else {
-          Log('Tracking already started')
-        }
+      notification: {
+        title: t('services.geolocationTracking.androidNotificationTitle'),
+        text: t('services.geolocationTracking.androidNotificationDescription'),
+        smallIcon: 'mipmap/ic_stat_ic_notification'
       }
-    )
+    })
+    BackgroundGeolocation.start(() => {
+      Log('Tracking started')
+      storeData(StorageKeys.ShouldBeTrackingFlagStorageAdress, true)
+    })
     return true
   } catch (e) {
     log.error(e)
@@ -171,7 +160,7 @@ export const handleActivityChange = async event => {
     // Skip still activities as it could artifically extend a trip
     const location = await BackgroundGeolocation.getCurrentPosition({
       persist: true, // Persist location in SQLite storage
-      maximumAge: 5 * 60 * 1000, // Accept the last-recorded-location if no older than supplied value in ms. Default is 0.
+      maximumAge: 5 * 60 * 1000, // 5min. Accept the last-recorded-location if no older than supplied value in ms. Default is 0.
       desiredAccuracy: 20,
       samples: 6
     })

--- a/src/app/domain/geolocation/tracking/storage.js
+++ b/src/app/domain/geolocation/tracking/storage.js
@@ -116,6 +116,9 @@ export const storeActivity = async activity => {
 
 export const getActivities = async ({ beforeTs } = {}) => {
   const activities = await getData(StorageKeys.Activities)
+  if (!activities) {
+    return []
+  }
   if (beforeTs) {
     const activitiesBeforeTs = activities.filter(activity => {
       return activity?.data?.ts <= beforeTs
@@ -131,7 +134,6 @@ export const removeActivities = async ({ beforeTs } = {}) => {
     return clearAllActivities()
   }
   const activities = await getActivities()
-  Log('All activities to remove ' + JSON.stringify(activities)) // TODO: useful for debug, but should be removed eventually
   const activitiesToKeep = activities.filter(activity => {
     if (activity?.data?.ts) {
       return activity.data.ts > beforeTs

--- a/src/app/domain/geolocation/tracking/tracking.js
+++ b/src/app/domain/geolocation/tracking/tracking.js
@@ -1,5 +1,5 @@
 import { uploadUserCache } from '/app/domain/geolocation/tracking/upload'
-import { createUser } from '/app/domain/geolocation/tracking/user'
+import { getOrCreateUser } from '/app/domain/geolocation/tracking/user'
 import { getTs, Log, parseISOString } from '/app/domain/geolocation/helpers'
 import {
   getActivities,
@@ -30,9 +30,9 @@ export const createDataBatch = (locations, nRun, maxBatchSize) => {
 // Future entry point of algorithm
 // prepareTrackingData / extractTrackingDate
 export const smartSend = async (locations, user, { force = false } = {}) => {
-  await createUser(user) // Will throw on fail, skipping the rest (trying again later is handled a level above smartSend)
+  await getOrCreateUser(user)
 
-  if (locations.length === 0) {
+  if (!locations || locations.length === 0) {
     Log('No new locations')
     await uploadWithNoNewPoints({ user, force })
   } else {

--- a/src/app/domain/geolocation/tracking/tracking.js
+++ b/src/app/domain/geolocation/tracking/tracking.js
@@ -353,10 +353,6 @@ const translateToEMissionLocationPoint = location_point => {
 
 const translateEventToEMissionMotionActivity = event => {
   const ts = Math.floor(parseISOString(event.timestamp).getTime() / 1000)
-  Log('Activity type : ' + event.activity.type + ' at ' + event.timestamp)
-  if (event.activity.type === 'unknown') {
-    Log('Unknown activity at: ' + event.timestamp)
-  }
   // See: https://transistorsoft.github.io/react-native-background-geoevent/interfaces/motionactivity.html#type
   return {
     data: {

--- a/src/app/domain/geolocation/tracking/tracking.js
+++ b/src/app/domain/geolocation/tracking/tracking.js
@@ -302,7 +302,7 @@ export const filterNonHeadingPointsAfterStillActivity = (
 
 export const getFilteredActivities = async ({ beforeTs }) => {
   const activities = await getActivities({ beforeTs })
-  if (!activities) {
+  if (!activities || activities?.length < 1) {
     return null
   }
   const result = []

--- a/src/app/domain/geolocation/tracking/tracking.js
+++ b/src/app/domain/geolocation/tracking/tracking.js
@@ -73,6 +73,7 @@ const prepareMotionData = async ({ locations, lastBatchPoint }) => {
         ' - to ' +
         locations[locations.length - 1]?.timestamp
     )
+    Log('Total points : ' + locations.length)
   }
 
   // Add activities stored in local storage
@@ -287,8 +288,11 @@ export const filterNonHeadingPointsAfterStillActivity = (
     return locations
   }
   const lastPointTs = getTs(locations[locations.length - 1])
+  const sortedActivities = activities.sort(
+    (a, b) => new Date(a.data.ts) - new Date(b.data.ts)
+  )
   let lastStillActivityTs = null
-  for (const activity of activities) {
+  for (const activity of sortedActivities) {
     if (activity?.data?.stationary) {
       lastStillActivityTs = activity?.data?.ts
     }
@@ -296,7 +300,6 @@ export const filterNonHeadingPointsAfterStillActivity = (
   if (!lastStillActivityTs) {
     lastStillActivityTs = lastPointTs
   }
-
   const points = locations.filter(loc => {
     return getTs(loc) <= lastStillActivityTs || loc?.coords?.heading > -1
   })

--- a/src/app/domain/geolocation/tracking/tracking.js
+++ b/src/app/domain/geolocation/tracking/tracking.js
@@ -16,7 +16,7 @@ import {
 const largeTemporalDeltaBetweenPoints = 30 * 60 // In seconds. Shouldn't have longer breaks without siginificant motion
 const maxTemporalDeltaBetweenPoints = 12 * 60 * 60 // In seconds. See https://github.com/e-mission/e-mission-server/blob/f6bf89a274e6cd10353da8f17ebb327a998c788a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py#L194
 const minSpeedBetweenDistantPoints = 0.1 // In m/s. Note the average walking speed is ~1.4 m/s
-const MAX_DOCS_PER_BATCH = 10000
+const MAX_DOCS_PER_BATCH = 30000 // Should be less than 10 MB. Should never reach 15 MB.
 
 const LOW_CONFIDENCE_THRESHOLD = 0.5
 
@@ -318,6 +318,7 @@ export const getFilteredActivities = async ({ beforeTs, locations }) => {
   if (!activities || activities?.length < 1) {
     Log('No activity found in local storage. Get it from locations')
     // Fallback when no activity was captured
+    // TODO: filter stationary
     const activitiesFromLoc = getActivitiesFromLocations(locations)
     return activitiesFromLoc
   }

--- a/src/app/domain/geolocation/tracking/upload.js
+++ b/src/app/domain/geolocation/tracking/upload.js
@@ -5,8 +5,8 @@ import { getOrCreateId } from '/app/domain/geolocation/tracking/user'
 import { Log } from '/app/domain/geolocation/helpers'
 import { storeFlagFailUpload } from '/app/domain/geolocation/tracking/storage'
 import { utf8ByteSize } from '/app/domain/geolocation/tracking/utils'
+import { SERVER_URL } from '/app/domain/geolocation/tracking/consts'
 
-const serverURL = 'https://openpath.cozycloud.cc'
 const heavyLogs = false // Log points, motion changes...
 
 export const uploadUserCache = async (content, user) => {
@@ -19,7 +19,7 @@ export const uploadUserCache = async (content, user) => {
 
   const body = JSON.stringify(request)
 
-  let response = await fetch(serverURL + '/usercache/put', {
+  let response = await fetch(SERVER_URL + '/usercache/put', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'

--- a/src/app/domain/geolocation/tracking/user.js
+++ b/src/app/domain/geolocation/tracking/user.js
@@ -1,10 +1,10 @@
 import { getUniqueId } from 'react-native-device-info'
 
+import { SERVER_URL } from '/app/domain/geolocation/tracking/consts'
 import { Log } from '/app/domain/geolocation/helpers'
 import { storeId, getId } from '/app/domain/geolocation/tracking/storage'
 
 const useUniqueDeviceId = false
-const serverURL = 'https://openpath.cozycloud.cc'
 
 export const getOrCreateId = async () => {
   try {
@@ -26,7 +26,7 @@ export const getOrCreateId = async () => {
 }
 
 export const createUser = async user => {
-  let response = await fetch(serverURL + '/profile/create', {
+  let response = await fetch(SERVER_URL + '/profile/create', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -45,7 +45,7 @@ export const createUser = async user => {
 export const getOrCreateUser = async user => {
   let response
   try {
-    const respFetch = await fetch(serverURL + '/profile/get', {
+    const respFetch = await fetch(SERVER_URL + '/profile/get', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/src/app/domain/geolocation/tracking/user.js
+++ b/src/app/domain/geolocation/tracking/user.js
@@ -42,6 +42,30 @@ export const createUser = async user => {
   }
 }
 
+export const getOrCreateUser = async user => {
+  let response
+  try {
+    const respFetch = await fetch(serverURL + '/profile/get', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ user: user })
+    })
+    if (respFetch.status === 403) {
+      return createUser(user)
+    }
+    response = await respFetch.json()
+    const uuid = response?.user_id?.['$uuid']
+    if (!uuid) {
+      await createUser(user)
+    }
+    return uuid
+  } catch (err) {
+    return createUser(user)
+  }
+}
+
 export const updateId = async newId => {
   // If there are still non-uploaded locations, it should be handled before changing the Id or they will be sent with the new one
   Log('Updating Id to ' + newId)


### PR DESCRIPTION
This introduces many small things, mainly aiming at improving trip detection and segmentation. In short:
- Add a `STOP_TRACKING` tracking, which is very useful for the server. This one is the main improvement and actually fixes 3 things:
  - Wrong starting point date, somehow based on previous trip
  - Wrong start point, based on previous trip
  - Wrong trips, not corresponding to anything
- Adjust spatial frequency tracking
- Force location fetching for first detected motion activity, to improve starting point accuracy
- Avoid creating user at each upload
- Do not start tracking when already started: this was probably causing unexpected side-effects
- Increase batch size, w.r.t the proxy limit (15MB)
- Remove extra logs
- Increase duration for log and local data retention