### PR TITLE
fix: Select _rev for existing files

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -438,7 +438,8 @@ export default class Launcher {
           'size',
           'md5sum',
           'mime',
-          'trashed'
+          'trashed',
+          '_rev'
         ])
     )
     // @ts-ignore


### PR DESCRIPTION
Clisk's lib use client.save() to create OR update a file. Even if the clisk lib pass a string 'updateById' to say "we want to update the existing file", if there is no _rev passed to the existing file, then, cozy-client will make a create not an update.

`updateById` string defined here:
https://github.com/konnectors/libs/blob/22ccb509f21394befc253a58116529dba172f39a/packages/cozy-clisk/src/launcher/saveFiles.js#L276

then call client.save here:
https://github.com/konnectors/libs/blob/22ccb509f21394befc253a58116529dba172f39a/packages/cozy-clisk/src/launcher/saveFiles.js#L494-L504

cozy-client check to see if it need to create or update: https://github.com/cozy/cozy-client/blob/ece1e7dd986a3d7f6bca32ce8749837b8953fea5/packages/cozy-client/src/CozyClient.js#L776-L781

It should fix the issue when a clisk wants to force an update of the content of the file.

before this fix, we have a lot of 409 on the EDF attestation.


#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

