### PR TITLE
feat: add new non-native Modal component

### DIFF
--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -74,33 +74,12 @@ const LockView = ({
           content={t('logout_dialog.content')}
           onClose={toggleLogoutDialog}
           title={t('logout_dialog.title')}
-          native={false}
+          // Don't use the native modal on iOS because it interferes with the FullWindowOverlay
+          native={Platform.OS === 'ios' ? false : true}
         />
       )}
 
       <Container>
-        {hasLogoutDialog && (
-          <ConfirmDialog
-            actions={
-              <>
-                <Button
-                  onPress={toggleLogoutDialog}
-                  label={t('logout_dialog.cancel')}
-                />
-
-                <Button
-                  onPress={logout}
-                  variant="secondary"
-                  label={t('logout_dialog.confirm')}
-                />
-              </>
-            }
-            content={t('logout_dialog.content')}
-            onClose={toggleLogoutDialog}
-            title={t('logout_dialog.title')}
-          />
-        )}
-
         <Grid container direction="column" justifyContent="space-between">
           <Grid justifyContent="space-between">
             <IconButton onPress={toggleLogoutDialog}>

--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -56,27 +56,29 @@ const LockView = ({
   return (
     <>
       {hasLogoutDialog && (
-        <ConfirmDialog
-          actions={
-            <>
-              <Button
-                onPress={toggleLogoutDialog}
-                label={t('logout_dialog.cancel')}
-              />
+        <CozyTheme variant="normal">
+          <ConfirmDialog
+            actions={
+              <>
+                <Button
+                  onPress={toggleLogoutDialog}
+                  label={t('logout_dialog.cancel')}
+                />
 
-              <Button
-                onPress={logout}
-                variant="secondary"
-                label={t('logout_dialog.confirm')}
-              />
-            </>
-          }
-          content={t('logout_dialog.content')}
-          onClose={toggleLogoutDialog}
-          title={t('logout_dialog.title')}
-          // Don't use the native modal on iOS because it interferes with the FullWindowOverlay
-          native={Platform.OS === 'ios' ? false : true}
-        />
+                <Button
+                  onPress={logout}
+                  variant="secondary"
+                  label={t('logout_dialog.confirm')}
+                />
+              </>
+            }
+            content={t('logout_dialog.content')}
+            onClose={toggleLogoutDialog}
+            title={t('logout_dialog.title')}
+            // Don't use the native modal because it interferes with the FullWindowOverlay
+            native={false}
+          />
+        </CozyTheme>
       )}
 
       <Container>

--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -54,7 +54,7 @@ const LockView = ({
   const { colors } = useCozyTheme()
 
   return (
-    <Container>
+    <>
       {hasLogoutDialog && (
         <ConfirmDialog
           actions={
@@ -74,104 +74,129 @@ const LockView = ({
           content={t('logout_dialog.content')}
           onClose={toggleLogoutDialog}
           title={t('logout_dialog.title')}
+          native={false}
         />
       )}
 
-      <Grid container direction="column" justifyContent="space-between">
-        <Grid justifyContent="space-between">
-          <IconButton onPress={toggleLogoutDialog}>
-            <Icon icon={LogoutFlipped} color={colors.primaryColor} />
-          </IconButton>
+      <Container>
+        {hasLogoutDialog && (
+          <ConfirmDialog
+            actions={
+              <>
+                <Button
+                  onPress={toggleLogoutDialog}
+                  label={t('logout_dialog.cancel')}
+                />
 
-          {biometryType && biometryEnabled ? (
-            <IconButton onPress={(): void => void handleBiometry()}>
-              <Icon
-                icon={getBiometryIcon(biometryType)}
-                color={colors.primaryColor}
-              />
+                <Button
+                  onPress={logout}
+                  variant="secondary"
+                  label={t('logout_dialog.confirm')}
+                />
+              </>
+            }
+            content={t('logout_dialog.content')}
+            onClose={toggleLogoutDialog}
+            title={t('logout_dialog.title')}
+          />
+        )}
+
+        <Grid container direction="column" justifyContent="space-between">
+          <Grid justifyContent="space-between">
+            <IconButton onPress={toggleLogoutDialog}>
+              <Icon icon={LogoutFlipped} color={colors.primaryColor} />
             </IconButton>
-          ) : null}
-        </Grid>
 
-        <Grid alignItems="center" direction="column">
-          <Icon icon={CozyCircle} style={{ marginBottom: 14 }} />
-
-          <Typography variant="h4" color="primary">
-            {mode === 'password' ? t('screens.lock.title') : null}
-            {mode === 'PIN' ? t('screens.lock.pin_title') : null}
-          </Typography>
-
-          <Typography
-            color="primary"
-            style={{ opacity: 0.64, marginBottom: 24 }}
-            variant="body2"
-          >
-            {fqdn}
-          </Typography>
-
-          <Tooltip title={uiError}>
-            {mode === 'password' ? (
-              <TextField
-                endAdornment={
-                  <IconButton onPress={togglePasswordVisibility}>
-                    <Icon
-                      icon={!passwordVisibility ? EyeClosed : Eye}
-                      color={colors.primaryColor}
-                    />
-                  </IconButton>
-                }
-                label={t('screens.lock.password_label')}
-                onChangeText={handleInput}
-                onSubmitEditing={tryUnlock}
-                returnKeyType="go"
-                secureTextEntry={!passwordVisibility}
-                value={input}
-                autoCapitalize="none"
-              />
+            {biometryType && biometryEnabled ? (
+              <IconButton onPress={(): void => void handleBiometry()}>
+                <Icon
+                  icon={getBiometryIcon(biometryType)}
+                  color={colors.primaryColor}
+                />
+              </IconButton>
             ) : null}
+          </Grid>
 
-            {mode === 'PIN' ? (
-              <TextField
-                endAdornment={
-                  <IconButton onPress={togglePasswordVisibility}>
-                    <Icon
-                      icon={!passwordVisibility ? EyeClosed : Eye}
-                      color={colors.primaryColor}
-                    />
-                  </IconButton>
-                }
-                inputComponent={RnMaskInput}
-                inputComponentProps={{
-                  onChangeText: handleInput,
-                  mask: [[/\d/], [/\d/], [/\d/], [/\d/]]
-                }}
-                keyboardType="numeric"
-                label={t('screens.lock.pin_label')}
-                onSubmitEditing={tryUnlock}
-                returnKeyType="go"
-                secureTextEntry={!passwordVisibility}
-                value={input}
-              />
-            ) : null}
-          </Tooltip>
+          <Grid alignItems="center" direction="column">
+            <Icon icon={CozyCircle} style={{ marginBottom: 14 }} />
 
-          <Link
-            onPress={toggleMode}
-            style={{ alignSelf: 'flex-start', marginVertical: 16 }}
-          >
-            <Typography variant="underline">
-              {mode === 'PIN' ? t('ui.buttons.forgotPin') : null}
-
-              {mode === 'password' ? t('ui.buttons.forgotPassword') : null}
+            <Typography variant="h4" color="primary">
+              {mode === 'password' ? t('screens.lock.title') : null}
+              {mode === 'PIN' ? t('screens.lock.pin_title') : null}
             </Typography>
-          </Link>
-        </Grid>
 
-        <Grid direction="column">
-          <Button onPress={tryUnlock} label={t('ui.buttons.unlock')} />
+            <Typography
+              color="primary"
+              style={{ opacity: 0.64, marginBottom: 24 }}
+              variant="body2"
+            >
+              {fqdn}
+            </Typography>
+
+            <Tooltip title={uiError}>
+              {mode === 'password' ? (
+                <TextField
+                  endAdornment={
+                    <IconButton onPress={togglePasswordVisibility}>
+                      <Icon
+                        icon={!passwordVisibility ? EyeClosed : Eye}
+                        color={colors.primaryColor}
+                      />
+                    </IconButton>
+                  }
+                  label={t('screens.lock.password_label')}
+                  onChangeText={handleInput}
+                  onSubmitEditing={tryUnlock}
+                  returnKeyType="go"
+                  secureTextEntry={!passwordVisibility}
+                  value={input}
+                  autoCapitalize="none"
+                />
+              ) : null}
+
+              {mode === 'PIN' ? (
+                <TextField
+                  endAdornment={
+                    <IconButton onPress={togglePasswordVisibility}>
+                      <Icon
+                        icon={!passwordVisibility ? EyeClosed : Eye}
+                        color={colors.primaryColor}
+                      />
+                    </IconButton>
+                  }
+                  inputComponent={RnMaskInput}
+                  inputComponentProps={{
+                    onChangeText: handleInput,
+                    mask: [[/\d/], [/\d/], [/\d/], [/\d/]]
+                  }}
+                  keyboardType="numeric"
+                  label={t('screens.lock.pin_label')}
+                  onSubmitEditing={tryUnlock}
+                  returnKeyType="go"
+                  secureTextEntry={!passwordVisibility}
+                  value={input}
+                />
+              ) : null}
+            </Tooltip>
+
+            <Link
+              onPress={toggleMode}
+              style={{ alignSelf: 'flex-start', marginVertical: 16 }}
+            >
+              <Typography variant="underline">
+                {mode === 'PIN' ? t('ui.buttons.forgotPin') : null}
+
+                {mode === 'password' ? t('ui.buttons.forgotPassword') : null}
+              </Typography>
+            </Link>
+          </Grid>
+
+          <Grid direction="column">
+            <Button onPress={tryUnlock} label={t('ui.buttons.unlock')} />
+          </Grid>
         </Grid>
-      </Grid>
-    </Container>
+      </Container>
+    </>
   )
 }
 

--- a/src/app/view/Secure/SetPinView.tsx
+++ b/src/app/view/Secure/SetPinView.tsx
@@ -7,7 +7,6 @@ import {
   KeyboardAvoidingView
 } from 'react-native'
 import RnMaskInput from 'react-native-mask-input'
-import { FullWindowOverlay } from 'react-native-screens'
 
 import { savePinCode } from '/app/domain/authorization/services/SecurityService'
 import { Container } from '/ui/Container'
@@ -20,7 +19,6 @@ import { IconButton } from '/ui/IconButton'
 import { Eye } from '/ui/Icons/Eye'
 import { EyeClosed } from '/ui/Icons/EyeClosed'
 import { TextField } from '/ui/TextField'
-import { ConditionalWrapper } from '/components/ConditionalWrapper'
 import { palette } from '/ui/palette'
 import { useI18n } from '/locales/i18n'
 import { CozyTheme } from '/ui/CozyTheme/CozyTheme'
@@ -161,26 +159,16 @@ interface SetPinProps {
 }
 
 export const SetPinView = (props: SetPinProps): JSX.Element => (
-  <ConditionalWrapper
-    condition={Platform.OS === 'ios'}
-    wrapper={(children): JSX.Element => (
-      <FullWindowOverlay>{children}</FullWindowOverlay>
-    )}
+  <TouchableWithoutFeedback
+    onPress={Keyboard.dismiss}
+    style={{ backgroundColor: palette.Primary[600], height: '100%' }}
   >
-    <TouchableWithoutFeedback
-      onPress={Keyboard.dismiss}
-      style={{ backgroundColor: palette.Primary[600], height: '100%' }}
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      >
-        <CozyTheme variant="inverted">
-          <SetPinViewSimple
-            {...props}
-            onSuccess={props.route.params.onSuccess}
-          />
-        </CozyTheme>
-      </KeyboardAvoidingView>
-    </TouchableWithoutFeedback>
-  </ConditionalWrapper>
+      <CozyTheme variant="inverted">
+        <SetPinViewSimple {...props} onSuccess={props.route.params.onSuccess} />
+      </CozyTheme>
+    </KeyboardAvoidingView>
+  </TouchableWithoutFeedback>
 )

--- a/src/ui/CozyDialogs/ConfirmDialog.tsx
+++ b/src/ui/CozyDialogs/ConfirmDialog.tsx
@@ -8,15 +8,44 @@ import { Typography } from '/ui/Typography'
 import { styles } from '/ui/CozyDialogs/styles'
 
 interface ConfirmDialogProps {
+  /**
+   * Actions to be displayed in the footer of the dialog. This can be a single React element
+   * or an array of elements, typically buttons that the user can interact with.
+   */
   actions:
     | ReactElement<{
         children: ReactElement<{ style: StyleProp<ViewStyle> }>[]
       }>
     | ReactElement<{ style: StyleProp<ViewStyle> }>
+
+  /**
+   * Content of the dialog. This can be a simple string or a React element for more complex content.
+   */
   content: string | ReactElement
+
+  /**
+   * A function that will be called when the dialog is requested to be closed. This does not
+   * handle the closing itself, which should be controlled by the parent component's state.
+   */
   onClose: () => void
+
+  /**
+   * Optional title text to be displayed at the top of the dialog.
+   */
   title?: string
+
+  /**
+   * Optional style or styles to apply to the header component of the dialog. Can be used to
+   * customize the appearance of the dialog's header.
+   */
   headerStyle?: StyleProp<ViewStyle>
+
+  /**
+   * Optional boolean that determines whether the native Modal component should be used.
+   * If true, the native Modal will be used (default behaviour); otherwise if false, a custom non-native overlay will be used.
+   * This allows for greater flexibility in cases where the native Modal may conflict with other libraries.
+   */
+  native?: boolean
 }
 
 const renderActions = (
@@ -41,34 +70,72 @@ const renderActions = (
   return actions
 }
 
+const ModalContent = ({
+  onClose,
+  title,
+  headerStyle,
+  content,
+  actions
+}: Partial<ConfirmDialogProps>): JSX.Element => (
+  <>
+    <Pressable style={styles.dialog}>
+      <View style={[styles.header, headerStyle]}>
+        <Typography variant="h3">{title}</Typography>
+
+        <IconButton onPress={onClose}>
+          <Icon icon={Cross} />
+        </IconButton>
+      </View>
+
+      <View style={styles.content}>
+        {typeof content === 'string' ? (
+          <Typography>{content}</Typography>
+        ) : (
+          content
+        )}
+      </View>
+
+      <View style={styles.footer}>{actions && renderActions(actions)}</View>
+    </Pressable>
+  </>
+)
+
 export const ConfirmDialog = ({
   actions,
   content,
   onClose,
   title,
-  headerStyle
-}: ConfirmDialogProps): JSX.Element => (
-  <Modal onRequestClose={onClose} statusBarTranslucent transparent>
-    <Pressable style={styles.dialogContainer} onPress={onClose}>
-      <View style={styles.dialog}>
-        <View style={[styles.header, headerStyle]}>
-          <Typography variant="h3">{title}</Typography>
-
-          <IconButton onPress={onClose}>
-            <Icon icon={Cross} />
-          </IconButton>
+  headerStyle,
+  native = true
+}: ConfirmDialogProps): JSX.Element => {
+  // The common modal content component
+  const modalContent = (
+    <View style={styles.overlay}>
+      <Pressable style={styles.overlayBackground} onPress={onClose}>
+        <View style={styles.dialogContainer}>
+          <ModalContent
+            onClose={onClose}
+            title={title}
+            headerStyle={headerStyle}
+            content={content}
+            actions={actions}
+          />
         </View>
+      </Pressable>
+    </View>
+  )
 
-        <View style={styles.content}>
-          {typeof content === 'string' ? (
-            <Typography>{content}</Typography>
-          ) : (
-            content
-          )}
-        </View>
+  // Render the native Modal if the `native` prop is true, default behaviour
+  if (native) {
+    return (
+      <Modal onRequestClose={onClose} statusBarTranslucent transparent>
+        {modalContent}
+      </Modal>
+    )
+  }
 
-        <View style={styles.footer}>{renderActions(actions)}</View>
-      </View>
-    </Pressable>
-  </Modal>
-)
+  // Otherwise, render directly the modal content
+  // This should be avoided if possible, because it can't guarantee that the modal will be displayed on top of other components
+  // (use it if the native modal can't be displayed or can't be seen at all)
+  return modalContent
+}

--- a/src/ui/CozyDialogs/ConfirmDialog.tsx
+++ b/src/ui/CozyDialogs/ConfirmDialog.tsx
@@ -4,8 +4,9 @@ import { Modal, Pressable, StyleProp, View, ViewStyle } from 'react-native'
 import { Cross } from '/ui/Icons/Cross'
 import { Icon } from '/ui/Icon'
 import { IconButton } from '/ui/IconButton'
-import { Typography } from '/ui/Typography'
+import { Typography, TypographyColor } from '/ui/Typography'
 import { styles } from '/ui/CozyDialogs/styles'
+import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
 
 interface ConfirmDialogProps {
   /**
@@ -76,29 +77,40 @@ const ModalContent = ({
   headerStyle,
   content,
   actions
-}: Partial<ConfirmDialogProps>): JSX.Element => (
-  <>
-    <Pressable style={styles.dialog}>
-      <View style={[styles.header, headerStyle]}>
-        <Typography variant="h3">{title}</Typography>
+}: Partial<ConfirmDialogProps>): JSX.Element => {
+  const { colors } = useCozyTheme()
 
-        <IconButton onPress={onClose}>
-          <Icon icon={Cross} />
-        </IconButton>
-      </View>
+  return (
+    <>
+      <Pressable style={styles.dialog}>
+        <View style={[styles.header, headerStyle]}>
+          <Typography
+            variant="h3"
+            color={colors.primaryTextColor as TypographyColor}
+          >
+            {title}
+          </Typography>
 
-      <View style={styles.content}>
-        {typeof content === 'string' ? (
-          <Typography>{content}</Typography>
-        ) : (
-          content
-        )}
-      </View>
+          <IconButton onPress={onClose}>
+            <Icon icon={Cross} />
+          </IconButton>
+        </View>
 
-      <View style={styles.footer}>{actions && renderActions(actions)}</View>
-    </Pressable>
-  </>
-)
+        <View style={styles.content}>
+          {typeof content === 'string' ? (
+            <Typography color={colors.primaryTextColor as TypographyColor}>
+              {content}
+            </Typography>
+          ) : (
+            content
+          )}
+        </View>
+
+        <View style={styles.footer}>{actions && renderActions(actions)}</View>
+      </Pressable>
+    </>
+  )
+}
 
 export const ConfirmDialog = ({
   actions,

--- a/src/ui/CozyDialogs/ConfirmDialog.tsx
+++ b/src/ui/CozyDialogs/ConfirmDialog.tsx
@@ -4,9 +4,8 @@ import { Modal, Pressable, StyleProp, View, ViewStyle } from 'react-native'
 import { Cross } from '/ui/Icons/Cross'
 import { Icon } from '/ui/Icon'
 import { IconButton } from '/ui/IconButton'
-import { Typography, TypographyColor } from '/ui/Typography'
+import { Typography } from '/ui/Typography'
 import { styles } from '/ui/CozyDialogs/styles'
-import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
 
 interface ConfirmDialogProps {
   /**
@@ -77,40 +76,27 @@ const ModalContent = ({
   headerStyle,
   content,
   actions
-}: Partial<ConfirmDialogProps>): JSX.Element => {
-  const { colors } = useCozyTheme()
+}: Partial<ConfirmDialogProps>): JSX.Element => (
+  <Pressable style={styles.dialog}>
+    <View style={[styles.header, headerStyle]}>
+      <Typography variant="h3">{title}</Typography>
 
-  return (
-    <>
-      <Pressable style={styles.dialog}>
-        <View style={[styles.header, headerStyle]}>
-          <Typography
-            variant="h3"
-            color={colors.primaryTextColor as TypographyColor}
-          >
-            {title}
-          </Typography>
+      <IconButton onPress={onClose}>
+        <Icon icon={Cross} />
+      </IconButton>
+    </View>
 
-          <IconButton onPress={onClose}>
-            <Icon icon={Cross} />
-          </IconButton>
-        </View>
+    <View style={styles.content}>
+      {typeof content === 'string' ? (
+        <Typography>{content}</Typography>
+      ) : (
+        content
+      )}
+    </View>
 
-        <View style={styles.content}>
-          {typeof content === 'string' ? (
-            <Typography color={colors.primaryTextColor as TypographyColor}>
-              {content}
-            </Typography>
-          ) : (
-            content
-          )}
-        </View>
-
-        <View style={styles.footer}>{actions && renderActions(actions)}</View>
-      </Pressable>
-    </>
-  )
-}
+    <View style={styles.footer}>{actions && renderActions(actions)}</View>
+  </Pressable>
+)
 
 export const ConfirmDialog = ({
   actions,

--- a/src/ui/CozyDialogs/styles.ts
+++ b/src/ui/CozyDialogs/styles.ts
@@ -24,13 +24,22 @@ export const styles = StyleSheet.create({
     width: '100%'
   },
   dialogContainer: {
-    alignItems: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    display: 'flex',
+    width: '100%',
     height: '100%',
+    margin: 0,
+    alignItems: 'center',
     justifyContent: 'center',
-    padding: 24,
-    width: '100%'
+    padding: 24
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1000
+  },
+  overlayBackground: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)'
   },
   footer: {
     display: 'flex',

--- a/src/ui/CozyTheme/CozyTheme.tsx
+++ b/src/ui/CozyTheme/CozyTheme.tsx
@@ -10,7 +10,9 @@ interface CozyThemeState {
   variant: CozyThemeVariant
 }
 
-export const CozyThemeContext = createContext<CozyThemeState>({
+// We'll consider the context as possibly undefined
+// This will allow us to use the runtime hook with a fallback value and correctly type it
+export const CozyThemeContext = createContext<CozyThemeState | undefined>({
   variant: 'normal'
 })
 
@@ -38,9 +40,10 @@ export const useCozyTheme = (
 ): CozyThemeHook => {
   const context = useContext(CozyThemeContext)
 
+  // Using optional chaining here to avoid a runtime error
   const colors = useMemo<CozyThemeColors>(
-    () => getColors(forcedVariant ? forcedVariant : context.variant),
-    [forcedVariant, context.variant]
+    () => getColors(forcedVariant ? forcedVariant : context?.variant),
+    [forcedVariant, context?.variant]
   )
 
   if (forcedVariant) {

--- a/src/ui/Typography/index.tsx
+++ b/src/ui/Typography/index.tsx
@@ -22,7 +22,7 @@ type TypographyVariant =
   | 'underline'
   | 'link'
 
-export type TypographyColor =
+type TypographyColor =
   | 'initial'
   | 'inherit'
   | 'primary'

--- a/src/ui/Typography/index.tsx
+++ b/src/ui/Typography/index.tsx
@@ -22,7 +22,7 @@ type TypographyVariant =
   | 'underline'
   | 'link'
 
-type TypographyColor =
+export type TypographyColor =
   | 'initial'
   | 'inherit'
   | 'primary'


### PR DESCRIPTION
This is needed on screens where we do not have agency in what is displayed on top of the screen. While it may be tempting to use it everywhere for consistency, I believe it's better to rely on the react-native Modal component when possible. This should be used as a last resort where FullWindowOverlay for instance disallow us to display anything above it (on the native UI side).