### PR TITLE
Improve password change scenario in lockscreen

### DIFF
--- a/src/app/domain/authorization/services/LockScreenScenarios.md
+++ b/src/app/domain/authorization/services/LockScreenScenarios.md
@@ -1,0 +1,60 @@
+In `validatePassword` function, there are several functional scenarios or permutations to consider, based on different outcomes at each step of the process. Here's a breakdown of these scenarios:
+
+### 1. Successful Validation with Cached Password
+
+- **Scenario:** The cached password is still valid (server confirms this).
+You are right. In the scenario where the cached password is confirmed as valid by the server, the next step is to check the input password against this cached password. Here's the corrected scenario:
+- **Flow:**
+  - The server does not throw an error when the cached password is checked, indicating it's still valid.
+  - The function then compares the user's input password hash with the cached password hash.
+  - If the input hash matches the cached hash, the function calls `onSuccess`.
+  - If the input hash does not match the cached hash, the function calls `onFailure` with an incorrect password error.
+
+### 2. Successful Validation with User Input Password
+
+- **Scenario:** The cached password is outdated or invalid, but the user's input password is correct.
+- **Flow:**
+  - The server throws an error (403) when the cached password is checked.
+  - The function then checks the user input password against the server.
+  - The server confirms the input password is correct.
+  - The local cache is updated with the new password hash.
+  - The function calls `onSuccess`.
+
+### 3. Invalid Cached Password and Invalid User Input
+
+- **Scenario:** The cached password is invalid, and the user's input password is also incorrect.
+- **Flow:**
+  - The server throws an error (403) when the cached password is checked.
+  - The function checks the user input password against the server.
+  - The server throws an error (403) indicating the input password is also incorrect.
+  - The function calls `onFailure` with a bad password error message.
+
+### 4. Unexpected Server Error on Cached Password Check
+
+- **Scenario:** An unexpected error occurs when checking the cached password (not a 403 error).
+- **Flow:**
+  - The server throws an error (not 403) when the cached password is checked.
+  - The function calls `onFailure` with a generic server error message.
+
+### 5. Unexpected Server Error on User Input Password Check
+
+- **Scenario:** The cached password is invalid, and an unexpected error occurs when checking the user input password.
+- **Flow:**
+  - The server throws an error (403) when the cached password is checked.
+  - An unexpected error occurs (not 403) when checking the user input password.
+  - The function calls `onFailure` with a generic server error message.
+
+### 6. Error in the Success Handler
+
+- **Scenario:** The password validation is successful, but an error occurs in the `onSuccess` handler.
+- **Flow:**
+  - The password validation (either cached or user input) is successful.
+  - An error occurs during the execution of `onSuccess`.
+  - The function calls `onFailure` with an unknown error message.
+
+### 7. Network or Communication Errors
+
+- **Scenario:** Network or communication issues occur during the server validation process.
+- **Flow:**
+  - A network or communication error occurs when attempting to check the cached or input password against the server.
+  - The function calls `onFailure` with a server error or a specific network error message.

