### PR TITLE
feat: add new render logic for osreceive screen

### DIFF
--- a/src/app/domain/osReceive/models/OsReceiveState.ts
+++ b/src/app/domain/osReceive/models/OsReceiveState.ts
@@ -73,3 +73,7 @@ export interface OsReceiveApiMethods {
 export interface UploadStatus {
   filesToHandle: OsReceiveState['filesToUpload']
 }
+
+export interface FileQueueStatus {
+  hasAllFilesQueued: boolean
+}

--- a/src/app/view/OsReceive/OsReceiveScreen.tsx
+++ b/src/app/view/OsReceive/OsReceiveScreen.tsx
@@ -12,6 +12,7 @@ import { Radio } from '/ui/Radio'
 import { Typography } from '/ui/Typography'
 import {
   useAppsForUpload,
+  useFilesQueueStatus,
   useFilesToUpload
 } from '/app/view/OsReceive/state/OsReceiveState'
 import {
@@ -32,6 +33,7 @@ import { FileThumbnail } from '/ui/ImageThumbnail'
 
 export const OsReceiveScreen = (): JSX.Element | null => {
   const filesToUpload = useFilesToUpload()
+  const { hasAllFilesQueued } = useFilesQueueStatus()
   const appsForUpload = useAppsForUpload()
   const { t } = useI18n()
   const {
@@ -47,7 +49,8 @@ export const OsReceiveScreen = (): JSX.Element | null => {
   const isSingleFile = filesToUpload.length === 1
   const isMultipleFiles = filesToUpload.length > 1
   const shouldRender =
-    hasFilesToUpload && appsForUpload && appsForUpload.length > 0
+    (hasFilesToUpload && appsForUpload && appsForUpload.length > 0) ||
+    hasAllFilesQueued
 
   if (!shouldRender) return null
 
@@ -92,7 +95,7 @@ export const OsReceiveScreen = (): JSX.Element | null => {
               </ListSubHeader>
             }
           >
-            {appsForUpload.map((app, index) => (
+            {appsForUpload?.map((app, index) => (
               <React.Fragment key={app.slug}>
                 <ListItem
                   button={!app.reasonDisabled && app.slug !== selectedOption}

--- a/src/app/view/OsReceive/state/OsReceiveState.ts
+++ b/src/app/view/OsReceive/state/OsReceiveState.ts
@@ -10,7 +10,8 @@ import {
   OsReceiveAction,
   OsReceiveActionType,
   OsReceiveFile,
-  OsReceiveFileStatus
+  OsReceiveFileStatus,
+  FileQueueStatus
 } from '/app/domain/osReceive/models/OsReceiveState'
 import { getAppsForUpload } from '/app/domain/osReceive/services/OsReceiveCandidateApps'
 import { AppForUpload } from '/app/domain/osReceive/models/OsReceiveCozyApp'
@@ -132,6 +133,16 @@ export const useFilesToUpload = (): OsReceiveFile[] => {
   return state.filesToUpload.filter(
     file => file.status === OsReceiveFileStatus.toUpload
   )
+}
+
+export const useFilesQueueStatus = (): FileQueueStatus => {
+  const state = useOsReceiveState()
+
+  return {
+    hasAllFilesQueued: state.filesToUpload.every(
+      file => file.status === OsReceiveFileStatus.queued
+    )
+  }
 }
 
 export const useAppsForUpload = (): AppForUpload[] | undefined => {


### PR DESCRIPTION
To avoid screen flashing, always display the screen
if all files in upload queue are in queued status
(meaning no upload started yet)