### PR TITLE
feat: Handle MAIN_FOLDER_REMOVED error on saveFiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
     "cozy-client": "^44.0.0",
-    "cozy-clisk": "^0.26.0",
+    "cozy-clisk": "^0.27.0",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
     "cozy-intent": "^2.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6400,10 +6400,10 @@ cozy-client@^44.0.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-clisk@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.26.0.tgz#b63734b5678a9ed8c992554da6031c1e6ac1d805"
-  integrity sha512-E1V3vcrQyrcq6Uxn2B8YqVdufIaI3MTJ//TAwnIhlBYgebo1MRIRoaRYpK8kNXB7EsmQXY5DlgLMOA+1A/YZTQ==
+cozy-clisk@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.27.0.tgz#49853c67a4e89e950d08fef0f9239f379c4edc29"
+  integrity sha512-uJR61dQSnXJgGHDhO+6OKo8uj7haGJNnK7gCEhWwj9KlePCajsRm0UuEwh3tl7Kk9bOeteT/LG5wGkw3I2EZyQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     bluebird-retry "^0.11.0"


### PR DESCRIPTION
When this even occurs, it means that the main destination folder of the
konnector has been removed during konnector execution.

In this case, we :
 - Regenerate the files index
 - create the destination folder according to the manifest
 - update the trigger with the new message.folder_to_save attribute
 - retry saveFiles

see https://github.com/konnectors/libs/pull/973

Still needs https://github.com/konnectors/libs/pull/973 to be merged and the resulting version of cozy-clisk to be added.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

