### PR TITLE
fix: handle race condition in resetUiState

### DIFF
--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -106,3 +106,15 @@ jest.mock(
   'react-native-background-geolocation',
   () => mockRNBackgroundGeolocation
 )
+
+// This function isn't meant to be tested
+// It is breaking the tests just by being imported
+// Have to remove that mock when we refactor the actual function
+jest.mock('../src/app/view/OsReceive/state/OsReceiveState', () => ({
+  getDangerousOsReceiveState: jest.fn().mockReturnValue({
+    filesToUpload: [],
+    routeToUpload: {},
+    errored: false,
+    candidateApps: undefined
+  })
+}))

--- a/src/app/view/OsReceive/state/OsReceiveState.ts
+++ b/src/app/view/OsReceive/state/OsReceiveState.ts
@@ -28,6 +28,7 @@ export const osReceiveReducer = (
   action: OsReceiveAction
 ): OsReceiveState => {
   let nextState = state
+  dangerousOsReceiveState = nextState
 
   switch (action.type) {
     case OsReceiveActionType.SetFilesToUpload:
@@ -91,6 +92,21 @@ export const initialState: OsReceiveState = {
   errored: false,
   candidateApps: undefined
 }
+
+/**
+ * This variable is used to expose the state to the outside world.
+ *
+ * It is meant to be a temporary solution to fix an issue where resetUIstate()
+ * has to know the state of this feature before executing its logic,
+ * but at the time of writing resetUIState has no connection to the React tree.
+ *
+ * It should not be used anywhere else unless absolutely necessary.
+ * ResetUIState() should be refactored to use a proper React context.
+ * It can't be done at the time of this commit for time constraints.
+ */
+let dangerousOsReceiveState = initialState
+export const getDangerousOsReceiveState = (): OsReceiveState =>
+  dangerousOsReceiveState
 
 export const useOsReceiveState = (): OsReceiveState => {
   const context = useContext(OsReceiveStateContext)

--- a/src/libs/intents/setFlagshipUI.ts
+++ b/src/libs/intents/setFlagshipUI.ts
@@ -13,6 +13,7 @@ import {
 } from '/app/theme/themeManager'
 import { navigationRef } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
+import { getDangerousOsReceiveState } from '/app/view/OsReceive/state/OsReceiveState'
 
 const isDarkMode = (bottomTheme: StatusBarStyle): boolean =>
   bottomTheme === StatusBarStyle.Light
@@ -207,9 +208,20 @@ export const resetUIState = (
   uri: string,
   callback?: (theme: StatusBarStyle) => void
 ): void => {
-  const theme = urlHasKonnectorOpen(uri)
+  let theme = urlHasKonnectorOpen(uri)
     ? ThemeInput.Dark
     : getHomeThemeAsThemeInput()
+
+  // If the theme is light, and there are files to upload (OsReceiveScreen visible), then set the theme to dark
+  // This is done because the file upload dialog is light background, so we want to use dark icons
+  // This is a temporary fix until we have a proper React context
+  // see src/app/view/OsReceive/state/OsReceiveState.ts#getDangerousOsReceiveState
+  if (theme === ThemeInput.Light) {
+    const hasFilesToUpload =
+      getDangerousOsReceiveState().filesToUpload.length > 0
+
+    if (hasFilesToUpload) theme = ThemeInput.Dark
+  }
 
   themeLog.info('resetUIState', { uri, theme })
 


### PR DESCRIPTION
It is meant to be a temporary solution to fix an issue where `resetUIstate`  has to know the state of this feature before executing its logic. Still, at the time of writing, `resetUIState` has no connection to the React tree.

`ResetUIState` should be refactored to use a proper React context.  It can't be done during this commit for time constraints.