### PR TITLE
fix: Pass the expected log option to saveFiles from cozy-clisk

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
     "cozy-client": "^44.0.0",
-    "cozy-clisk": "^0.27.0",
+    "cozy-clisk": "^0.28.0",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^2.11.0",
     "cozy-intent": "^2.18.0",

--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -484,7 +484,8 @@ export default class Launcher {
         // @ts-ignore
         dataUri: await this.worker.call('downloadFileInWorker', entry)
       }),
-      existingFilesIndex
+      existingFilesIndex,
+      log: this.log.bind(this)
     }
 
     try {

--- a/src/libs/Launcher.spec.js
+++ b/src/libs/Launcher.spec.js
@@ -277,6 +277,7 @@ describe('Launcher', () => {
       expect(saveFiles).toHaveBeenCalledWith(client, [{}], 'folderPath', {
         downloadAndFormatFile: expect.any(Function),
         manifest: expect.any(Object),
+        log: expect.any(Function),
         existingFilesIndex: new Map([
           [
             'fileidattribute',
@@ -355,6 +356,7 @@ describe('Launcher', () => {
       expect(saveFiles).toHaveBeenNthCalledWith(1, client, [{}], 'folderPath', {
         downloadAndFormatFile: expect.any(Function),
         manifest: expect.any(Object),
+        log: expect.any(Function),
         existingFilesIndex: new Map([
           [
             'fileidattribute',
@@ -370,6 +372,7 @@ describe('Launcher', () => {
       expect(saveFiles).toHaveBeenNthCalledWith(2, client, [{}], 'folderPath', {
         downloadAndFormatFile: expect.any(Function),
         manifest: expect.any(Object),
+        log: expect.any(Function),
         existingFilesIndex: new Map([
           [
             'fileidattribute',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6427,10 +6427,10 @@ cozy-client@^44.0.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-clisk@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.27.0.tgz#49853c67a4e89e950d08fef0f9239f379c4edc29"
-  integrity sha512-uJR61dQSnXJgGHDhO+6OKo8uj7haGJNnK7gCEhWwj9KlePCajsRm0UuEwh3tl7Kk9bOeteT/LG5wGkw3I2EZyQ==
+cozy-clisk@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.28.0.tgz#d8587c2deaddb3a2df264976eccfcc74336f3074"
+  integrity sha512-fh2e0YjtOxo2F90UVQWjJu7t2dGCXnvKGRoEzCySaYi5eB1cx48Dkh25nGHJ2ZY9uuH4hO1g4tUpEyXnPLMnoQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     bluebird-retry "^0.11.0"


### PR DESCRIPTION
This option was removed by mistake

Still in draft because expecting https://github.com/konnectors/libs/pull/977 to be merged and will upgrade to the next cozy-clisk version.


#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [X] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

