### PR TITLE
fix: get correct route object in security flow

### DIFF
--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -21,11 +21,7 @@ import {
 import { getDevModeFunctions } from '/app/domain/authorization/utils/devMode'
 import { routes } from '/constants/routes'
 import { devlog, shouldDisableAutolock } from '/core/tools/env'
-import {
-  getCurrentRouteName,
-  navigate,
-  navigationRef
-} from '/libs/RootNavigation'
+import { getCurrentRoute, navigate, navigationRef } from '/libs/RootNavigation'
 import { getInstanceAndFqdnFromClient } from '/libs/client'
 import { authConstants } from '/app/domain/authorization/constants'
 import { safePromise } from '/utils/safePromise'
@@ -308,7 +304,7 @@ const tryLockingApp = async (
 export const handleSecurityFlowWakeUp = async (
   client: CozyClient
 ): Promise<void> => {
-  const currentRoute = getCurrentRouteName()
+  const currentRoute = getCurrentRoute()
   let parsedRoute: Route<string, { href: string; slug: string }>
 
   try {

--- a/src/libs/RootNavigation.ts
+++ b/src/libs/RootNavigation.ts
@@ -1,6 +1,7 @@
 import {
   createNavigationContainerRef,
-  CommonActions
+  CommonActions,
+  Route
 } from '@react-navigation/native'
 
 import Minilog from 'cozy-minilog'
@@ -9,6 +10,14 @@ const log = Minilog('RootNavigation')
 
 export const navigationRef =
   createNavigationContainerRef<Record<string, unknown>>()
+
+export const getCurrentRoute = (): Route<string> | null => {
+  if (!navigationRef.isReady()) {
+    return null
+  }
+
+  return navigationRef.getCurrentRoute() ?? null
+}
 
 export const getCurrentRouteName = (): string | null => {
   if (!navigationRef.isReady()) {


### PR DESCRIPTION
A recent change was getting route name instead of route object.
Thus we didn't have the slug and it was silently failing and
redirecting to home screen when coming back after background mode.
