### PR TITLE
fix: add appname when incompatible mime

### DIFF
--- a/src/app/domain/osReceive/services/OsReceiveCandidateApps.ts
+++ b/src/app/domain/osReceive/services/OsReceiveCandidateApps.ts
@@ -94,7 +94,9 @@ const checkFileMimes =
       return app
     }
 
-    const reason = t('services.osReceive.disableReasons.incompatibleMime')
+    const reason = t('services.osReceive.disableReasons.incompatibleMime', {
+      appname: app.name
+    })
     const reasons = app.reasonDisabled
       ? [...app.reasonDisabled, reason]
       : [reason]


### PR DESCRIPTION
The variable was not injected