### PR TITLE
fix: handle disabled button styles

### DIFF
--- a/src/app/view/Secure/SetPinView.tsx
+++ b/src/app/view/Secure/SetPinView.tsx
@@ -47,6 +47,9 @@ const SetPinViewSimple = ({
     }
   }
 
+  const isPasswordComplete = (password: string): boolean =>
+    password.length === 4
+
   return (
     <Container>
       <Grid container direction="column" justifyContent="space-between">
@@ -94,10 +97,13 @@ const SetPinViewSimple = ({
 
             <Button
               onPress={handleFirstInputSubmit}
-              disabled={firstInput.length !== 4}
+              disabled={!isPasswordComplete(firstInput)}
               testID="pin-next"
             >
-              <Typography color="primary" variant="button">
+              <Typography
+                color={!isPasswordComplete(firstInput) ? 'disabled' : 'primary'}
+                variant="button"
+              >
                 {t('screens.SecureScreen.pinsave_step1_cta')}
               </Typography>
             </Button>
@@ -144,8 +150,16 @@ const SetPinViewSimple = ({
               </Tooltip>
             </Grid>
 
-            <Button onPress={handleSecondInputSubmit}>
-              <Typography color="primary" variant="button">
+            <Button
+              onPress={handleSecondInputSubmit}
+              disabled={!isPasswordComplete(secondInput)}
+            >
+              <Typography
+                color={
+                  !isPasswordComplete(secondInput) ? 'disabled' : 'primary'
+                }
+                variant="button"
+              >
                 {t('screens.SecureScreen.pinsave_step2_cta')}
               </Typography>
             </Button>

--- a/src/ui/Button/index.tsx
+++ b/src/ui/Button/index.tsx
@@ -18,7 +18,7 @@ export const Button = ({
     style={[
       styles.button,
       styles[variant],
-      disabled ? styles.disabled : {},
+      disabled ? styles[`disabled_${variant}`] : {},
       style
     ]}
     disabled={disabled}

--- a/src/ui/Button/styles.ts
+++ b/src/ui/Button/styles.ts
@@ -19,7 +19,15 @@ export const styles = StyleSheet.create({
     borderColor: 'rgba(255, 255, 255, 0.24)',
     borderWidth: 1
   },
-  disabled: {
+  // TODO: this is actually the inverted theme with Primary style
+  disabled_primary: {
+    boxShadow: 'none',
+    color: 'rgba(255,255,255,0.32)',
+    backgroundColor: 'rgba(255,255,255,0.12)',
+    borderWidth: 0
+  },
+  // TODO: this is actually the normal theme with Primary style
+  disabled_secondary: {
     boxShadow: 'none',
     color: 'rgba(29,33,42,0.24)',
     backgroundColor: 'rgba(29,33,42,0.12)'

--- a/src/ui/Typography/index.tsx
+++ b/src/ui/Typography/index.tsx
@@ -26,6 +26,7 @@ type TypographyColor =
   | 'textPrimary'
   | 'textSecondary'
   | 'error'
+  | 'disabled'
 
 interface TypographyProps extends TextProps {
   color?: TypographyColor

--- a/src/ui/Typography/styles.ts
+++ b/src/ui/Typography/styles.ts
@@ -11,6 +11,7 @@ export const styles = StyleSheet.create({
   textPrimary: { color: palette.Grey['900'] },
   textSecondary: { color: palette.Common.white },
   error: { color: palette.Primary.ContrastText },
+  disabled: { color: 'rgba(255,255,255,0.32)' }, // TODO: clarify palette object
   h4: {
     fontFamily: 'Lato-Bold',
     fontSize: 20,


### PR DESCRIPTION
They weren't well adjusted. We have to rationalize quickly
these themes issues.
This commit is more a quick fix.
Some buttons in the app don't use the disabled style some do.
Also we need 1 disabled style per variant per theme (that we use in the
app though).

![image](https://github.com/cozy/cozy-flagship-app/assets/12577784/feca7fc7-4f78-45a4-9d73-9ae6d86c58dc)

