### PR TITLE
fix: check filesToUpload length before  queue

### DIFF
--- a/src/app/view/OsReceive/state/OsReceiveState.ts
+++ b/src/app/view/OsReceive/state/OsReceiveState.ts
@@ -139,9 +139,11 @@ export const useFilesQueueStatus = (): FileQueueStatus => {
   const state = useOsReceiveState()
 
   return {
-    hasAllFilesQueued: state.filesToUpload.every(
-      file => file.status === OsReceiveFileStatus.queued
-    )
+    hasAllFilesQueued:
+      state.filesToUpload.length > 0 &&
+      state.filesToUpload.every(
+        file => file.status === OsReceiveFileStatus.queued
+      )
   }
 }
 


### PR DESCRIPTION
```ts
state.filesToUpload.every(
        file => file.status === OsReceiveFileStatus.queued
      )
```
This returned `true` when given an empty array
Indeed using every() on an empty array will return true
