### PR TITLE
fix: only show first disabled reason in sharing

### DIFF
--- a/src/app/view/OsReceive/OsReceiveScreen.tsx
+++ b/src/app/view/OsReceive/OsReceiveScreen.tsx
@@ -124,7 +124,11 @@ export const OsReceiveScreen = (): JSX.Element | null => {
 
                     {app.reasonDisabled && (
                       <Typography variant="caption">
-                        {app.reasonDisabled}
+                        {
+                          // We only show the first reason for the app being disabled.
+                          // We don't want to remove the other reasons instead, because they might be useful for debugging
+                          app.reasonDisabled[0]
+                        }
                       </Typography>
                     )}
                   </ListItemText>


### PR DESCRIPTION
We only show the first reason for the app being disabled in the view.
We do not trim the reasons array earlier,
because it could be useful to have the other reasons still
available for debugging or other purposes.