### PR TITLE
fix: use `null` value in all animations config

### DIFF
--- a/src/app/view/Loading/RemountProgress.tsx
+++ b/src/app/view/Loading/RemountProgress.tsx
@@ -16,7 +16,7 @@ export const RemountProgress = (): JSX.Element => {
 }
 
 const progressBarConfig = {
-  width: undefined,
+  width: null as unknown as number | undefined, // TODO: understand why the width has to be set to null to avoid progress bar to be cut
   indeterminate: true,
   unfilledColor: palette.Grey[200],
   color: palette.Primary[600],

--- a/src/components/ProgressContainer.tsx
+++ b/src/components/ProgressContainer.tsx
@@ -10,7 +10,7 @@ import { styles } from '/components/ProgressContainer.styles'
 const colors = getColors()
 
 const progressBarConfig = {
-  width: undefined,
+  width: null as unknown as number | undefined, // TODO: understand why the width has to be set to null to avoid progress bar to be cut
   indeterminate: false,
   unfilledColor: palette.Grey[200],
   color: colors.primaryColor,

--- a/src/screens/cozy-app/CozyAppScreen.functions.ts
+++ b/src/screens/cozy-app/CozyAppScreen.functions.ts
@@ -37,7 +37,7 @@ export const config = {
 // Width has to be null at start even if it's not a valid value (was set to undefined and it broke the progress bar)
 // At the time of this fix we want to go back the previously working value but we have to investigate why it has to be null
 export const progressBarConfig = {
-  width: null as unknown as number,
+  width: null as unknown as number | undefined,
   indeterminate: true,
   unfilledColor: palette.Grey[200],
   color: palette.Primary[600],


### PR DESCRIPTION
At the time of this commit we know the null value is working,
but it's still a non valid style value.
While not strictly necessary, it would be preferrable to investigate
the source of this behaviour