### PR TITLE
fix: Correctly display cozy-apps when the device's Keyboard is displayed

### DIFF
--- a/src/components/webviews/CozyProxyWebView.js
+++ b/src/components/webviews/CozyProxyWebView.js
@@ -104,7 +104,11 @@ export const CozyProxyWebView = ({
   const Wrapper = Platform.OS === 'ios' ? View : KeyboardAvoidingView
 
   return (
-    <Wrapper style={{ ...styles.view, ...style }} behavior="height">
+    <Wrapper
+      style={{ ...styles.view, ...style }}
+      behavior="height"
+      keyboardVerticalOffset={props.keyboardVerticalOffset || 0}
+    >
       {state.source ? (
         <CozyWebView
           source={state.source}

--- a/src/screens/cozy-app/CozyAppScreen.tsx
+++ b/src/screens/cozy-app/CozyAppScreen.tsx
@@ -86,6 +86,7 @@ export const CozyAppScreen = ({
           logId="AppScreen"
           onLoadEnd={onLoadEnd}
           onError={handleError}
+          keyboardVerticalOffset={dimensions.statusBarHeight}
         />
       </View>
 

--- a/src/screens/cozy-app/CozyAppScreen.tsx
+++ b/src/screens/cozy-app/CozyAppScreen.tsx
@@ -64,9 +64,7 @@ export const CozyAppScreen = ({
 
       <View
         style={{
-          height: isFirstHalf
-            ? dimensions.statusBarHeight
-            : styles.immersiveHeight.height,
+          height: dimensions.statusBarHeight,
           backgroundColor: topBackground
         }}
       >
@@ -79,19 +77,6 @@ export const CozyAppScreen = ({
       </View>
 
       <View style={styles.mainView}>
-        {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          route.params.iconParams && !isReady && (
-            <Animation
-              onFirstHalf={setFirstHalf}
-              onFinished={setReady}
-              shouldExit={shouldExitAnimation}
-              params={route.params.iconParams}
-              slug={route.params.slug}
-            />
-          )
-        }
-
         <CozyProxyWebView
           style={webViewStyle}
           slug={route.params.slug}
@@ -106,9 +91,7 @@ export const CozyAppScreen = ({
 
       <View
         style={{
-          height: isFirstHalf
-            ? dimensions.navbarHeight
-            : styles.immersiveHeight.height,
+          height: dimensions.navbarHeight,
           backgroundColor: bottomBackground
         }}
       >
@@ -119,6 +102,18 @@ export const CozyAppScreen = ({
           }}
         />
       </View>
+      {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        route.params.iconParams && !isReady && (
+          <Animation
+            onFirstHalf={setFirstHalf}
+            onFinished={setReady}
+            shouldExit={shouldExitAnimation}
+            params={route.params.iconParams}
+            slug={route.params.slug}
+          />
+        )
+      }
     </>
   )
 }


### PR DESCRIPTION
### fix: Prevent CozyAppScreen's WebView to move after loading animation

The `KeyboardAvoidingView` component struggles to adapt to Ui layout changes

With previous implementation, the one on `CozyAppScreen` would offset the View using the wrong values

This is because it is initialized while the `isFirstHalf` variable being false, and so when the `dimensions.statusBarHeight` is applied on top of the View, then the `KeyboardAvoidingView` won't notice the change

To prevent this, we want to avoid any change in the UI layout, and so we want the `Animation` to have no impact on it

This can be done by moving it outside of the main View

### fix: Make cozy-apps handle status bar offset when keyboard is displayed

When using `KeyboardAvoidingView` we need to apply `keyboardVerticalOffset` based on the offset between the View that needs to react to keyboard and the top of the screen

Otherwise, the View wouldn't move enough when keyboard is displayed and it would appear behind it

Related documentation:
https://reactnative.dev/docs/keyboardavoidingview#keyboardverticaloffset