### PR TITLE
feat: Add CozyTheme provider to handle normal and inverted themes and adapt existing UI

### DIFF
--- a/src/app/view/Auth/ErrorTokenModal.tsx
+++ b/src/app/view/Auth/ErrorTokenModal.tsx
@@ -20,11 +20,11 @@ export const ErrorTokenModal = ({
   return (
     <ConfirmDialog
       actions={
-        <Button onPress={onClose} variant="secondary">
-          <Typography color="textSecondary" variant="button">
-            {t('modals.ErrorToken.button')}
-          </Typography>
-        </Button>
+        <Button
+          onPress={onClose}
+          variant="secondary"
+          label={t('modals.ErrorToken.button')}
+        />
       }
       content={
         <Typography>

--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -31,6 +31,7 @@ import { getBiometryIcon } from '/app/domain/authorization/services/LockScreenSe
 import { palette } from '/ui/palette'
 import { useLockScreenProps } from '/app/view/Lock/useLockScreen'
 import { useI18n } from '/locales/i18n'
+import { CozyTheme, useCozyTheme } from '/ui/CozyTheme/CozyTheme'
 
 const LockView = ({
   biometryEnabled,
@@ -50,6 +51,7 @@ const LockView = ({
   uiError
 }: LockViewProps): JSX.Element => {
   const { t } = useI18n()
+  const { colors } = useCozyTheme()
 
   return (
     <Container>
@@ -78,12 +80,15 @@ const LockView = ({
       <Grid container direction="column" justifyContent="space-between">
         <Grid justifyContent="space-between">
           <IconButton onPress={toggleLogoutDialog}>
-            <Icon icon={LogoutFlipped} />
+            <Icon icon={LogoutFlipped} color={colors.primaryColor} />
           </IconButton>
 
           {biometryType && biometryEnabled ? (
             <IconButton onPress={(): void => void handleBiometry()}>
-              <Icon icon={getBiometryIcon(biometryType)} />
+              <Icon
+                icon={getBiometryIcon(biometryType)}
+                color={colors.primaryColor}
+              />
             </IconButton>
           ) : null}
         </Grid>
@@ -91,13 +96,13 @@ const LockView = ({
         <Grid alignItems="center" direction="column">
           <Icon icon={CozyCircle} style={{ marginBottom: 14 }} />
 
-          <Typography variant="h4" color="secondary">
+          <Typography variant="h4" color="primary">
             {mode === 'password' ? t('screens.lock.title') : null}
             {mode === 'PIN' ? t('screens.lock.pin_title') : null}
           </Typography>
 
           <Typography
-            color="secondary"
+            color="primary"
             style={{ opacity: 0.64, marginBottom: 24 }}
             variant="body2"
           >
@@ -109,7 +114,10 @@ const LockView = ({
               <TextField
                 endAdornment={
                   <IconButton onPress={togglePasswordVisibility}>
-                    <Icon icon={!passwordVisibility ? EyeClosed : Eye} />
+                    <Icon
+                      icon={!passwordVisibility ? EyeClosed : Eye}
+                      color={colors.primaryColor}
+                    />
                   </IconButton>
                 }
                 label={t('screens.lock.password_label')}
@@ -126,7 +134,10 @@ const LockView = ({
               <TextField
                 endAdornment={
                   <IconButton onPress={togglePasswordVisibility}>
-                    <Icon icon={!passwordVisibility ? EyeClosed : Eye} />
+                    <Icon
+                      icon={!passwordVisibility ? EyeClosed : Eye}
+                      color={colors.primaryColor}
+                    />
                   </IconButton>
                 }
                 inputComponent={RnMaskInput}
@@ -148,7 +159,7 @@ const LockView = ({
             onPress={toggleMode}
             style={{ alignSelf: 'flex-start', marginVertical: 16 }}
           >
-            <Typography color="textSecondary" variant="underline">
+            <Typography variant="underline">
               {mode === 'PIN' ? t('ui.buttons.forgotPin') : null}
 
               {mode === 'password' ? t('ui.buttons.forgotPassword') : null}
@@ -184,7 +195,9 @@ export const LockScreen = (props: LockScreenProps): React.ReactNode => {
           <KeyboardAvoidingView
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
           >
-            <LockView {...useLockScreenProps(props)} />
+            <CozyTheme variant="inverted">
+              <LockView {...useLockScreenProps(props)} />
+            </CozyTheme>
           </KeyboardAvoidingView>
         </TouchableWithoutFeedback>
       </>

--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -57,17 +57,16 @@ const LockView = ({
         <ConfirmDialog
           actions={
             <>
-              <Button onPress={toggleLogoutDialog}>
-                <Typography variant="button">
-                  {t('logout_dialog.cancel')}
-                </Typography>
-              </Button>
+              <Button
+                onPress={toggleLogoutDialog}
+                label={t('logout_dialog.cancel')}
+              />
 
-              <Button onPress={logout} variant="secondary">
-                <Typography color="textSecondary" variant="button">
-                  {t('logout_dialog.confirm')}
-                </Typography>
-              </Button>
+              <Button
+                onPress={logout}
+                variant="secondary"
+                label={t('logout_dialog.confirm')}
+              />
             </>
           }
           content={t('logout_dialog.content')}
@@ -158,11 +157,7 @@ const LockView = ({
         </Grid>
 
         <Grid direction="column">
-          <Button onPress={tryUnlock}>
-            <Typography color="primary" variant="button">
-              {t('ui.buttons.unlock')}
-            </Typography>
-          </Button>
+          <Button onPress={tryUnlock} label={t('ui.buttons.unlock')} />
         </Grid>
       </Grid>
     </Container>

--- a/src/app/view/OsReceive/OsReceiveScreen.tsx
+++ b/src/app/view/OsReceive/OsReceiveScreen.tsx
@@ -155,15 +155,12 @@ export const OsReceiveScreen = (): JSX.Element | null => {
           variant="secondary"
           onPress={proceedToWebview}
           disabled={canProceed()}
-        >
-          <Typography color="secondary" variant="button">
-            {t(
+          label={t(
               hasAppsForUpload()
                 ? 'services.osReceive.submit'
                 : 'services.osReceive.abort'
             )}
-          </Typography>
-        </Button>
+        />
       </Grid>
     </Container>
   )

--- a/src/app/view/OsReceive/OsReceiveScreen.tsx
+++ b/src/app/view/OsReceive/OsReceiveScreen.tsx
@@ -21,12 +21,12 @@ import {
   ListItemText,
   ListSubHeader
 } from '/ui/List'
-import { palette } from '/ui/palette'
 import { Divider } from '/ui/Divider'
 import { useOsReceiveScreenLogic } from '/app/view/OsReceive/hooks/useOsReceiveScreen'
 
 import { osReceiveScreenStyles } from '/app/view/OsReceive/OsReceiveScreen.styles'
 
+import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
 import { FileDuotone } from '/ui/Icons/FileDuotone'
 import { FileThumbnail } from '/ui/ImageThumbnail'
 
@@ -41,6 +41,7 @@ export const OsReceiveScreen = (): JSX.Element | null => {
     proceedToWebview,
     hasAppsForUpload
   } = useOsReceiveScreenLogic()
+  const { colors } = useCozyTheme('normal')
 
   const hasFilesToUpload = filesToUpload.length > 0
   const isSingleFile = filesToUpload.length === 1
@@ -85,11 +86,7 @@ export const OsReceiveScreen = (): JSX.Element | null => {
           <List
             subheader={
               <ListSubHeader>
-                <Typography
-                  // @ts-expect-error There is an issue with the palette secondary color
-                  color={palette.light.text.secondary}
-                  variant="subtitle2"
-                >
+                <Typography variant="subtitle2">
                   {t('services.osReceive.documentType')}
                 </Typography>
               </ListSubHeader>
@@ -118,7 +115,7 @@ export const OsReceiveScreen = (): JSX.Element | null => {
                         <Icon
                           icon={FileDuotone}
                           size={24}
-                          color={palette.light.text.secondary}
+                          color={colors.secondaryTextColor}
                         />
                       )
                     })()}
@@ -152,14 +149,14 @@ export const OsReceiveScreen = (): JSX.Element | null => {
         </Grid>
 
         <Button
-          variant="secondary"
+          variant="primary"
           onPress={proceedToWebview}
           disabled={canProceed()}
           label={t(
-              hasAppsForUpload()
-                ? 'services.osReceive.submit'
-                : 'services.osReceive.abort'
-            )}
+            hasAppsForUpload()
+              ? 'services.osReceive.submit'
+              : 'services.osReceive.abort'
+          )}
         />
       </Grid>
     </Container>

--- a/src/app/view/Secure/PinPrompt.tsx
+++ b/src/app/view/Secure/PinPrompt.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { PromptingPage } from '/components/templates/PromptingPage'
 import { usePinPrompt } from '/app/view/Secure/hooks/usePinPrompt'
 import { useI18n } from '/locales/i18n'
+import { CozyTheme } from '/ui/CozyTheme/CozyTheme'
 
 type RootStackParamList = Record<string, undefined | { onSuccess: () => void }>
 
@@ -18,17 +19,19 @@ export const PinPrompt = (props: PinPromptProps): JSX.Element => {
   const { t } = useI18n()
 
   return (
-    <PromptingPage
-      title={t('screens.SecureScreen.pinprompt_title')}
-      body={t('screens.SecureScreen.pinprompt_body')}
-      button1={{
-        label: t('screens.SecureScreen.pinprompt_cta'),
-        onPress: handleSetPinCode
-      }}
-      button2={{
-        label: t('screens.SecureScreen.pinprompt_refusal'),
-        onPress: handleIgnorePinCode
-      }}
-    />
+    <CozyTheme variant="inverted">
+      <PromptingPage
+        title={t('screens.SecureScreen.pinprompt_title')}
+        body={t('screens.SecureScreen.pinprompt_body')}
+        button1={{
+          label: t('screens.SecureScreen.pinprompt_cta'),
+          onPress: handleSetPinCode
+        }}
+        button2={{
+          label: t('screens.SecureScreen.pinprompt_refusal'),
+          onPress: handleIgnorePinCode
+        }}
+      />
+    </CozyTheme>
   )
 }

--- a/src/app/view/Secure/SetPinView.tsx
+++ b/src/app/view/Secure/SetPinView.tsx
@@ -23,6 +23,7 @@ import { TextField } from '/ui/TextField'
 import { ConditionalWrapper } from '/components/ConditionalWrapper'
 import { palette } from '/ui/palette'
 import { useI18n } from '/locales/i18n'
+import { CozyTheme } from '/ui/CozyTheme/CozyTheme'
 
 const SetPinViewSimple = ({
   onSuccess
@@ -57,14 +58,12 @@ const SetPinViewSimple = ({
             <Grid alignItems="center" direction="column">
               <Typography
                 variant="h4"
-                color="secondary"
                 style={{ maxWidth: 296, marginBottom: 24, textAlign: 'center' }}
               >
                 {t('screens.SecureScreen.pinsave_step1_title')}
               </Typography>
 
               <Typography
-                color="secondary"
                 style={{ marginBottom: 24, textAlign: 'center' }}
                 variant="body1"
               >
@@ -104,12 +103,11 @@ const SetPinViewSimple = ({
         {step === 2 && (
           <>
             <Grid alignItems="center" direction="column">
-              <Typography variant="h4" color="secondary">
+              <Typography variant="h4">
                 {t('screens.SecureScreen.pinsave_step2_title')}
               </Typography>
 
               <Typography
-                color="secondary"
                 style={{ marginBottom: 24, textAlign: 'center' }}
                 variant="body2"
               >
@@ -172,7 +170,12 @@ export const SetPinView = (props: SetPinProps): JSX.Element => (
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
-        <SetPinViewSimple {...props} onSuccess={props.route.params.onSuccess} />
+        <CozyTheme variant="inverted">
+          <SetPinViewSimple
+            {...props}
+            onSuccess={props.route.params.onSuccess}
+          />
+        </CozyTheme>
       </KeyboardAvoidingView>
     </TouchableWithoutFeedback>
   </ConditionalWrapper>

--- a/src/app/view/Secure/SetPinView.tsx
+++ b/src/app/view/Secure/SetPinView.tsx
@@ -48,6 +48,9 @@ const SetPinViewSimple = ({
     }
   }
 
+  const isPasswordComplete = (password: string): boolean =>
+    password.length === 4
+
   return (
     <Container>
       <Grid container direction="column" justifyContent="space-between">
@@ -93,7 +96,7 @@ const SetPinViewSimple = ({
 
             <Button
               onPress={handleFirstInputSubmit}
-              disabled={firstInput.length !== 4}
+              disabled={!isPasswordComplete(firstInput)}
               testID="pin-next"
               label={t('screens.SecureScreen.pinsave_step1_cta')}
             />
@@ -141,6 +144,7 @@ const SetPinViewSimple = ({
 
             <Button
               onPress={handleSecondInputSubmit}
+              disabled={!isPasswordComplete(secondInput)}
               label={t('screens.SecureScreen.pinsave_step2_cta')}
             />
           </>

--- a/src/app/view/Secure/SetPinView.tsx
+++ b/src/app/view/Secure/SetPinView.tsx
@@ -96,11 +96,8 @@ const SetPinViewSimple = ({
               onPress={handleFirstInputSubmit}
               disabled={firstInput.length !== 4}
               testID="pin-next"
-            >
-              <Typography color="primary" variant="button">
-                {t('screens.SecureScreen.pinsave_step1_cta')}
-              </Typography>
-            </Button>
+              label={t('screens.SecureScreen.pinsave_step1_cta')}
+            />
           </>
         )}
 
@@ -144,11 +141,10 @@ const SetPinViewSimple = ({
               </Tooltip>
             </Grid>
 
-            <Button onPress={handleSecondInputSubmit}>
-              <Typography color="primary" variant="button">
-                {t('screens.SecureScreen.pinsave_step2_cta')}
-              </Typography>
-            </Button>
+            <Button
+              onPress={handleSecondInputSubmit}
+              label={t('screens.SecureScreen.pinsave_step2_cta')}
+            />
           </>
         )}
       </Grid>

--- a/src/components/templates/PromptingPage.tsx
+++ b/src/components/templates/PromptingPage.tsx
@@ -52,18 +52,18 @@ export const PromptingPage = ({
       </Grid>
 
       <Grid direction="column">
-        <Button onPress={button1.onPress} style={{ marginBottom: 8 }}>
-          <Typography color="primary" variant="button">
-            {button1.label}
-          </Typography>
-        </Button>
+        <Button
+          onPress={button1.onPress}
+          style={{ marginBottom: 8 }}
+          label={button1.label}
+        />
 
         {button2 && (
-          <Button variant="secondary" onPress={button2.onPress}>
-            <Typography color="secondary" variant="button">
-              {button2.label}
-            </Typography>
-          </Button>
+          <Button
+            variant="secondary"
+            onPress={button2.onPress}
+            label={button2.label}
+          />
         )}
       </Grid>
     </Grid>

--- a/src/components/templates/PromptingPage.tsx
+++ b/src/components/templates/PromptingPage.tsx
@@ -36,14 +36,12 @@ export const PromptingPage = ({
 
         <Typography
           variant="h4"
-          color="secondary"
           style={{ marginBottom: 24, maxWidth: 296, textAlign: 'center' }}
         >
           {title}
         </Typography>
 
         <Typography
-          color="secondary"
           style={{ maxWidth: 296, textAlign: 'center' }}
           variant="body1"
         >

--- a/src/libs/icon/IconChangedModal.tsx
+++ b/src/libs/icon/IconChangedModal.tsx
@@ -57,11 +57,11 @@ export const IconChangedModal = (): JSX.Element | null => {
       }
       actions={
         <>
-          <Button variant="secondary" onPress={(): void => setShow(!show)}>
-            <Typography variant="button" color="secondary">
-              OK
-            </Typography>
-          </Button>
+          <Button
+            variant="secondary"
+            onPress={(): void => setShow(!show)}
+            label="OK"
+          />
         </>
       }
       onClose={(): void => setShow(!show)}

--- a/src/screens/home/components/ErrorParallelKonnectors.tsx
+++ b/src/screens/home/components/ErrorParallelKonnectors.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { Button } from '/ui/Button'
 import { ConfirmDialog } from '/ui/CozyDialogs/ConfirmDialog'
-import { Typography } from '/ui/Typography'
 import { useI18n } from '/locales/i18n'
 
 interface ErrorParallelKonnectorsProps {
@@ -21,11 +20,11 @@ export const ErrorParallelKonnectors = ({
   return (
     <ConfirmDialog
       actions={
-        <Button onPress={onClose} variant="secondary">
-          <Typography color="textSecondary" variant="button">
-            {t('konnectors.errorDoubleRun.button')}
-          </Typography>
-        </Button>
+        <Button
+          onPress={onClose}
+          variant="secondary"
+          label={t('konnectors.errorDoubleRun.button')}
+        />
       }
       content={t('konnectors.errorDoubleRun.body', {
         running_konnector: currentRunningKonnector,

--- a/src/ui/Button/index.tsx
+++ b/src/ui/Button/index.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { TouchableOpacity, TouchableOpacityProps } from 'react-native'
 
-import { styles } from '/ui/Button/styles'
+import { ButtonStyles, styles as computeStyles } from '/ui/Button/styles'
+import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
 
 type ButtonProps = TouchableOpacityProps & { variant?: 'primary' | 'secondary' }
 
@@ -12,13 +13,17 @@ export const Button = ({
   style,
   variant = 'primary',
   ...props
-}: ButtonProps): JSX.Element => (
+}: ButtonProps): JSX.Element | null => {
+  const { colors } = useCozyTheme()
+  const styles = useMemo<ButtonStyles>(() => computeStyles(colors), [colors])
+
+  return (
   <TouchableOpacity
     onPress={onPress}
     style={[
       styles.button,
       styles[variant],
-      disabled ? styles.disabled : {},
+        disabled ? styles[`disabled_${variant}`] : {},
       style
     ]}
     disabled={disabled}
@@ -27,3 +32,4 @@ export const Button = ({
     {children}
   </TouchableOpacity>
 )
+}

--- a/src/ui/Button/index.tsx
+++ b/src/ui/Button/index.tsx
@@ -3,11 +3,27 @@ import { TouchableOpacity, TouchableOpacityProps } from 'react-native'
 
 import { ButtonStyles, styles as computeStyles } from '/ui/Button/styles'
 import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
+import { Typography } from '/ui/Typography'
 
-type ButtonProps = TouchableOpacityProps & { variant?: 'primary' | 'secondary' }
+type ButtonPropsbase = TouchableOpacityProps & {
+  variant?: 'primary' | 'secondary'
+}
+
+type ButtonPropsWithChildren = ButtonPropsbase & {
+  label?: never
+  children: React.ReactNode
+}
+
+type ButtonPropsWithLabel = ButtonPropsbase & {
+  label: string
+  children?: never
+}
+
+type ButtonProps = ButtonPropsWithChildren | ButtonPropsWithLabel
 
 export const Button = ({
   children,
+  label,
   disabled,
   onPress,
   style,
@@ -18,18 +34,32 @@ export const Button = ({
   const styles = useMemo<ButtonStyles>(() => computeStyles(colors), [colors])
 
   return (
-  <TouchableOpacity
-    onPress={onPress}
-    style={[
-      styles.button,
-      styles[variant],
+    <TouchableOpacity
+      onPress={onPress}
+      style={[
+        styles.button,
+        styles[variant],
         disabled ? styles[`disabled_${variant}`] : {},
-      style
-    ]}
-    disabled={disabled}
-    {...props}
-  >
-    {children}
-  </TouchableOpacity>
-)
+        style
+      ]}
+      disabled={disabled}
+      {...props}
+    >
+      {children ? (
+        children
+      ) : (
+        <Typography
+          variant="button"
+          style={[
+            variant === 'primary' && {
+              color: colors.primaryContrastTextColor
+            },
+            disabled && { color: colors.actionColorDisabled }
+          ]}
+        >
+          {label}
+        </Typography>
+      )}
+    </TouchableOpacity>
+  )
 }

--- a/src/ui/Button/styles.ts
+++ b/src/ui/Button/styles.ts
@@ -1,27 +1,39 @@
-import { StyleSheet } from 'react-native'
+import { StyleSheet, ViewStyle } from 'react-native'
 
-import { palette } from '/ui/palette'
+import { CozyThemeColors } from '/ui/colors'
 
-export const styles = StyleSheet.create({
-  button: {
-    borderRadius: 2,
-    paddingHorizontal: 16,
-    paddingVertical: 11,
-    width: '100%'
-  },
-  primary: {
-    backgroundColor: palette.Common.white,
-    borderColor: 'rgba(255, 255, 255, 1)',
-    borderWidth: 1
-  },
-  secondary: {
-    backgroundColor: palette.Primary['600'],
-    borderColor: 'rgba(255, 255, 255, 0.24)',
-    borderWidth: 1
-  },
-  disabled: {
-    boxShadow: 'none',
-    color: 'rgba(29,33,42,0.24)',
-    backgroundColor: 'rgba(29,33,42,0.12)'
-  }
-})
+export interface ButtonStyles {
+  button: ViewStyle
+  primary: ViewStyle
+  secondary: ViewStyle
+  disabled_primary: ViewStyle
+  disabled_secondary: ViewStyle
+}
+
+export const styles = (colors: CozyThemeColors): ButtonStyles =>
+  StyleSheet.create({
+    button: {
+      borderRadius: 2,
+      paddingHorizontal: 16,
+      paddingVertical: 11,
+      width: '100%'
+    },
+    primary: {
+      backgroundColor: colors.primaryColor
+    },
+    secondary: {
+      backgroundColor: colors.paperBackgroundColor,
+      borderColor: colors.borderMainColor,
+      borderWidth: 1
+    },
+    disabled_primary: {
+      boxShadow: 'none',
+      color: colors.actionColorDisabled,
+      backgroundColor: colors.actionColorDisabledBackground
+    },
+    disabled_secondary: {
+      boxShadow: 'none',
+      color: colors.actionColorDisabled,
+      backgroundColor: 'transparent'
+    }
+  })

--- a/src/ui/Container/index.tsx
+++ b/src/ui/Container/index.tsx
@@ -3,6 +3,7 @@ import { SafeAreaView, View, ViewProps } from 'react-native'
 
 import { useDimensions } from '/libs/dimensions'
 import { styles } from '/ui/Container/styles'
+import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
 
 type ContainerProps = ViewProps
 
@@ -12,12 +13,16 @@ export const Container = ({
   ...props
 }: ContainerProps): JSX.Element => {
   const dimensions = useDimensions()
+  const { colors } = useCozyTheme()
 
   return (
     <View
       style={[
         styles.container,
-        { paddingBottom: dimensions.navbarHeight + 16 },
+        {
+          paddingBottom: dimensions.navbarHeight + 16,
+          backgroundColor: colors.paperBackgroundColor
+        },
         style
       ]}
       {...props}

--- a/src/ui/CozyTheme/CozyTheme.tsx
+++ b/src/ui/CozyTheme/CozyTheme.tsx
@@ -1,0 +1,69 @@
+import React, { ReactNode, createContext, useContext, useMemo } from 'react'
+
+import log from 'cozy-logger'
+
+import { CozyThemeColors, getColors } from '/ui/colors'
+
+export type CozyThemeVariant = 'normal' | 'inverted'
+
+interface CozyThemeState {
+  variant: CozyThemeVariant
+}
+
+export const CozyThemeContext = createContext<CozyThemeState>({
+  variant: 'normal'
+})
+
+interface CozyThemeProps {
+  variant: CozyThemeVariant
+  children: ReactNode
+}
+
+export const CozyTheme = ({
+  variant,
+  children
+}: CozyThemeProps): JSX.Element => (
+  <CozyThemeContext.Provider value={{ variant }}>
+    {children}
+  </CozyThemeContext.Provider>
+)
+
+interface CozyThemeHook {
+  variant: CozyThemeVariant
+  colors: CozyThemeColors
+}
+
+export const useCozyTheme = (
+  forcedVariant: CozyThemeVariant | undefined = undefined
+): CozyThemeHook => {
+  const context = useContext(CozyThemeContext)
+
+  const colors = useMemo<CozyThemeColors>(
+    () => getColors(forcedVariant ? forcedVariant : context.variant),
+    [forcedVariant, context.variant]
+  )
+
+  if (forcedVariant) {
+    return {
+      variant: forcedVariant,
+      colors
+    }
+  }
+
+  if (!context) {
+    log(
+      'error',
+      '`CozyThemeContext` is missing. `useCozyTheme()` must be used within a `<CozyTheme>`. `normal` is returned as fallback value.'
+    )
+
+    return {
+      variant: 'normal',
+      colors
+    }
+  }
+
+  return {
+    ...context,
+    colors
+  }
+}

--- a/src/ui/TextField/index.tsx
+++ b/src/ui/TextField/index.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Platform, TextInput, TextInputProps, View } from 'react-native'
 import { MaskInputProps } from 'react-native-mask-input'
 
+import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
+import { TextFieldStyles, styles as computeStyles } from '/ui/TextField/styles'
 import { Typography } from '/ui/Typography'
-import { styles } from '/ui/TextField/styles'
 
 export interface TextFieldProps extends TextInputProps {
   cursorColor?: string
@@ -25,34 +26,43 @@ export const TextField = ({
   inputComponentProps,
   value = '',
   ...props
-}: TextFieldProps): JSX.Element => (
-  <View style={[styles.textField, style]}>
-    <Typography color="secondary" style={styles.label}>
-      {label}
-    </Typography>
+}: TextFieldProps): JSX.Element | null => {
+  const { colors } = useCozyTheme()
+  const styles = useMemo<TextFieldStyles>(() => computeStyles(colors), [colors])
 
-    {InputComponent ? (
-      <InputComponent
-        cursorColor={styles.input.color}
-        selectionColor={Platform.OS === 'ios' ? styles.input.color : undefined}
-        style={[styles.input, { letterSpacing: 10 }]}
-        value={value}
-        placeholderTextColor={styles.input.color}
-        {...props}
-        {...inputComponentProps}
-      />
-    ) : (
-      <TextInput
-        cursorColor={styles.input.color}
-        selectionColor={Platform.OS === 'ios' ? styles.input.color : undefined}
-        style={styles.input}
-        value={value}
-        {...props}
-      />
-    )}
+  return (
+    <View style={[styles.textField, style]}>
+      <Typography color="primary" style={styles.label}>
+        {label}
+      </Typography>
 
-    {endAdornment ? (
-      <View style={styles.endAdornment}>{endAdornment}</View>
-    ) : null}
-  </View>
-)
+      {InputComponent ? (
+        <InputComponent
+          cursorColor={styles.input.color}
+          selectionColor={
+            Platform.OS === 'ios' ? styles.input.color : undefined
+          }
+          style={[styles.input, { letterSpacing: 10 }]}
+          value={value}
+          placeholderTextColor={styles.input.color}
+          {...props}
+          {...inputComponentProps}
+        />
+      ) : (
+        <TextInput
+          cursorColor={styles.input.color}
+          selectionColor={
+            Platform.OS === 'ios' ? styles.input.color : undefined
+          }
+          style={styles.input}
+          value={value}
+          {...props}
+        />
+      )}
+
+      {endAdornment ? (
+        <View style={styles.endAdornment}>{endAdornment}</View>
+      ) : null}
+    </View>
+  )
+}

--- a/src/ui/TextField/styles.ts
+++ b/src/ui/TextField/styles.ts
@@ -1,36 +1,44 @@
-import { StyleSheet } from 'react-native'
+import { StyleSheet, TextStyle, ViewStyle } from 'react-native'
 
-import { palette } from '/ui/palette'
+import { CozyThemeColors } from '/ui/colors'
 
-export const styles = StyleSheet.create({
-  textField: {
-    borderColor: palette.Primary.ContrastText,
-    borderRadius: 4,
-    borderWidth: 1,
-    display: 'flex',
-    flexDirection: 'row',
-    fontFamily: 'Lato-Regular',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    position: 'relative',
-    width: '100%'
-  },
-  label: {
-    backgroundColor: palette.Primary['600'],
-    fontSize: 12,
-    left: 16,
-    padding: 4,
-    position: 'absolute',
-    top: -16
-  },
-  endAdornment: { marginRight: 16 },
-  input: {
-    color: palette.Primary.ContrastText,
-    fontFamily: 'Lato-Regular',
-    fontSize: 16,
-    paddingLeft: 16,
-    paddingRight: 40,
-    paddingVertical: 13,
-    flex: 1
-  }
-})
+export interface TextFieldStyles {
+  textField: TextStyle
+  label: TextStyle
+  endAdornment: ViewStyle
+  input: TextStyle
+}
+
+export const styles = (colors: CozyThemeColors): TextFieldStyles =>
+  StyleSheet.create({
+    textField: {
+      borderColor: colors.borderMainColor,
+      borderRadius: 4,
+      borderWidth: 1,
+      display: 'flex',
+      flexDirection: 'row',
+      fontFamily: 'Lato-Regular',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      position: 'relative',
+      width: '100%'
+    },
+    label: {
+      backgroundColor: colors.paperBackgroundColor,
+      fontSize: 12,
+      left: 16,
+      padding: 4,
+      position: 'absolute',
+      top: -16
+    },
+    endAdornment: { marginRight: 16 },
+    input: {
+      color: colors.primaryTextColor,
+      fontFamily: 'Lato-Regular',
+      fontSize: 16,
+      paddingLeft: 16,
+      paddingRight: 40,
+      paddingVertical: 13,
+      flex: 1
+    }
+  })

--- a/src/ui/Typography/index.tsx
+++ b/src/ui/Typography/index.tsx
@@ -1,7 +1,11 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Text, TextProps } from 'react-native'
 
-import { styles } from '/ui/Typography/styles'
+import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
+import {
+  TypographyStyles,
+  styles as computeStyles
+} from '/ui/Typography/styles'
 
 type TypographyVariant =
   | 'h1'
@@ -38,8 +42,19 @@ export const Typography = ({
   variant = 'body2',
   style,
   ...props
-}: TypographyProps): JSX.Element => (
-  <Text style={[styles.base, styles[variant], styles[color], style]} {...props}>
-    {children}
-  </Text>
-)
+}: TypographyProps): JSX.Element | null => {
+  const { colors } = useCozyTheme()
+  const styles = useMemo<TypographyStyles>(
+    () => computeStyles(colors),
+    [colors]
+  )
+
+  return (
+    <Text
+      style={[styles.base, styles[variant], styles[color], style]}
+      {...props}
+    >
+      {children}
+    </Text>
+  )
+}

--- a/src/ui/Typography/styles.ts
+++ b/src/ui/Typography/styles.ts
@@ -1,60 +1,86 @@
-import { StyleSheet } from 'react-native'
+import { StyleSheet, TextStyle } from 'react-native'
 
+import { CozyThemeColors } from '/ui/colors'
 import { palette } from '/ui/palette'
 
-export const styles = StyleSheet.create({
-  base: { fontFamily: 'Lato-Regular' },
-  initial: { color: palette.Primary.ContrastText },
-  inherit: { color: palette.Primary.ContrastText },
-  primary: { color: palette.Primary['600'] },
-  secondary: { color: palette.Primary.ContrastText },
-  textPrimary: { color: palette.Grey['900'] },
-  textSecondary: { color: palette.Common.white },
-  error: { color: palette.Primary.ContrastText },
-  h4: {
-    fontFamily: 'Lato-Bold',
-    fontSize: 20,
-    lineHeight: 23
-  },
-  body2: {
-    fontFamily: 'Lato-Regular',
-    fontSize: 14,
-    lineHeight: 19
-  },
-  underline: {
-    textDecorationLine: 'underline',
-    fontSize: 16,
-    lineHeight: 21
-  },
-  button: {
-    color: palette.Primary['600'],
-    fontFamily: 'Lato-Bold',
-    fontSize: 14,
-    lineHeight: 18,
-    textTransform: 'uppercase',
-    textAlign: 'center'
-  },
-  h1: { fontSize: 16 },
-  h2: { fontSize: 16 },
-  h3: {
-    fontSize: 20,
-    fontFamily: 'Lato-Bold',
-    color: palette.Grey['900']
-  },
-  h5: { fontSize: 18, fontFamily: 'Lato-Bold', lineHeight: 23 },
-  subtitle1: { fontSize: 16 },
-  subtitle2: {
-    fontSize: 12,
-    lineHeight: 16,
-    fontFamily: 'Lato-Bold',
-    textTransform: 'uppercase'
-  },
-  body1: { fontSize: 16 },
-  caption: { fontSize: 12, lineHeight: 16, fontFamily: 'Lato-Regular' },
-  link: {
-    fontFamily: 'Lato-Regular',
-    fontSize: 14,
-    lineHeight: 19,
-    textDecorationLine: 'underline'
-  }
-})
+export interface TypographyStyles {
+  base: TextStyle
+  initial: TextStyle
+  inherit: TextStyle
+  primary: TextStyle
+  secondary: TextStyle
+  textPrimary: TextStyle
+  textSecondary: TextStyle
+  error: TextStyle
+  h4: TextStyle
+  body2: TextStyle
+  underline: TextStyle
+  button: TextStyle
+  h1: TextStyle
+  h2: TextStyle
+  h3: TextStyle
+  h5: TextStyle
+  subtitle1: TextStyle
+  subtitle2: TextStyle
+  body1: TextStyle
+  caption: TextStyle
+  link: TextStyle
+}
+
+export const styles = (colors: CozyThemeColors): TypographyStyles =>
+  StyleSheet.create({
+    base: { fontFamily: 'Lato-Regular' },
+    initial: { color: colors.primaryTextColor }, // should be removed?
+    inherit: { color: colors.primaryTextColor }, // should be removed?
+    primary: { color: colors.primaryColor },
+    secondary: { color: colors.secondaryTextColor },
+    textPrimary: { color: colors.primaryTextColor },
+    textSecondary: { color: colors.secondaryTextColor },
+    error: { color: colors.errorColor },
+    h4: {
+      fontFamily: 'Lato-Bold',
+      fontSize: 20,
+      lineHeight: 23
+    },
+    body2: {
+      fontFamily: 'Lato-Regular',
+      fontSize: 14,
+      lineHeight: 19
+    },
+    underline: {
+      textDecorationLine: 'underline',
+      fontSize: 16,
+      lineHeight: 21
+    },
+    button: {
+      color: palette.Primary['600'],
+      fontFamily: 'Lato-Bold',
+      fontSize: 14,
+      lineHeight: 18,
+      textTransform: 'uppercase',
+      textAlign: 'center'
+    },
+    h1: { fontSize: 16 },
+    h2: { fontSize: 16 },
+    h3: {
+      fontSize: 20,
+      fontFamily: 'Lato-Bold',
+      color: palette.Grey['900']
+    },
+    h5: { fontSize: 18, fontFamily: 'Lato-Bold', lineHeight: 23 },
+    subtitle1: { fontSize: 16 },
+    subtitle2: {
+      fontSize: 12,
+      lineHeight: 16,
+      fontFamily: 'Lato-Bold',
+      textTransform: 'uppercase'
+    },
+    body1: { fontSize: 16 },
+    caption: { fontSize: 12, lineHeight: 16, fontFamily: 'Lato-Regular' },
+    link: {
+      fontFamily: 'Lato-Regular',
+      fontSize: 14,
+      lineHeight: 19,
+      textDecorationLine: 'underline'
+    }
+  })

--- a/src/ui/colors.ts
+++ b/src/ui/colors.ts
@@ -1,10 +1,64 @@
+import { CozyThemeVariant } from '/ui/CozyTheme/CozyTheme'
 import { palette } from '/ui/palette'
 
+const ALPHA_0_12 = '1F'
+const ALPHA_0_16 = '29'
+const ALPHA_0_24 = '3D'
+const ALPHA_0_32 = '52'
+const ALPHA_0_48 = '7A'
+const ALPHA_0_64 = 'A3'
+const ALPHA_0_90 = 'E5'
+
 const colors = {
+  // ACTIONS
+  actionColorDisabled: palette.Grey['900'] + ALPHA_0_24,
+  actionColorDisabledBackground: palette.Grey['900'] + ALPHA_0_12,
+
+  // BORDERS
+  borderMainColor: palette.Grey['900'] + ALPHA_0_16,
+
+  // BACKGROUND
+  paperBackgroundColor: palette.Common.white,
+
+  // PRIMARY
   primaryColor: palette.Primary['600'],
-  paperBackgroundColor: palette.Common.white
+  primaryContrastTextColor: palette.Common.white,
+
+  // ERROR
+  errorColor: palette.Error['600'],
+
+  // TEXT
+  primaryTextColor: palette.Grey['900'] + ALPHA_0_90,
+  secondaryTextColor: palette.Grey['900'] + ALPHA_0_48
 }
 
-export const getColors = (): typeof colors => {
-  return colors
+const colorsInverted = {
+  // ACTIONS
+  actionColorDisabled: palette.Common.white + ALPHA_0_32,
+  actionColorDisabledBackground: palette.Common.white + ALPHA_0_12,
+
+  // BORDERS
+  borderMainColor: palette.Common.white + ALPHA_0_24,
+
+  // BACKGROUND
+  paperBackgroundColor: palette.Primary['600'],
+
+  // PRIMARY
+  primaryColor: palette.Common.white,
+  primaryContrastTextColor: palette.Primary['600'],
+
+  // ERROR
+  errorColor: palette.Error['200'],
+
+  // TEXT
+  primaryTextColor: palette.Common.white,
+  secondaryTextColor: palette.Common.white + ALPHA_0_64
+}
+
+export type CozyThemeColors = typeof colors
+
+export const getColors = (
+  variant: CozyThemeVariant = 'normal'
+): CozyThemeColors => {
+  return variant === 'normal' ? colors : colorsInverted
 }

--- a/src/ui/palette.ts
+++ b/src/ui/palette.ts
@@ -10,7 +10,7 @@ export const palette = {
     '700': '#0f5cc7',
     '800': '#0b3672',
     '900': '#081d39',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Secondary: {
@@ -24,7 +24,7 @@ export const palette = {
     '700': '#7a349a',
     '800': '#4e1f63',
     '900': '#230c2e',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Error: {
@@ -38,7 +38,7 @@ export const palette = {
     '700': '#d31f1f',
     '800': '#771212',
     '900': '#340b0b',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Warning: {
@@ -52,7 +52,7 @@ export const palette = {
     '700': '#986100',
     '800': '#553804',
     '900': '#281c07',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Success: {
@@ -66,7 +66,7 @@ export const palette = {
     '700': '#018711',
     '800': '#054c0d',
     '900': '#08250b',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Info: {
@@ -100,8 +100,8 @@ export const palette = {
   },
 
   Common: {
-    white: '#fff',
-    black: '#000'
+    white: '#ffffff',
+    black: '#000000'
   },
 
   light: {

--- a/white_label/brands/cozy/js/ui/palette.ts
+++ b/white_label/brands/cozy/js/ui/palette.ts
@@ -10,7 +10,7 @@ export const palette = {
     '700': '#0f5cc7',
     '800': '#0b3672',
     '900': '#081d39',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Secondary: {
@@ -24,7 +24,7 @@ export const palette = {
     '700': '#7a349a',
     '800': '#4e1f63',
     '900': '#230c2e',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Error: {
@@ -38,7 +38,7 @@ export const palette = {
     '700': '#d31f1f',
     '800': '#771212',
     '900': '#340b0b',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Warning: {
@@ -52,7 +52,7 @@ export const palette = {
     '700': '#986100',
     '800': '#553804',
     '900': '#281c07',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Success: {
@@ -66,7 +66,7 @@ export const palette = {
     '700': '#018711',
     '800': '#054c0d',
     '900': '#08250b',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Info: {
@@ -100,8 +100,8 @@ export const palette = {
   },
 
   Common: {
-    white: '#fff',
-    black: '#000'
+    white: '#ffffff',
+    black: '#000000'
   },
 
   light: {

--- a/white_label/brands/mabulle/js/ui/palette.ts
+++ b/white_label/brands/mabulle/js/ui/palette.ts
@@ -10,7 +10,7 @@ export const palette = {
     '700': '#0054d2',
     '800': '#0047b2',
     '900': '#002b6c',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Secondary: {
@@ -24,7 +24,7 @@ export const palette = {
     '700': '#7a349a',
     '800': '#4e1f63',
     '900': '#230c2e',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Error: {
@@ -38,7 +38,7 @@ export const palette = {
     '700': '#d31f1f',
     '800': '#771212',
     '900': '#340b0b',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Warning: {
@@ -52,7 +52,7 @@ export const palette = {
     '700': '#986100',
     '800': '#553804',
     '900': '#281c07',
-    ContrastText: '#fff'
+    ContrastText: '#ffffff'
   },
 
   Success: {
@@ -100,8 +100,8 @@ export const palette = {
   },
 
   Common: {
-    white: '#fff',
-    black: '#000'
+    white: '#ffffff',
+    black: '#000000'
   },
 
   light: {


### PR DESCRIPTION
> [!TIP]
> As usual this PR is meant to be read commit by commit
> Also, to ease reading `styles.ts` files diffs you can hide whitespace diffs

We want the UI to adapt to `normal` and `inverted` themes

Until now we did not support Theming in the UI and we manually applied colors to component based on the expected result (`normal` or `inverted`)

In the IAP feature we will need to reuse the `PromptingPage` component using `normal` theme, but this component is implemented for the `inverted` theme only

So it is time to implement some Theming mechanism

The `CozyTheme` provider will be responsible to enforce a theme (`normal` or `inverted`) to all its children

This provider is inspired by the one on cozy-ui

Then `useCozyTheme` hook can be used on every component and should return the current theme name and its corresponding colors palette

This hook takes a `forcedVariant` parameter that can be used by top level components that are not embedded in the provider

Related files:
https://github.com/cozy/cozy-ui/blob/master/react/providers/CozyTheme/index.jsx

___

This PR also ports some of the following components:
- Button
- Typography
- TextField

And the following views:
- LockScreen
- PinPrompt
- SetPinView
- OsReceiveScreen

Some other components still have to be adapted but this can be done in another PR. The requirement was to adapt the PromptingPage. All edits on previous components were side effects as they would have been broken when porting PromptingPage

Next to this PR, the goal would be to adapt remaining components AND to get rid of [this code](https://github.com/cozy/cozy-flagship-app/blob/master/src/ui/palette.ts#L107-L121) that should not be in the palette (its place is in colours.ts as semantic variables)

___

### TODO:

- [x] Adapt Colors for MaBulle