### PR TITLE
feat: Send existing files index to pilot fetch

### DIFF
--- a/src/app/domain/manifest/permissions.ts
+++ b/src/app/domain/manifest/permissions.ts
@@ -1,0 +1,11 @@
+import { KonnectorsDocument } from 'cozy-client/types/types'
+
+export const hasPermission = (
+  konnector: KonnectorsDocument,
+  permission: string
+): boolean => {
+  return Object.values(konnector.permissions ?? []).some(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    perm => perm?.type === permission // Unsafe member access .type on an `any` value
+  )
+}

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -22,6 +22,7 @@ import {
   activateKeepAwake,
   deactivateKeepAwake
 } from '/app/domain/sleep/services/sleep'
+import { hasPermission } from '/app/domain/manifest/permissions'
 
 const log = Minilog('ReactNativeLauncher')
 
@@ -345,6 +346,13 @@ class ReactNativeLauncher extends Launcher {
         trigger,
         job,
         sourceAccountIdentifier
+      }
+
+      if (hasPermission(manifest, 'io.cozy.files')) {
+        const existingFilesIndex = await this.getExistingFilesIndex()
+        const serializableExistingFilesIndex =
+          Object.fromEntries(existingFilesIndex)
+        pilotContext.existingFilesIndex = serializableExistingFilesIndex
       }
       await this.pilot.call('fetch', pilotContext)
       await this.stop()


### PR DESCRIPTION
This index is sent only if the konnector has a permission on
io.cozy.files, to avoid unneccessary requests.

This existing files index is needed to have `shouldReplaceFile`
functionnal in konnectors. But shouldReplaceFile won't throw if it is
not present.

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