--- a/src/app/domain/authorization/services/LockScreenService.spec.ts
+++ b/src/app/domain/authorization/services/LockScreenService.spec.ts
@@ -1,0 +1,258 @@
+import CozyClient from 'cozy-client'
+
+import { validatePassword } from '/app/domain/authorization/services/LockScreenService'
+
+const mockGetVaultInformation = jest.fn()
+const mockFetchJSON = jest.fn()
+const mockDoHashPassword = jest.fn()
+const mockSaveVaultInformation = jest.fn()
+
+jest.mock('/libs/functions/passwordHelpers', () => ({
+  __esModule: true,
+  doHashPassword: (): { passwordHash: string } =>
+    mockDoHashPassword() as { passwordHash: string }
+}))
+
+jest.mock('/libs/client', () => ({
+  __esModule: true,
+  getInstanceAndFqdnFromClient: jest.fn().mockReturnValue({
+    fqdn: 'http://test.fqdn'
+  })
+}))
+
+jest.mock('/libs/keychain', () => ({
+  getVaultInformation: (): Promise<string> =>
+    Promise.resolve(mockGetVaultInformation() as unknown as string),
+  removeVaultInformation: jest.fn(),
+  saveVaultInformation: (...args: unknown[]): Promise<void> => {
+    mockSaveVaultInformation(...(args as [string, string]))
+    return Promise.resolve()
+  }
+}))
+
+jest.mock('cozy-client', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    getStackClient: jest.fn().mockReturnValue({
+      fetchJSON: mockFetchJSON,
+      uri: 'http://test.cozy.tools:8080'
+    })
+  }))
+}))
+
+describe('validatePassword', () => {
+  // Mocks and common setup
+  let client: CozyClient
+  let onSuccessMock: jest.Mock
+  let onFailureMock: jest.Mock
+
+  beforeEach(() => {
+    client = new CozyClient()
+    onSuccessMock = jest.fn()
+    onFailureMock = jest.fn()
+  })
+
+  it('should succeed when cached password is correct and input is correct', async () => {
+    // Mock the server response for the KdfIterations
+    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
+
+    // Mock the local password cache hash value
+    mockGetVaultInformation.mockResolvedValue('1337')
+
+    // Mock the input password hash value
+    mockDoHashPassword.mockResolvedValueOnce({
+      passwordHash: '1337'
+    })
+
+    // Mock the server response for successful cached password check
+    mockFetchJSON.mockResolvedValueOnce({})
+
+    // Call the function
+    await validatePassword({
+      client,
+      input: 'password',
+      onSuccess: onSuccessMock,
+      onFailure: onFailureMock
+    })
+
+    // Assertions
+    expect(onSuccessMock).toHaveBeenCalled()
+    expect(mockSaveVaultInformation).not.toHaveBeenCalled()
+    expect(onFailureMock).not.toHaveBeenCalled()
+  })
+
+  it('should fail when cached password is correct but user input is not correct', async () => {
+    // Mock the server response for the KdfIterations
+    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
+
+    // Mock the local password cache hash value
+    mockGetVaultInformation.mockResolvedValue('1337')
+
+    // Mock the input password hash value
+    mockDoHashPassword.mockResolvedValueOnce({
+      passwordHash: '7331'
+    })
+
+    // Mock the server response for successful cached password check
+    mockFetchJSON.mockResolvedValueOnce({})
+
+    // Call the function
+    await validatePassword({
+      client,
+      input: 'password',
+      onSuccess: onSuccessMock,
+      onFailure: onFailureMock
+    })
+
+    // Assertions
+    expect(onSuccessMock).not.toHaveBeenCalled()
+    expect(mockSaveVaultInformation).not.toHaveBeenCalled()
+    expect(onFailureMock).toHaveBeenCalledWith('errors.badUnlockPassword')
+  })
+
+  it('should succeed when cached password is correct but user input is not correct', async () => {
+    // Mock the server response for the KdfIterations
+    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
+
+    // Mock the local password cache hash value
+    mockGetVaultInformation.mockResolvedValue('1337')
+
+    // Mock the input password hash value
+    mockDoHashPassword.mockResolvedValueOnce({
+      passwordHash: '1337'
+    })
+
+    // Mock the server response for a failed cached password check
+    mockFetchJSON.mockRejectedValueOnce({ status: 403 })
+
+    // Mock the server response for a correct input password check
+    mockFetchJSON.mockResolvedValueOnce({})
+
+    // Call the function
+    await validatePassword({
+      client,
+      input: 'password',
+      onSuccess: onSuccessMock,
+      onFailure: onFailureMock
+    })
+
+    // Assertions
+    expect(onSuccessMock).toHaveBeenCalled()
+    expect(mockSaveVaultInformation).toHaveBeenCalledWith(
+      'passwordHash',
+      '1337'
+    )
+    expect(onFailureMock).not.toHaveBeenCalled()
+  })
+
+  it('should fail when both cached and user input passwords are not correct', async () => {
+    // Mock the server response for the KdfIterations
+    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
+
+    // Mock the local password cache hash value
+    mockGetVaultInformation.mockResolvedValue('1337')
+
+    // Mock the input password hash value
+    mockDoHashPassword.mockResolvedValueOnce({
+      passwordHash: '1337'
+    })
+
+    // Cached password check
+    mockFetchJSON.mockRejectedValueOnce({ status: 403 })
+
+    // User input password check
+    mockFetchJSON.mockRejectedValueOnce({ status: 403 })
+
+    // Call the function
+    await validatePassword({
+      client,
+      input: 'password',
+      onSuccess: onSuccessMock,
+      onFailure: onFailureMock
+    })
+
+    // Assertions
+    expect(onFailureMock).toHaveBeenCalledWith('errors.badUnlockPassword')
+    expect(mockSaveVaultInformation).not.toHaveBeenCalled()
+    expect(onSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('should handle unexpected server error during cached password check', async () => {
+    // Mock the server response for the KdfIterations
+    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
+
+    // Mock the local password cache hash value
+    mockGetVaultInformation.mockResolvedValue('1337')
+
+    // Mock the input password hash value
+    mockDoHashPassword.mockResolvedValueOnce({
+      passwordHash: '1337'
+    })
+
+    // Mock server response to throw a non-403 error
+    mockFetchJSON.mockRejectedValueOnce({ status: 500 }) // Cached password check
+
+    // Call the function
+    await validatePassword({
+      client,
+      input: 'password',
+      onSuccess: onSuccessMock,
+      onFailure: onFailureMock
+    })
+
+    // Assertions
+    expect(onFailureMock).toHaveBeenCalledWith('errors.serverError')
+    expect(mockSaveVaultInformation).not.toHaveBeenCalled()
+    expect(onSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('should handle unexpected server error during input password check', async () => {
+    // Mock the server response for the KdfIterations
+    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
+
+    // Mock the local password cache hash value
+    mockGetVaultInformation.mockResolvedValue('1337')
+
+    // Mock the input password hash value
+    mockDoHashPassword.mockResolvedValueOnce({
+      passwordHash: '1337'
+    })
+
+    // Mock the server response for a failed cached password check
+    mockFetchJSON.mockRejectedValueOnce({ status: 403 })
+
+    // Mock the server response for a correct input password check
+    mockFetchJSON.mockRejectedValueOnce({ status: 500 })
+
+    // Call the function
+    await validatePassword({
+      client,
+      input: 'password',
+      onSuccess: onSuccessMock,
+      onFailure: onFailureMock
+    })
+
+    // Assertions
+    expect(onFailureMock).toHaveBeenCalledWith('errors.serverError')
+    expect(mockSaveVaultInformation).not.toHaveBeenCalled()
+    expect(onSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('should handle network or communication errors', async () => {
+    // Every fetchJSON call will throw a network error
+    mockFetchJSON.mockRejectedValue(new Error('Unexpected error'))
+
+    // Call the function
+    await validatePassword({
+      client,
+      input: 'any-input',
+      onSuccess: onSuccessMock,
+      onFailure: onFailureMock
+    })
+
+    // Assertions
+    expect(onFailureMock).toHaveBeenCalledWith('errors.unknown_error')
+    expect(mockSaveVaultInformation).not.toHaveBeenCalled()
+    expect(onSuccessMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -20,7 +20,7 @@ import {
 } from '/app/domain/settings/services/SettingsService'
 import { getDevModeFunctions } from '/app/domain/authorization/utils/devMode'
 import { routes } from '/constants/routes'
-import { devlog } from '/core/tools/env'
+import { devlog, shouldDisableAutolock } from '/core/tools/env'
 import {
   getCurrentRouteName,
   navigate,
@@ -42,9 +42,15 @@ const fns = getDevModeFunctions(
     hasDefinedPassword
   },
   {
-    isDeviceSecured: undefined, // async (): Promise<boolean> => Promise.resolve(false),
-    isAutoLockEnabled: undefined, // async (): Promise<boolean> => Promise.resolve(false),
-    hasDefinedPassword: undefined // async (): Promise<boolean> => Promise.resolve(false)
+    isDeviceSecured: shouldDisableAutolock()
+      ? async (): Promise<boolean> => Promise.resolve(true)
+      : undefined,
+    isAutoLockEnabled: shouldDisableAutolock()
+      ? async (): Promise<boolean> => Promise.resolve(false)
+      : undefined,
+    hasDefinedPassword: shouldDisableAutolock()
+      ? async (): Promise<boolean> => Promise.resolve(true)
+      : undefined
   }
 )
 

--- a/src/app/view/Secure/PinPrompt.spec.tsx
+++ b/src/app/view/Secure/PinPrompt.spec.tsx
@@ -20,7 +20,8 @@ jest.mock('/libs/RootNavigation', () => ({
   navigate: jest.fn()
 }))
 jest.mock('/core/tools/env', () => ({
-  devlog: jest.fn()
+  devlog: jest.fn(),
+  shouldDisableAutolock: jest.fn().mockReturnValue(false)
 }))
 
 // This is our main test suite for the PinPrompt component

--- a/src/constants/dev-config.ts
+++ b/src/constants/dev-config.ts
@@ -14,5 +14,6 @@ export const devConfig = {
   cliskKonnectorDevMode: false, // Do not show HomeView but just a special screen to run clisk konnectors
   forceInstallReferrer: false, // Enforce InstallReferrer with the 'enforcedInstallReferrer' string (strings.ONBOARDING_PARTNER_STORAGE_KEY must be clear to apply this value)
   enforcedInstallReferrer:
-    'utm_source=SOME_PARTNER&utm_content=SOME_CONTEXT&utm_campaign=onboarding_partner&anid=admob'
+    'utm_source=SOME_PARTNER&utm_content=SOME_CONTEXT&utm_campaign=onboarding_partner&anid=admob',
+  disableAutoLock: false // Disregard the device and app settings and disable the auto lock in all cases
 }

--- a/src/core/tools/env.ts
+++ b/src/core/tools/env.ts
@@ -56,7 +56,8 @@ const {
   enableReduxLogger,
   enforcedInstallReferrer,
   forceInstallReferrer,
-  enableKonnectorExtensiveLog
+  enableKonnectorExtensiveLog,
+  disableAutoLock
 } = getDevConfig(isDev())
 
 if (enableLocalSentry) toggleLocalSentry(true)
@@ -75,6 +76,8 @@ export const shouldEnableReduxLogger = (): boolean =>
 
 export const shouldEnableKonnectorExtensiveLog = (): boolean =>
   enableKonnectorExtensiveLog
+
+export const shouldDisableAutolock = (): boolean => disableAutoLock
 
 export const EnvService = {
   name,

--- a/src/libs/functions/getErrorMessage.ts
+++ b/src/libs/functions/getErrorMessage.ts
@@ -28,3 +28,7 @@ const toErrorWithMessage = (maybeError: unknown): ErrorWithMessage => {
 export const getErrorMessage = (error: unknown): string => {
   return toErrorWithMessage(error).message
 }
+
+export const isHttpError = (error: unknown): error is { status: number } => {
+  return typeof error === 'object' && error !== null && 'status' in error
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -15,7 +15,9 @@
     "contactUs": "A problem, a suggestion? Contact us at",
     "unknown_error": "An unexpected error occurred, please try again.",
     "reset": "Return to home",
-    "platformNotSupported": "Platform not supported for this request"
+    "platformNotSupported": "Platform not supported for this request",
+    "serverError": "An error occurred while processing your request",
+    "cacheCheckError": "An error occurred while processing your request"
   },
   "logout_dialog": {
     "cancel": "Cancel",


### PR DESCRIPTION
This pull request includes changes to the `validatePassword` function in the lockscreen feature. The function now handles several scenarios, including successful validation with cached password, successful validation with user input password, invalid cached password and invalid user input, unexpected server errors, errors in the success handler, and network or communication errors. These changes improve the overall user experience and ensure that the lockscreen feature is more reliable and secure.
