### PR TITLE
fix: revert animation width to previous value

### DIFF
--- a/src/screens/cozy-app/CozyAppScreen.Animation.tsx
+++ b/src/screens/cozy-app/CozyAppScreen.Animation.tsx
@@ -36,8 +36,7 @@ export const Animation = ({
     render(): JSX.Element {
       return (
         <SvgXml
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          xml={iconTable[slug]?.xml || iconFallback}
+          xml={iconTable[slug]?.xml ?? iconFallback}
           width={config.width}
           height={config.height}
         />

--- a/src/screens/cozy-app/CozyAppScreen.functions.ts
+++ b/src/screens/cozy-app/CozyAppScreen.functions.ts
@@ -34,8 +34,10 @@ export const config = {
   driver: true
 }
 
+// Width has to be null at start even if it's not a valid value (was set to undefined and it broke the progress bar)
+// At the time of this fix we want to go back the previously working value but we have to investigate why it has to be null
 export const progressBarConfig = {
-  width: undefined,
+  width: null as unknown as number,
   indeterminate: true,
   unfilledColor: palette.Grey[200],
   color: palette.Primary[600],


### PR DESCRIPTION
Width has to be null at start even if it's not a valid value
 (was set to undefined and it broke the progress bar)
 At the time of this fix we want to go back the previously working value
 but we have to investigate why it has to be null