### PR TITLE
fix: Do not intercept manager and scheme links in cozyAppFallbackURL

### DIFF
--- a/src/app/domain/deeplinks/services/DeeplinksParserService.spec.ts
+++ b/src/app/domain/deeplinks/services/DeeplinksParserService.spec.ts
@@ -1,4 +1,7 @@
-import { parseOnboardLink } from '/app/domain/deeplinks/services/DeeplinksParserService'
+import {
+  parseFallbackURL,
+  parseOnboardLink
+} from '/app/domain/deeplinks/services/DeeplinksParserService'
 import { routes } from '/constants/routes'
 
 describe('DeeplinksParserService', () => {
@@ -67,6 +70,29 @@ describe('DeeplinksParserService', () => {
           managerUrl: 'SOME_FALLBACK'
         }
       })
+    })
+  })
+
+  describe('parseFallbackURL', () => {
+    it('should not intercept cozy:// links as cozyAppFallbackURL', () => {
+      const deeplink =
+        'https://links.mycozy.cloud/flagship/onboarding?flagship=true&fallback=cozy%3A%2F%2Fonboarding%3Fflagship%3Dtrue%26fqdn%3Dclaude.mycozy.cloud&fqdn=claude.mycozy.cloud'
+
+      const { mainAppFallbackURL, cozyAppFallbackURL } =
+        parseFallbackURL(deeplink)
+
+      expect(mainAppFallbackURL).toBeUndefined()
+      expect(cozyAppFallbackURL).toBeUndefined()
+    })
+    it('should not intercept manager.cozycloud.cc links as cozyAppFallbackURL', () => {
+      const deeplink =
+        'https://links.mycozy.cloud/flagship/manager?fallback=https%3A%2F%2Fmanager.cozycloud.cc%2Fv2%2Fcozy%2Fstart%2FSOME_ID%3Fredirect%3Dhttps%253A%252F%252Flinks.mycozy.cloud%252Fflagship%252Fonboarding%253Fflagship%253Dtrue%2526fallback%253Dcozy%25253A%25252F%25252Fonboarding%25253Fflagship%25253Dtrue'
+
+      const { mainAppFallbackURL, cozyAppFallbackURL } =
+        parseFallbackURL(deeplink)
+
+      expect(mainAppFallbackURL).toBeUndefined()
+      expect(cozyAppFallbackURL).toBeUndefined()
     })
   })
 })

--- a/src/app/domain/deeplinks/services/DeeplinksParserService.ts
+++ b/src/app/domain/deeplinks/services/DeeplinksParserService.ts
@@ -95,7 +95,17 @@ export const parseFallbackURL = (url: string | null): FallbackUrl => {
 
   try {
     const makeURL = new URL(url)
-    const fallback = makeURL.searchParams.get(FALLBACK_PARAM) ?? undefined
+    let fallback = makeURL.searchParams.get(FALLBACK_PARAM) ?? undefined
+
+    if (
+      fallback?.startsWith('cozy://') ||
+      fallback?.startsWith('https://manager.cozycloud.cc') ||
+      fallback?.startsWith('https://staging-manager.cozycloud.cc') ||
+      fallback?.startsWith('https://manager-dev.cozycloud.cc')
+    ) {
+      fallback = undefined
+    }
+
     const isMainApp =
       makeURL.pathname.startsWith(`/${MAIN_APP}`) ||
       makeURL.pathname.startsWith(`/${UNIVERSAL_LINK_BASE_PATH}/${MAIN_APP}`) ||


### PR DESCRIPTION
With current implementation, when clicking on a login email, if the app is already connected to a Cozy, then the app tries to open a cozy-app with that link

We don't want that to happen as it would produce an error and also this is not an expected scenario

To prevent that we want to ignore links that start with a scheme or manager links

Note that this implementation is not bullet proof. Instead of preventing forbidden URLs we should instead hande only authorised ones. This should be done in another commit

Also this bug highlighted another bug: when the login by email scenario ends and when the flagship certification is automatic, then the Linking `url` event is triggered another time (in useAppBootstrap). So this would trigger the navigation to a cozy-app

By ignoring manager links we removed that bug's side effect but the incorrect behavior (double event) is still present. We must fix that bug in the future