### PR TITLE
fix: Reset the send file scenario when switching to background (android)

### DIFF
--- a/src/app/view/OsReceive/OsReceiveProvider.tsx
+++ b/src/app/view/OsReceive/OsReceiveProvider.tsx
@@ -38,6 +38,7 @@ export const OsReceiveProvider = ({
     const onFilesReceived = (files: OsReceiveFile[]): void => {
       if (!client?.isLogged) return
       dispatch({ type: OsReceiveActionType.SetFilesToUpload, payload: files })
+      OsReceiveEmitter.clearReceivedFiles()
       backToHome().catch(error => {
         OsReceiveLogger.error('Could not go back to home', error)
       })


### PR DESCRIPTION
With current implementation, the native plugin would trigger `receiveFiles` event everytime the app is sent to background then foreground. This would reset the "send file" scenario even if the user chose a cozy-app to receive files

By calling `OsReceiveEmitter.clearReceivedFiles()` we ensure the event won't be sent again until a new share is done by the user

This commit relies on the
`@mythologi+react-native-receive-sharing-intent+2.2.1.patch` patch that modifies the `OsReceiveEmitter.clearReceivedFiles()` behaviour

Related commit: d23cbcd1ab171b5d55b6c00f89a37bda52a213e9

Thanks to @Ldoppea & @acezard for their help ❤️ 

#### Checklist

* [ ] Tested on iOS
* [x] Tested on Android

