### PR TITLE
Multiple bug fixed when deleting manually backup folder

### DIFF
--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -110,6 +110,9 @@ declare module 'cozy-client' {
       metadata?: {
         backupDeviceIds: string[]
       }
+      attributes: {
+        path: string
+      }
     }
   }
 

--- a/src/app/domain/backup/helpers/error.ts
+++ b/src/app/domain/backup/helpers/error.ts
@@ -1,4 +1,4 @@
-import { UploadError } from '/app/domain/upload/models'
+import { NetworkError, UploadError } from '/app/domain/upload/models'
 
 export class BackupError extends Error {
   textMessage: string
@@ -17,6 +17,13 @@ export class BackupError extends Error {
   }
 }
 
+export const isNetworkError = (error: unknown): boolean => {
+  return (
+    error instanceof NetworkError ||
+    (error instanceof Error && error.message === 'Network request failed')
+  )
+}
+
 export const isUploadError = (error: unknown): error is UploadError => {
   return (
     typeof error === 'object' &&
@@ -26,6 +33,7 @@ export const isUploadError = (error: unknown): error is UploadError => {
     Array.isArray(error.errors)
   )
 }
+
 export const isQuotaExceededError = (error: UploadError): boolean => {
   return (
     error.statusCode === 413 &&

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -4,7 +4,7 @@ import Minilog from 'cozy-minilog'
 
 import {
   getLocalBackupConfig,
-  initiazeLocalBackupConfig,
+  initializeLocalBackupConfig,
   setBackupAsInitializing,
   setBackupAsReady,
   setBackupAsRunning,
@@ -258,7 +258,7 @@ const initializeBackup = async (
       backupedAlbums = [] as BackupedAlbum[]
     }
 
-    const backupConfig = await initiazeLocalBackupConfig(
+    const backupConfig = await initializeLocalBackupConfig(
       client,
       deviceRemoteBackupConfig,
       backupedMedias,

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -104,11 +104,13 @@ export const startBackup = async (
     let status: LastBackup['status'] = 'success'
     let titleKey = 'services.backup.notifications.backupSuccessTitle'
     let bodyKey = 'services.backup.notifications.backupSuccessBody'
+    let message
 
     if (partialSuccessMessage) {
       status = 'partial_success'
       titleKey = 'services.backup.notifications.backupPartialSuccessTitle'
       bodyKey = 'services.backup.notifications.backupPartialSuccessBody'
+      message = partialSuccessMessage
     }
 
     await setLastBackup(client, {
@@ -117,7 +119,8 @@ export const startBackup = async (
         postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount -
         postUploadLocalBackupConfig.currentBackup.mediasToBackup.length,
       totalMediasToBackupCount:
-        postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount
+        postUploadLocalBackupConfig.currentBackup.totalMediasToBackupCount,
+      message
     })
 
     await showLocalNotification({

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -10,7 +10,7 @@ import {
   setBackupAsRunning,
   setBackupAsDone,
   setLastBackup,
-  updateRemoteBackupConfigLocally,
+  fixLocalBackupConfigIfNecessary,
   addRemoteDuplicatesToBackupedMedias
 } from '/app/domain/backup/services/manageLocalBackupConfig'
 import { getMediasToBackup } from '/app/domain/backup/services/getMedias'
@@ -83,8 +83,6 @@ export const startBackup = async (
   onProgress: ProgressCallback
 ): Promise<BackupInfo> => {
   log.debug('Backup started')
-
-  await updateRemoteBackupConfigLocally(client)
 
   const localBackupConfig = await getLocalBackupConfig(client)
 
@@ -233,6 +231,8 @@ const initializeBackup = async (
   }
 
   log.debug('Backup found')
+
+  await fixLocalBackupConfigIfNecessary(client)
 
   if (flag('flagship.backup.dedup')) {
     await addRemoteDuplicatesToBackupedMedias(client)

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -13,7 +13,6 @@ import {
   updateRemoteBackupConfigLocally,
   addRemoteDuplicatesToBackupedMedias
 } from '/app/domain/backup/services/manageLocalBackupConfig'
-import { fetchBackupedAlbums } from '/app/domain/backup/services/manageAlbums'
 import { getMediasToBackup } from '/app/domain/backup/services/getMedias'
 import {
   uploadMedias,
@@ -24,19 +23,12 @@ import {
   getCurrentUploadId
 } from '/app/domain/upload/services/upload'
 import {
-  fetchDeviceRemoteBackupConfig,
-  fetchBackupedMedias,
-  createRemoteBackupFolder
-} from '/app/domain/backup/services/manageRemoteBackupConfig'
-import {
   activateKeepAwake,
   deactivateKeepAwake
 } from '/app/domain/sleep/services/sleep'
 import {
   BackupInfo,
   ProgressCallback,
-  BackupedMedia,
-  BackupedAlbum,
   LocalBackupConfig,
   LastBackup
 } from '/app/domain/backup/models'
@@ -241,30 +233,8 @@ const initializeBackup = async (
     return backupConfig
   } catch {
     // if there is no local backup config
-    let deviceRemoteBackupConfig = await fetchDeviceRemoteBackupConfig(client)
-    let backupedMedias
-    let backupedAlbums
+    const localBackupConfig = await initializeLocalBackupConfig(client)
 
-    if (deviceRemoteBackupConfig) {
-      log.debug('Backup will be restored')
-
-      backupedMedias = await fetchBackupedMedias(client)
-      backupedAlbums = await fetchBackupedAlbums(client)
-    } else {
-      log.debug('Backup will be created')
-
-      deviceRemoteBackupConfig = await createRemoteBackupFolder(client)
-      backupedMedias = [] as BackupedMedia[]
-      backupedAlbums = [] as BackupedAlbum[]
-    }
-
-    const backupConfig = await initializeLocalBackupConfig(
-      client,
-      deviceRemoteBackupConfig,
-      backupedMedias,
-      backupedAlbums
-    )
-
-    return backupConfig
+    return localBackupConfig
   }
 }

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -232,7 +232,7 @@ const initializeBackup = async (
 
   log.debug('Backup found')
 
-  await fixLocalBackupConfigIfNecessary(client)
+  localBackupConfig = await fixLocalBackupConfigIfNecessary(client)
 
   if (flag('flagship.backup.dedup')) {
     await addRemoteDuplicatesToBackupedMedias(client)

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -220,21 +220,24 @@ export const getBackupInfo = async (
 const initializeBackup = async (
   client: CozyClient
 ): Promise<LocalBackupConfig> => {
+  let localBackupConfig
+
   try {
-    let backupConfig = await getLocalBackupConfig(client)
-
-    log.debug('Backup found')
-
-    if (flag('flagship.backup.dedup')) {
-      await addRemoteDuplicatesToBackupedMedias(client)
-      backupConfig = await getLocalBackupConfig(client)
-    }
-
-    return backupConfig
+    localBackupConfig = await getLocalBackupConfig(client)
   } catch {
-    // if there is no local backup config
-    const localBackupConfig = await initializeLocalBackupConfig(client)
+    log.debug('Backup not found')
 
-    return localBackupConfig
+    const newLocalBackupConfig = await initializeLocalBackupConfig(client)
+
+    return newLocalBackupConfig
   }
+
+  log.debug('Backup found')
+
+  if (flag('flagship.backup.dedup')) {
+    await addRemoteDuplicatesToBackupedMedias(client)
+    localBackupConfig = await getLocalBackupConfig(client)
+  }
+
+  return localBackupConfig
 }

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -232,7 +232,17 @@ const initializeBackup = async (
 
   log.debug('Backup found')
 
-  localBackupConfig = await fixLocalBackupConfigIfNecessary(client)
+  try {
+    localBackupConfig = await fixLocalBackupConfigIfNecessary(client)
+  } catch (e) {
+    if (e instanceof Error) {
+      if (e.message === 'Remote backup folder has been trashed.') {
+        return await initializeLocalBackupConfig(client)
+      }
+    }
+
+    throw e
+  }
 
   if (flag('flagship.backup.dedup')) {
     await addRemoteDuplicatesToBackupedMedias(client)

--- a/src/app/domain/backup/services/manageBackup.ts
+++ b/src/app/domain/backup/services/manageBackup.ts
@@ -236,7 +236,10 @@ const initializeBackup = async (
     localBackupConfig = await fixLocalBackupConfigIfNecessary(client)
   } catch (e) {
     if (e instanceof Error) {
-      if (e.message === 'Remote backup folder has been trashed.') {
+      if (
+        e.message === 'Remote backup folder has been trashed.' ||
+        e.message === 'Remote backup folder has been deleted.'
+      ) {
         return await initializeLocalBackupConfig(client)
       }
     }

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -66,7 +66,7 @@ export const setLocalBackupConfig = async (
   )
 }
 
-export const initiazeLocalBackupConfig = async (
+export const initializeLocalBackupConfig = async (
   client: CozyClient,
   remoteBackupConfig: RemoteBackupConfig,
   backupedMedias: BackupedMedia[],

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -155,7 +155,7 @@ export const setMediaAsBackuped = async (
   await setLocalBackupConfig(client, localBackupConfig)
 }
 
-export const updateRemoteBackupConfigLocally = async (
+export const fixLocalBackupConfigIfNecessary = async (
   client: CozyClient
 ): Promise<void> => {
   const localBackupConfig = await getLocalBackupConfig(client)

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -157,7 +157,7 @@ export const setMediaAsBackuped = async (
 
 export const fixLocalBackupConfigIfNecessary = async (
   client: CozyClient
-): Promise<void> => {
+): Promise<LocalBackupConfig> => {
   const localBackupConfig = await getLocalBackupConfig(client)
 
   const fileQuery = buildFileQuery(
@@ -174,6 +174,8 @@ export const fixLocalBackupConfigIfNecessary = async (
     remoteBackupFolderUpdated.path
 
   await setLocalBackupConfig(client, localBackupConfig)
+
+  return localBackupConfig
 }
 
 export const setBackupAsToDo = async (client: CozyClient): Promise<void> => {

--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -12,7 +12,8 @@ import { buildFileQuery } from '/app/domain/backup/queries'
 import {
   fetchBackupedMedias,
   fetchDeviceRemoteBackupConfig,
-  createRemoteBackupFolder
+  createRemoteBackupFolder,
+  isInTrash
 } from '/app/domain/backup/services/manageRemoteBackupConfig'
 import { fetchBackupedAlbums } from '/app/domain/backup/services/manageAlbums'
 import { isSameMedia } from '/app/domain/backup/helpers'
@@ -167,6 +168,10 @@ export const fixLocalBackupConfigIfNecessary = async (
   const { data: remoteBackupFolderUpdated } = (await client.query(
     fileQuery
   )) as FileCollectionGetResult
+
+  if (isInTrash(remoteBackupFolderUpdated.attributes.path)) {
+    throw new Error('Remote backup folder has been trashed.')
+  }
 
   localBackupConfig.remoteBackupConfig.backupFolder.name =
     remoteBackupFolderUpdated.name

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.spec.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.spec.ts
@@ -24,13 +24,14 @@ describe('fetchRemoteBackupConfigs', () => {
     expect(remoteBackupConfigs).toEqual([])
   })
 
-  test('returns an array with the correct backup folders when findReferencedBy returns an array with two items', async () => {
+  test('returns an array with backup folders sorted by most recent first when findReferencedBy returns an array with two items', async () => {
     // Given
     const client = mockClientWithFindReferencedByResult({
       included: [
         {
           _id: '1',
           attributes: {
+            created_at: '2023-11-28T12:00:31.541756+01:00',
             name: 'Device 1',
             path: '/Backup/Device 1',
             metadata: { backupDeviceIds: ['A'] }
@@ -39,6 +40,7 @@ describe('fetchRemoteBackupConfigs', () => {
         {
           _id: '2',
           attributes: {
+            created_at: '2023-11-28T12:10:00.402741+01:00',
             name: 'Device 2',
             path: '/Backup/Device 2',
             metadata: { backupDeviceIds: ['B'] }
@@ -54,12 +56,12 @@ describe('fetchRemoteBackupConfigs', () => {
     // Then
     expect(remoteBackupConfigs).toEqual([
       {
-        backupFolder: { id: '1', name: 'Device 1', path: '/Backup/Device 1' },
-        backupDeviceIds: ['A']
-      },
-      {
         backupFolder: { id: '2', name: 'Device 2', path: '/Backup/Device 2' },
         backupDeviceIds: ['B']
+      },
+      {
+        backupFolder: { id: '1', name: 'Device 1', path: '/Backup/Device 1' },
+        backupDeviceIds: ['A']
       }
     ])
   })

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.spec.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.spec.ts
@@ -1,5 +1,4 @@
 import * as manageRemoteBackupConfig from '/app/domain/backup/services/manageRemoteBackupConfig'
-import * as manageLocalBackupConfig from '/app/domain/backup/services/manageLocalBackupConfig'
 
 import type CozyClient from 'cozy-client'
 
@@ -109,26 +108,6 @@ describe('fetchDeviceRemoteBackupConfig', () => {
         }
       ])
     jest
-      .spyOn(manageLocalBackupConfig, 'getLocalBackupConfig')
-      .mockResolvedValue({
-        remoteBackupConfig: {
-          backupFolder: {
-            id: '1',
-            name: 'Device 1',
-            path: '/Backup/Device 1'
-          },
-          backupDeviceIds: ['A']
-        },
-        lastBackupDate: 0,
-        backupedMedias: [],
-        backupedAlbums: [],
-        currentBackup: {
-          status: 'to_do',
-          mediasToBackup: [],
-          totalMediasToBackupCount: 0
-        }
-      })
-    jest
       .spyOn(manageRemoteBackupConfig, 'isRemoteBackupConfigFromDevice')
       .mockReturnValue(true)
 
@@ -149,26 +128,6 @@ describe('fetchDeviceRemoteBackupConfig', () => {
           backupDeviceIds: ['A']
         }
       ])
-    jest
-      .spyOn(manageLocalBackupConfig, 'getLocalBackupConfig')
-      .mockResolvedValue({
-        remoteBackupConfig: {
-          backupFolder: {
-            id: '1',
-            name: 'Device 1',
-            path: '/Backup/Device 1'
-          },
-          backupDeviceIds: ['A']
-        },
-        lastBackupDate: 0,
-        backupedMedias: [],
-        backupedAlbums: [],
-        currentBackup: {
-          status: 'to_do',
-          mediasToBackup: [],
-          totalMediasToBackupCount: 0
-        }
-      })
     jest
       .spyOn(manageRemoteBackupConfig, 'isRemoteBackupConfigFromDevice')
       .mockReturnValue(false)

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.ts
@@ -56,7 +56,7 @@ interface BackupFolderAttributes {
   metadata: { backupDeviceIds: string[] }
 }
 
-const isInTrash = (path: string): boolean => {
+export const isInTrash = (path: string): boolean => {
   return path.startsWith('/.cozy_trash')
 }
 

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.ts
@@ -42,6 +42,7 @@ interface BackupFolder {
   attributes: {
     name: string
     path: string
+    created_at: string
     metadata?: {
       backupDeviceIds: string[]
     }
@@ -72,6 +73,11 @@ export const fetchRemoteBackupConfigs = async (
 
   const remoteBackupConfigs: RemoteBackupConfig[] = backupFolders
     .filter(folder => !isInTrash(folder.attributes.path))
+    .sort(
+      (a, b) =>
+        new Date(b.attributes.created_at).getTime() -
+        new Date(a.attributes.created_at).getTime()
+    )
     .map(backupFolder => ({
       backupFolder: {
         id: backupFolder._id,

--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -14,6 +14,7 @@ import {
 import { getBackupInfo } from '/app/domain/backup/services/manageBackup'
 import {
   BackupError,
+  isNetworkError,
   isUploadError,
   isQuotaExceededError,
   isFileTooBigError,
@@ -28,8 +29,6 @@ import { t } from '/locales/i18n'
 import type CozyClient from 'cozy-client'
 import type { IOCozyFile } from 'cozy-client'
 import Minilog from 'cozy-minilog'
-
-import { NetworkError } from '/app/domain/upload/models'
 
 const log = Minilog('💿 Backup')
 
@@ -92,7 +91,7 @@ export const uploadMedias = async (
         } not uploaded or set as backuped correctly (${JSON.stringify(error)})`
       )
 
-      if (error instanceof NetworkError) {
+      if (isNetworkError(error)) {
         throw new BackupError(t('services.backup.errors.networkIssue'))
       }
 


### PR DESCRIPTION
When an user creates a backup, it creates a backup folder like `/Photos/Sauvegardé depuis mon mobile`, and the flagship app saves a reference to this backup folder.

In this PR, I mainly handle missing cases, especially when the user trash or trash + empty trash the backup folder.

Some refactoring too.