### PR TITLE
feat(backup): Improve dedup algorithm to work with old backup

### DIFF
--- a/src/app/domain/backup/services/manageRemoteBackupConfig.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.ts
@@ -244,15 +244,45 @@ export const createRemoteBackupFolder = async (
   return remoteBackupConfig
 }
 
-const isFileCorrespondingToMedia = (file: File, media: Media): boolean => {
-  const creationDate = new Date(
-    file?.metadata?.creationDateFromLibrary ?? file.created_at
-  )
-  creationDate.setMilliseconds(0)
+export const isFileCorrespondingToMedia = (
+  file: File,
+  media: Media
+): boolean => {
+  const creationDateFromLibrary = file.metadata?.creationDateFromLibrary
 
-  return (
-    file.name === media.name && creationDate.getTime() === media.creationDate
-  )
+  /* File come from the new backup */
+
+  if (creationDateFromLibrary) {
+    const creationDate = new Date(creationDateFromLibrary)
+    creationDate.setMilliseconds(0)
+
+    return (
+      file.name === media.name && creationDate.getTime() === media.creationDate
+    )
+  }
+
+  if (flag('flagship.backup.dedup')) {
+    const creationDate = new Date(file.created_at)
+    creationDate.setMilliseconds(0)
+
+    const mediaCreationDate = new Date(media.creationDate)
+
+    return (
+      file.name === media.name &&
+      creationDate.getFullYear() === mediaCreationDate.getFullYear() &&
+      creationDate.getMonth() === mediaCreationDate.getMonth() &&
+      creationDate.getDate() === mediaCreationDate.getDate() &&
+      creationDate.getMinutes() === mediaCreationDate.getMinutes() &&
+      creationDate.getSeconds() === mediaCreationDate.getSeconds()
+    )
+  } else {
+    const creationDate = new Date(file.created_at)
+    creationDate.setMilliseconds(0)
+
+    return (
+      file.name === media.name && creationDate.getTime() === media.creationDate
+    )
+  }
 }
 
 const formatBackupedMedia = (


### PR DESCRIPTION
Dedup in photo backup means that we do not upload pictures if they already exists in the Cozy.

To identify if two pictures are identical, we compare name and creation date.

For new backup, we compare with our own creation date added in the io.cozy.files metadata. It just works.

But in photo uploaded by old backup, we compare with the creation date that has been taken from EXIF and can  where the timezone could have been badly managed. So if we compare stricly date, it may not work.

So here we compare only part of the date in dedup mode by ignoring the "hour" field :
- its almost impossible to have a false identity by just ignoring the "hour" field => OK
- we can miss some identity => but we accept that our dedup is not 100% accurate
