### PR TITLE
fix: Convert JSInterception console.warn to log

### DIFF
--- a/src/components/webviews/jsInteractions/jsLogInterception.ts
+++ b/src/components/webviews/jsInteractions/jsLogInterception.ts
@@ -18,7 +18,7 @@ export const jsLogInterception = `
     log: (...log) => consoleLog('log', log),
     debug: (...log) => consoleLog('debug', log),
     info: (...log) => consoleLog('info', log),
-    warn: (...log) => consoleLog('warn', log),
+    warn: (...log) => consoleLog('log', 'warn: ' + log),
     error: (...log) => consoleLog('error', log),
   }
 `


### PR DESCRIPTION
We still want to send the console.warn() from the flagship app to sentry, but we don't want to send the console.warn coming from the WebApp to sentry. It makes too much noise and since we can't fix them from the flagship app, we don't need to send them. They should be already sent by the wepabb to its own sentry.

_Please explain what this PR does here._

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

