### PR TITLE
refactor: make candidateApps action less noisy

### DIFF
--- a/src/app/domain/osReceive/index.ts
+++ b/src/app/domain/osReceive/index.ts
@@ -1,9 +1,25 @@
 import Minilog from 'cozy-minilog'
 
 import { AcceptFromFlagshipManifest } from '/app/domain/osReceive/models/OsReceiveCozyApp'
-import { OsReceiveState } from '/app/domain/osReceive/models/OsReceiveState'
+import {
+  OsReceiveAction,
+  OsReceiveActionType,
+  OsReceiveState
+} from '/app/domain/osReceive/models/OsReceiveState'
 
 export const OsReceiveLogger = Minilog('🗃️ OsReceiveService')
+
+export const trimActionForLog = (action: OsReceiveAction): OsReceiveAction => {
+  if (action.type === OsReceiveActionType.SetCandidateApps) {
+    return {
+      ...action,
+      payload: action.payload.map((app: AcceptFromFlagshipManifest) => ({
+        name: app.name
+      })) as AcceptFromFlagshipManifest[]
+    }
+  }
+  return action
+}
 
 export const trimStateForLog = (state: OsReceiveState): OsReceiveState => ({
   ...state,

--- a/src/app/view/OsReceive/state/OsReceiveState.ts
+++ b/src/app/view/OsReceive/state/OsReceiveState.ts
@@ -1,6 +1,10 @@
 import { createContext, Dispatch, useContext, useEffect, useState } from 'react'
 
-import { OsReceiveLogger, trimStateForLog } from '/app/domain/osReceive'
+import {
+  OsReceiveLogger,
+  trimActionForLog,
+  trimStateForLog
+} from '/app/domain/osReceive'
 import {
   OsReceiveState,
   OsReceiveAction,
@@ -70,7 +74,9 @@ export const osReceiveReducer = (
   }
 
   OsReceiveLogger.info(
-    `osReceiveReducer handled action ${JSON.stringify(action)}}`
+    `osReceiveReducer handled action ${JSON.stringify(
+      trimActionForLog(action)
+    )}}`
   )
   OsReceiveLogger.info('osReceiveReducer prevState', trimStateForLog(state))
 


### PR DESCRIPTION
It was spamming too much info in logs.
Rather than disabling the whole logging for the feature,
trim the spammy action