### PR TITLE
fix: Remove the use of unexpected 'warning' log level

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -525,7 +525,7 @@ export default class Launcher {
 
     const folderPath = await this.getFolderPath(trigger.message?.folder_to_save)
     this.log({
-      level: 'warning',
+      level: 'warn',
       namespace: 'Launcher',
       label: 'saveFiles',
       msg: 'Destination folder removed during konnector execution, trying again'
@@ -626,7 +626,7 @@ export default class Launcher {
 
 /**
  * @typedef ContentScriptLogMessage
- * @property {'debug'|'info'|'warning'|'error'|'critical'} level - Log level
+ * @property {'debug'|'info'|'warn'|'error'|'critical'} level - Log level
  * @property {string} msg             - message content
  * @property {string | null} label     - user defined label
  * @property {string | null} namespace - user defined namespace

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -418,7 +418,7 @@ class ReactNativeLauncher extends Launcher {
       this.log({
         namespace: 'ReactNativeLauncher',
         label: 'fetchAndSaveDebugData',
-        level: 'warning',
+        level: 'warn',
         msg: 'Error while saving debug data : ' + message
       })
     }


### PR DESCRIPTION
And replace it with 'warn'

See cozy/cozy-flagship-app@c6d28d8/src/libs/ReactNativeLauncher.js#L114
for reference

Or else warning messages are displayed as simple log level messages

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

