### PR TITLE
fix: Avoid to have deformed webview warning logs

### DIFF
--- a/src/components/webviews/jsInteractions/jsLogInterception.ts
+++ b/src/components/webviews/jsInteractions/jsLogInterception.ts
@@ -18,7 +18,7 @@ export const jsLogInterception = `
     log: (...log) => consoleLog('log', log),
     debug: (...log) => consoleLog('debug', log),
     info: (...log) => consoleLog('info', log),
-    warn: (...log) => consoleLog('log', 'warn: ' + log),
+    warn: (...log) => consoleLog('log', ['warn:', ...log]),
     error: (...log) => consoleLog('error', log),
   }
 `


### PR DESCRIPTION
when a webview emits a warning log, we get a log which looks like this :

```
 LOG  CozyWebView [Console HomeView] w a r n :   % c c o z y - s t a c k
 - c l i e n t   D e p r e c a t e d :   i n   n e x t   v e r s i o n s
 o f   c o z y - c l i e n t ,   i t   w i l l   n o t   b e   p o s s i
 b l e   t o   q u e r y   s e t t i n g s   w i t h   a n   i n c o m p
 l e t e   i d

   -   Q ( ' i o . c o z y . s e t t i n g s ' ) . g e t B y I d ( ' i n
   s t a n c e ' )
    +   Q ( ' i o . c o z y . s e t t i n g s ' ) . g e t B y I d ( ' i
    o . c o z y . s e t t i n g s . i n s t a n c e ' ) , c o l o r :
    # f f f ;   b a c k g r o u n d :   # b b b b 0 0 ;

```

This fix allows to get a normal display of the logs

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

