### PR TITLE
fix: don't fetch for candidateapps at start

### DIFF
--- a/src/app/view/OsReceive/OsReceiveProvider.tsx
+++ b/src/app/view/OsReceive/OsReceiveProvider.tsx
@@ -64,7 +64,7 @@ export const OsReceiveProvider = ({
   useEffect(() => {
     if (!client || didCall.current || state.filesToUpload.length === 0) return
 
-    const fetchRegistry = async (): Promise<void> => {
+    const fetchAppsAndSetCandidates = async (): Promise<void> => {
       const res = (await client.fetchQueryAndGetFromState({
         definition: fetchOsReceiveCozyApps.definition,
         options: fetchOsReceiveCozyApps.options
@@ -79,7 +79,7 @@ export const OsReceiveProvider = ({
       }
     }
 
-    void fetchRegistry()
+    void fetchAppsAndSetCandidates()
   }),
     [client, state.filesToUpload.length]
 

--- a/src/app/view/OsReceive/OsReceiveProvider.tsx
+++ b/src/app/view/OsReceive/OsReceiveProvider.tsx
@@ -62,7 +62,7 @@ export const OsReceiveProvider = ({
   }, [client?.isLogged])
 
   useEffect(() => {
-    if (!client || didCall.current) return
+    if (!client || didCall.current || state.filesToUpload.length === 0) return
 
     const fetchRegistry = async (): Promise<void> => {
       const res = (await client.fetchQueryAndGetFromState({
@@ -81,7 +81,7 @@ export const OsReceiveProvider = ({
 
     void fetchRegistry()
   }),
-    [client]
+    [client, state.filesToUpload.length]
 
   // If an error is detected, we handle that by abandoning the flow.
   // The user will be redirected to the home screen and the osReceive mode is ended until next file osReceive.


### PR DESCRIPTION
This is triggering unecessary rerenders elsewhere in the app
when the user doesn't has files to upload.
Instead we fetch registry if we detect presence of files.
It might be slower in file upload scenario, but it cleans up a lot
app start rerenders (file upload state is linked to localMethods)