### PR TITLE
fix: Log Konnector failure log on errors which occur before fetch step with no account

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -294,7 +294,7 @@ export default class Launcher {
         level: 'debug',
         namespace: 'Launcher',
         label: 'ensureAccountTriggerAndLaunch',
-        message: 'Destination folder changed, updating the trigger'
+        msg: 'Destination folder changed, updating the trigger'
       })
 
       const triggerUpdateResponse = await client.save({
@@ -527,8 +527,7 @@ export default class Launcher {
       level: 'warning',
       namespace: 'Launcher',
       label: 'saveFiles',
-      message:
-        'Destination folder removed during konnector execution, trying again'
+      msg: 'Destination folder removed during konnector execution, trying again'
     })
     const folder = await models.konnectorFolder.ensureKonnectorFolder(client, {
       konnector: { ...konnector, _id: konnector.id }, // _id attribute is missing in konnector object, which causes the reference to the konnector in the destination folder to be null
@@ -627,7 +626,7 @@ export default class Launcher {
 /**
  * @typedef ContentScriptLogMessage
  * @property {'debug'|'info'|'warning'|'error'|'critical'} level - Log level
- * @property {any} message             - message content
+ * @property {string} msg             - message content
  * @property {string | null} label     - user defined label
  * @property {string | null} namespace - user defined namespace
  */

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -629,6 +629,7 @@ export default class Launcher {
  * @property {string} msg             - message content
  * @property {string | null} label     - user defined label
  * @property {string | null} namespace - user defined namespace
+ * @property {String} [timestamp] - DateTime iso string when the log message was created
  */
 
 /**
@@ -669,4 +670,16 @@ export default class Launcher {
  * @property {Function} [downloadAndFormatFile] - this callback will download the file and format to be useable by cozy-client
  * @property {string} [qualificationLabel] - qualification label defined in cozy-client which will be used on all given files
  * @property {number} [retry] - number of retries if the download of a file failes. No retry by default
+ */
+
+/**
+ * @typedef InitOptions
+ * @property {BridgeOptions} bridgeOptions - options which will be given as is to the bridge. Bridge options depend on the environment of the launcher
+ * @property {string} contentScript - source code of the content script which will be injected
+ */
+
+/**
+ * @typedef BridgeOptions
+ * @property {import('react-native-webview').WebView} pilotWebView - pilot webview reference
+ * @property {import('react-native-webview').WebView} workerWebview - worker webview reference
  */

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -215,6 +215,14 @@ class ReactNativeLauncher extends Launcher {
     deactivateKeepAwake('clisk')
     const { client, job } = this.getStartContext()
 
+    if (message && !job) {
+      this.log({
+        namespace: 'ReactNativeLauncher',
+        label: 'stop',
+        level: 'info',
+        msg: `Konnector failure: ${message}`
+      })
+    }
     if (message) {
       this.log({ level: 'error', msg: message })
     }


### PR DESCRIPTION
We did not have a "Konnector failure: ..." log when an error happened before the fetch step (ensureAuthenticated, getUserDataFromWebsite) and when the account, trigger and job did not exist yet

Since we use this log to supervise the execution of clisk konnectors, we need it in this case too.


- fix: Log Konnector failure log on errors before fetch
- fix: Wrong message attribute in launcher logs
- fix: Some ts-check lint errors

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

