### PR TITLE
refactor: use only one source of online events

### DIFF
--- a/src/app/view/Error/ErrorScreen.tsx
+++ b/src/app/view/Error/ErrorScreen.tsx
@@ -1,8 +1,9 @@
-import Minilog from 'cozy-minilog'
 import React, { useEffect } from 'react'
 import { Linking } from 'react-native'
 import { changeBarColors } from 'react-native-immersive-bars'
 import { WebViewMessageEvent } from 'react-native-webview/lib/WebViewTypes'
+
+import Minilog from 'cozy-minilog'
 
 import { ErrorPageGenerator } from '/app/view/Error/Pages/makeHtmlErrorPage'
 import { CozyBlockedPage } from '/app/view/Error/Pages/CozyBlockedPage'
@@ -15,6 +16,7 @@ import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
 import { routes } from '/constants/routes'
 import { goBack, reset } from '/libs/RootNavigation'
 import { getColors } from '/ui/colors'
+import { hideSplashScreen } from '/app/theme/SplashScreenService'
 
 const log = Minilog('ErrorScreen')
 
@@ -114,8 +116,10 @@ export const ErrorScreen = (props: ErrorScreenProps): JSX.Element => {
   /*
    * All error pages are in immersive mode with blue background, so we need light icons every time.
    * To err on the side of caution, we set the icon colors to white everytime this page is rendered.
+   * Also, we hide the splash screen here in case the error page is shown before the app is mounted.
    */
   useEffect(() => {
+    void hideSplashScreen()
     changeBarColors(true)
   }, [])
 


### PR DESCRIPTION
- Remove direct NetInfo use in NetStatusBoundary (use service instead)
- Add more error handling
- Use hidesplashscreen inside error screen instead of provider
- Refactor waitForOnline to accept callback as function
- Add some comments to clarify flow

All this should clear up conflicting authority issues on online events
NetStatusBoundary handles app mount with the help of NetService.
NetService remains react agnostic collection of functions to be used
by various components inside the application.
Possible improvements would be to have NetStatusBoundary act as runtime
manager of online events instead of having components using netservice
directly. That would require a lot more refactor though and it is not
clear at the moment if it would bring a huge benefit.