### PR TITLE
fix(backup): Stop correctly backup when app go to background

### DIFF
--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -46,7 +46,7 @@ export const setShouldStopBackup = (value: boolean): void => {
 }
 
 const shouldStopBecauseBackground = (): boolean => {
-  if (Platform.OS === 'android' && Platform.Version <= 31) {
+  if (Platform.OS === 'android' && Platform.Version < 31) {
     return false
   }
 


### PR DESCRIPTION
The library we use to upload in Android support background upload until Android 11 => API level 30.

So we must check if API level is stricly inferior than 31 and not inferior or equal than 31.