### PR TITLE
fix: don't call getCurrentRoute if nav isn't ready

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,11 +69,7 @@ const App = ({ setClient }) => {
 
   const { initialRoute, isLoading } = useAppBootstrap(client)
 
-  useGlobalAppState({
-    onNavigationRequest: route => {
-      RootNavigation.navigate(route)
-    }
-  })
+  useGlobalAppState()
   useSecureBackgroundSplashScreen()
   useCookieResyncOnResume()
   useNotifications()

--- a/src/components/webviews/jsInteractions/jsCozyInjection.ts
+++ b/src/components/webviews/jsInteractions/jsCozyInjection.ts
@@ -4,7 +4,7 @@ import Minilog from 'cozy-minilog'
 
 import { shouldDisableGetIndex } from '/core/tools/env'
 import { getDimensions } from '/libs/dimensions'
-import { navigationRef } from '/libs/RootNavigation'
+import { getCurrentRouteName, navigationRef } from '/libs/RootNavigation'
 
 import { version } from '../../../../package.json'
 
@@ -35,7 +35,7 @@ export const jsCozyGlobal = (
     window.cozy.ClientKonnectorLauncher = 'react-native'
     window.cozy.ClientConnectorLauncher = 'react-native' // deprecated
     window.cozy.flagship = ${makeMetadata(
-      routeName ?? navigationRef.getCurrentRoute()?.name ?? ''
+      routeName ?? getCurrentRouteName() ?? ''
     )}
     window.cozy.isSecureProtocol = ${isSecureProtocol ? 'true' : 'false'}
     // We have random issue on iOS when the app's script is executed

--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -61,13 +61,7 @@ const onStateChange = (
  * for it could create unintended side effects.
  */
 
-interface GlobalAppStateProps {
-  onNavigationRequest: (route: string) => void
-}
-
-export const useGlobalAppState = ({
-  onNavigationRequest
-}: GlobalAppStateProps): void => {
+export const useGlobalAppState = (): void => {
   // Ref to track if the logic has already been executed
   const hasExecuted = useRef(false)
   const client = useClient()
@@ -76,7 +70,7 @@ export const useGlobalAppState = ({
     if (!client) return
 
     void handleWakeUp(client)
-  }, [client, onNavigationRequest])
+  }, [client])
 
   useEffect(() => {
     let subscription: NativeEventSubscription | undefined
@@ -97,7 +91,7 @@ export const useGlobalAppState = ({
     return () => {
       appState = AppState.currentState
     }
-  }, [client, onNavigationRequest])
+  }, [client])
 
   // On app start
   useEffect(() => {
@@ -113,5 +107,5 @@ export const useGlobalAppState = ({
       log.info('useGlobalAppState: app start')
       void appStart()
     }
-  }, [onNavigationRequest])
+  }, [])
 }


### PR DESCRIPTION
This will removes error logs at app start when jsCozyInjection
was trying to get routeName too fast in the app cycle.
Now it will go through the getCurrentRouteName facade
which handles non-ready nav objects.
Also remove unused injections linked to navigation in useGlobalAppState