### PR TITLE
Manage geolocation tracking quota

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "cozy-client": "^45.4.0",
     "cozy-clisk": "^0.30.0",
     "cozy-device-helper": "^2.7.0",
-    "cozy-flags": "^2.12.0",
+    "cozy-flags": "^3.2.0",
     "cozy-intent": "^2.19.0",
     "cozy-logger": "^1.10.0",
     "cozy-minilog": "3.3.1",

--- a/src/@types/cozy-flags.d.ts
+++ b/src/@types/cozy-flags.d.ts
@@ -1,4 +1,0 @@
-declare module 'cozy-flags' {
-  const flag: (name: string) => boolean
-  export default flag
-}

--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -32,8 +32,9 @@ type CameraRollCursor = string | undefined
 const getPhotoIdentifiersPage = async (
   after: CameraRollCursor
 ): Promise<PhotoIdentifiersPage> => {
-  const shouldIncludeSharedAlbums =
-    flag('flagship.backup.includeSharedAlbums') || false
+  const shouldIncludeSharedAlbums = !!flag(
+    'flagship.backup.includeSharedAlbums'
+  )
 
   const photoIdentifiersPage = await CameraRoll.getPhotos({
     first: MEDIAS_BY_PAGE,

--- a/src/app/domain/backup/services/manageAlbums.ts
+++ b/src/app/domain/backup/services/manageAlbums.ts
@@ -28,8 +28,9 @@ export const areAlbumsEnabled = (): boolean => {
 }
 
 export const getAlbums = async (): Promise<Album[]> => {
-  const shouldIncludeSharedAlbums =
-    flag('flagship.backup.includeSharedAlbums') || false
+  const shouldIncludeSharedAlbums = !!flag(
+    'flagship.backup.includeSharedAlbums'
+  )
 
   const cameraRollAlbums = await CameraRoll.getAlbums()
   const albums = cameraRollAlbums

--- a/src/app/domain/geolocation/helpers/quota.ts
+++ b/src/app/domain/geolocation/helpers/quota.ts
@@ -45,7 +45,7 @@ const getFirstTimeserie = async (
     } else {
       const { data } = (await client.fetchQueryAndGetFromState({
         definition: Q('io.cozy.timeseries.geojson')
-          .where({ _id: { $gt: null } })
+          .where({ startDate: { $gt: null } })
           .select(['_id', 'startDate'])
           .indexFields(['startDate'])
           .sortBy([{ startDate: 'asc' }])

--- a/src/app/domain/geolocation/helpers/quota.ts
+++ b/src/app/domain/geolocation/helpers/quota.ts
@@ -3,6 +3,7 @@ import { differenceInDays } from 'date-fns'
 import { Q } from 'cozy-client'
 import CozyClient from 'cozy-client'
 import flag from 'cozy-flags'
+import Minilog from 'cozy-minilog'
 
 import { showLocalNotification } from '/libs/notifications/notifications'
 import { t } from '/locales/i18n'
@@ -10,6 +11,8 @@ import { getData, storeData, StorageKeys } from '/libs/localStore/storage'
 
 const MAX_DAYS_TO_CAPTURE_UNLIMITED = -1
 const ONE_DAY = 24 * 60 * 60 * 1000
+
+const log = Minilog('📍 Geolocation')
 
 export interface FirstTimeserie {
   id: string
@@ -60,6 +63,7 @@ export const isGeolocationQuotaExceeded = async (
       await storeData(StorageKeys.FirstTimeserie, firstTimeserie)
     }
   } catch (error) {
+    log.warn('Failed to get or fetch first timeserie', error)
     return false
   }
 

--- a/src/app/domain/geolocation/helpers/quota.ts
+++ b/src/app/domain/geolocation/helpers/quota.ts
@@ -4,6 +4,9 @@ import { Q } from 'cozy-client'
 import CozyClient from 'cozy-client'
 import flag from 'cozy-flags'
 
+import { showLocalNotification } from '/libs/notifications/notifications'
+import { t } from '/locales/i18n'
+
 const MAX_DAYS_TO_CAPTURE_UNLIMITED = -1
 const ONE_DAY = 24 * 60 * 60 * 1000
 interface FirstTimeserie {
@@ -55,4 +58,25 @@ export const isGeolocationQuotaExceeded = async (
   )
 
   return daysSinceFirstCapture > maxDaysToCapture
+}
+
+export const showQuotaExceededNotification = async (): Promise<void> => {
+  const maxDaysToCapture = flag('coachco2.max-days-to-capture') as number | null
+
+  if (typeof maxDaysToCapture !== 'number') {
+    return
+  }
+
+  await showLocalNotification({
+    title: t('services.geolocationTracking.quotaExceededNotificationTitle'),
+    body: t(
+      'services.geolocationTracking.quotaExceededNotificationDescription',
+      {
+        days: maxDaysToCapture.toString()
+      }
+    ),
+    data: {
+      redirectLink: 'coachco2/'
+    }
+  })
 }

--- a/src/app/domain/geolocation/helpers/quota.ts
+++ b/src/app/domain/geolocation/helpers/quota.ts
@@ -1,0 +1,58 @@
+import { differenceInDays } from 'date-fns'
+
+import { Q } from 'cozy-client'
+import CozyClient from 'cozy-client'
+import flag from 'cozy-flags'
+
+const MAX_DAYS_TO_CAPTURE_UNLIMITED = -1
+const ONE_DAY = 24 * 60 * 60 * 1000
+interface FirstTimeserie {
+  id: string
+  _id: string
+  type: string
+  startDate: string
+  }[]
+}
+
+export const isGeolocationQuotaExceeded = async (
+  client: CozyClient
+): Promise<boolean> => {
+  const maxDaysToCapture = flag('coachco2.max-days-to-capture') as number | null
+
+  if (
+    typeof maxDaysToCapture !== 'number' ||
+    maxDaysToCapture === MAX_DAYS_TO_CAPTURE_UNLIMITED
+  ) {
+    return false
+  }
+
+  let firstTimeserie
+
+  try {
+    const { data } = (await client.fetchQueryAndGetFromState({
+      definition: Q('io.cozy.timeseries.geojson')
+        .where({ _id: { $gt: null } })
+        .select(['_id', 'startDate'])
+        .indexFields(['startDate'])
+        .sortBy([{ startDate: 'asc' }])
+        .limitBy(1),
+      options: {
+        as: 'io.cozy.timeseries.geojson/firstTimeserie',
+        fetchPolicy: CozyClient.fetchPolicies.olderThan(ONE_DAY)
+      }
+    })) as unknown as { data: FirstTimeserie[] }
+
+    if (data.length === 0) return false
+
+    firstTimeserie = data[0]
+  } catch (error) {
+    return false
+  }
+
+  const daysSinceFirstCapture = differenceInDays(
+    new Date(),
+    new Date(firstTimeserie.startDate)
+  )
+
+  return daysSinceFirstCapture > maxDaysToCapture
+}

--- a/src/app/domain/geolocation/helpers/quota.ts
+++ b/src/app/domain/geolocation/helpers/quota.ts
@@ -8,6 +8,7 @@ import Minilog from 'cozy-minilog'
 import { showLocalNotification } from '/libs/notifications/notifications'
 import { t } from '/locales/i18n'
 import { getData, storeData, StorageKeys } from '/libs/localStore/storage'
+import { setGeolocationTracking } from '/app/domain/geolocation/services/tracking'
 
 const MAX_DAYS_TO_CAPTURE_UNLIMITED = -1
 const ONE_DAY = 24 * 60 * 60 * 1000
@@ -115,4 +116,16 @@ export const showQuotaExceededNotification = async (): Promise<void> => {
       redirectLink: 'coachco2/'
     }
   })
+}
+
+export const checkGeolocationQuota = async (
+  client: CozyClient
+): Promise<void> => {
+  const quotaExceeded = await isGeolocationQuotaExceeded(client)
+
+  if (quotaExceeded) {
+    log.debug('Geolocation quota exceeded')
+    await setGeolocationTracking(false)
+    await showQuotaExceededNotification()
+  }
 }

--- a/src/app/domain/geolocation/helpers/quota.ts
+++ b/src/app/domain/geolocation/helpers/quota.ts
@@ -21,14 +21,24 @@ export interface FirstTimeserie {
   startDate: string
 }
 
+const isMaxDaysToCaptureInvalid = (
+  maxDaysToCapture: number | null
+): maxDaysToCapture is null => {
+  return typeof maxDaysToCapture !== 'number'
+}
+
+const isMaxDaysToCaptureUnlimited = (maxDaysToCapture: number): boolean => {
+  return maxDaysToCapture === MAX_DAYS_TO_CAPTURE_UNLIMITED
+}
+
 export const isGeolocationQuotaExceeded = async (
   client: CozyClient
 ): Promise<boolean> => {
   const maxDaysToCapture = flag('coachco2.max-days-to-capture') as number | null
 
   if (
-    typeof maxDaysToCapture !== 'number' ||
-    maxDaysToCapture === MAX_DAYS_TO_CAPTURE_UNLIMITED
+    isMaxDaysToCaptureInvalid(maxDaysToCapture) ||
+    isMaxDaysToCaptureUnlimited(maxDaysToCapture)
   ) {
     return false
   }
@@ -78,7 +88,10 @@ export const isGeolocationQuotaExceeded = async (
 export const showQuotaExceededNotification = async (): Promise<void> => {
   const maxDaysToCapture = flag('coachco2.max-days-to-capture') as number | null
 
-  if (typeof maxDaysToCapture !== 'number') {
+  if (
+    isMaxDaysToCaptureInvalid(maxDaysToCapture) ||
+    isMaxDaysToCaptureUnlimited(maxDaysToCapture)
+  ) {
     return
   }
 

--- a/src/app/domain/geolocation/hooks/tracking.ts
+++ b/src/app/domain/geolocation/hooks/tracking.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { useClient } from 'cozy-client'
 
 import {
+  isGeolocationTrackingEnabled,
   getShouldStartTracking,
   setGeolocationTracking
 } from '/app/domain/geolocation/services/tracking'
@@ -14,10 +15,14 @@ export const useGeolocationTracking = (): void => {
     const initializeTracking = async (): Promise<void> => {
       if (!client) return
 
-      const shouldStartTracking = (await getShouldStartTracking()) as boolean
+      const trackingEnabled = await isGeolocationTrackingEnabled()
 
-      if (shouldStartTracking) {
-        await setGeolocationTracking(true)
+      if (!trackingEnabled) {
+        const shouldStartTracking = (await getShouldStartTracking()) as boolean
+
+        if (shouldStartTracking) {
+          await setGeolocationTracking(true)
+        }
       }
     }
 

--- a/src/app/domain/geolocation/hooks/tracking.ts
+++ b/src/app/domain/geolocation/hooks/tracking.ts
@@ -8,10 +8,7 @@ import {
   getShouldStartTracking,
   setGeolocationTracking
 } from '/app/domain/geolocation/services/tracking'
-import {
-  isGeolocationQuotaExceeded,
-  showQuotaExceededNotification
-} from '/app/domain/geolocation/helpers/quota'
+import { checkGeolocationQuota } from '/app/domain/geolocation/helpers/quota'
 
 const log = Minilog('📍 Geolocation')
 
@@ -25,14 +22,7 @@ export const useGeolocationTracking = (): void => {
       const trackingEnabled = await isGeolocationTrackingEnabled()
 
       if (trackingEnabled) {
-        const quotaExceeded = await isGeolocationQuotaExceeded(client)
-
-        if (quotaExceeded) {
-          log.debug('Geolocation quota exceeded')
-          await setGeolocationTracking(false)
-          await showQuotaExceededNotification()
-          return
-        }
+        await checkGeolocationQuota(client)
       } else {
         const shouldStartTracking = (await getShouldStartTracking()) as boolean
 

--- a/src/app/domain/geolocation/hooks/tracking.ts
+++ b/src/app/domain/geolocation/hooks/tracking.ts
@@ -8,7 +8,10 @@ import {
   getShouldStartTracking,
   setGeolocationTracking
 } from '/app/domain/geolocation/services/tracking'
-import { isGeolocationQuotaExceeded } from '/app/domain/geolocation/helpers/quota'
+import {
+  isGeolocationQuotaExceeded,
+  showQuotaExceededNotification
+} from '/app/domain/geolocation/helpers/quota'
 
 const log = Minilog('📍 Geolocation')
 
@@ -27,6 +30,7 @@ export const useGeolocationTracking = (): void => {
         if (quotaExceeded) {
           log.debug('Geolocation quota exceeded')
           await setGeolocationTracking(false)
+          await showQuotaExceededNotification()
           return
         }
       } else {

--- a/src/app/domain/geolocation/hooks/tracking.ts
+++ b/src/app/domain/geolocation/hooks/tracking.ts
@@ -1,16 +1,12 @@
 import { useEffect } from 'react'
 
 import { useClient } from 'cozy-client'
-import Minilog from 'cozy-minilog'
 
 import {
   isGeolocationTrackingEnabled,
-  getShouldStartTracking,
-  setGeolocationTracking
+  checkShouldStartTracking
 } from '/app/domain/geolocation/services/tracking'
 import { checkGeolocationQuota } from '/app/domain/geolocation/helpers/quota'
-
-const log = Minilog('📍 Geolocation')
 
 export const useGeolocationTracking = (): void => {
   const client = useClient()
@@ -24,13 +20,7 @@ export const useGeolocationTracking = (): void => {
       if (trackingEnabled) {
         await checkGeolocationQuota(client)
       } else {
-        const shouldStartTracking = (await getShouldStartTracking()) as boolean
-
-        if (shouldStartTracking) {
-          log.debug('Restarting geolocation tracking')
-          await setGeolocationTracking(true)
-          return
-        }
+        await checkShouldStartTracking()
       }
     }
 

--- a/src/app/domain/geolocation/services/tracking.ts
+++ b/src/app/domain/geolocation/services/tracking.ts
@@ -13,6 +13,9 @@ import {
 import { isGeolocationQuotaExceeded } from '/app/domain/geolocation/helpers/quota'
 
 import CozyClient from 'cozy-client/types/CozyClient'
+import Minilog from 'cozy-minilog'
+
+const log = Minilog('📍 Geolocation')
 
 export { stopTrackingAndClearData, getShouldStartTracking }
 
@@ -65,5 +68,14 @@ export const getGeolocationTrackingStatus = async (
   return {
     enabled: await isGeolocationTrackingEnabled(),
     quotaExceeded: await isGeolocationQuotaExceeded(client)
+  }
+}
+
+export const checkShouldStartTracking = async (): Promise<void> => {
+  const shouldStartTracking = (await getShouldStartTracking()) as boolean
+
+  if (shouldStartTracking) {
+    log.debug('Restarting geolocation tracking')
+    await setGeolocationTracking(true)
   }
 }

--- a/src/app/domain/geolocation/services/tracking.ts
+++ b/src/app/domain/geolocation/services/tracking.ts
@@ -45,6 +45,12 @@ interface GeolocationTrackingStatus {
   enabled: boolean
 }
 
+export const isGeolocationTrackingEnabled = async (): Promise<boolean> => {
+  const status = await BackgroundGeolocation.getState()
+
+  return status.enabled
+}
+
 export const getGeolocationTrackingStatus =
   async (): Promise<GeolocationTrackingStatus> => {
     const status = await BackgroundGeolocation.getState()

--- a/src/app/domain/limits/checkOauthClientsLimit.spec.ts
+++ b/src/app/domain/limits/checkOauthClientsLimit.spec.ts
@@ -6,7 +6,7 @@ import { checkOauthClientsLimit } from '/app/domain/limits/checkOauthClientsLimi
 jest.mock('cozy-client')
 jest.mock('cozy-flags')
 
-const mockFlag = flag as jest.Mock
+const mockFlag = flag as jest.MockedFunction<typeof flag>
 
 describe('checkOauthClientsLimit', () => {
   let client: CozyClient

--- a/src/libs/clientHelpers/createClient.ts
+++ b/src/libs/clientHelpers/createClient.ts
@@ -57,7 +57,6 @@ export const finalizeClientCreation = async (
 }
 
 const registerPlugins = async (client: CozyClient): Promise<void> => {
-  // @ts-expect-error Plugins are not typed yet
   await client.registerPlugin(flag.plugin, null)
 }
 

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -326,7 +326,7 @@ export const localMethods = (
     checkBackupPermissions,
     requestBackupPermissions,
     setLang,
-    getGeolocationTrackingStatus,
+    getGeolocationTrackingStatus: () => getGeolocationTrackingStatus(client),
     setGeolocationTracking,
     getGeolocationTrackingId,
     setGeolocationTrackingId,

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -2,6 +2,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { BiometryType } from 'react-native-biometrics'
 
 import { logger } from '/libs/functions/logger'
+import type { FirstTimeserie } from '/app/domain/geolocation/helpers/quota'
+
 const log = logger('storage.ts')
 
 const { setItem, getItem, removeItem } = AsyncStorage
@@ -20,7 +22,8 @@ export enum StorageKeys {
   LastStopTransitionTsKey = 'CozyGPSMemory.LastStopTransitionTsKey',
   LastStartTransitionTsKey = 'CozyGPSMemory.LastStartTransitionTsKey',
   GeolocationTrackingConfig = 'CozyGPSMemory.TrackingConfig',
-  Activities = 'CozyGPSMemory.Activities'
+  Activities = 'CozyGPSMemory.Activities',
+  FirstTimeserie = 'CozyGPSMemory.FirstTimeserie'
 }
 
 export type IconsCache = Record<string, { version: string; xml: string }>
@@ -30,6 +33,7 @@ export interface StorageItems {
   biometryType?: BiometryType
   sessionCreatedFlag: string
   iconCache: IconsCache
+  firstTimeserie: FirstTimeserie
 }
 
 export const storeData = async (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -121,7 +121,9 @@
     "geolocationTracking": {
       "androidBackgroundPermissionMessage": "Recording your movements requires to ≪ {backgroundPermissionOptionLabel} ≫",
       "androidNotificationTitle": "Location service on",
-      "androidNotificationDescription": "Your journey will be recorded into your Cozy"
+      "androidNotificationDescription": "Your journey will be recorded into your Cozy",
+      "quotaExceededNotificationTitle": "Journey recording disabled",
+      "quotaExceededNotificationDescription": "You have reached the limit of {{days}} days of journeys included in your offer."
     },
     "osReceive": {
       "documentType": "Document Type:",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -107,7 +107,9 @@
     "geolocationTracking": {
       "androidBackgroundPermissionMessage": "Registrar sus movimientos requiere ≪ {backgroundPermissionOptionLabel} ≫",
       "androidNotificationTitle": "Servicio de localización en",
-      "androidNotificationDescription": "Tu viaje quedará registrado en tu Cozy"
+      "androidNotificationDescription": "Tu viaje quedará registrado en tu Cozy",
+      "quotaExceededNotificationTitle": "Grabación de viaje desactivada",
+      "quotaExceededNotificationDescription": "Ha alcanzado el límite de {{days}} días de viaje incluidos en su oferta."
     },
     "osReceive": {
       "documentType": "Tipo de documento :",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -123,7 +123,9 @@
     "geolocationTracking": {
       "androidBackgroundPermissionMessage": "Mémoriser vos déplacements nécessite de ≪ {backgroundPermissionOptionLabel} ≫",
       "androidNotificationTitle": "Service de localisation actif",
-      "androidNotificationDescription": "Votre déplacement sera enregistré dans votre Cozy"
+      "androidNotificationDescription": "Votre déplacement sera enregistré dans votre Cozy",
+      "quotaExceededNotificationTitle": "Enregistrement des déplacements désactivés",
+      "quotaExceededNotificationDescription": "Vous avez atteint la limite des {{days}} jours de trajets inclus dans votre offre."
     },
     "osReceive": {
       "documentType": "Ajouter dans votre Cozy en tant que :",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7990,10 +7990,10 @@ cozy-device-helper@^2.7.0:
   dependencies:
     lodash "^4.17.19"
 
-cozy-flags@^2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.12.0.tgz#bc3d689db9c91389c28f053223142d4684573ef1"
-  integrity sha512-s0et8aWChaqY4rMKkNKDACflU2h5s6s9UVU1guU3Il9GqktSPrhvMo+ntHLnQb2l+yLL6xV1S6/rK0qniR1q0A==
+cozy-flags@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-3.2.0.tgz#644a9364c7431d43eef0c088793314663e419de3"
+  integrity sha512-SiM53/eOWDkxHKTU5ryUIx5fHTfnaf+GXQ5mTMi3pwGyLL9VW8Rf6l+s7ytJ5GHLQBINGo8TVl97FDkdJPh2Rg==
   dependencies:
     microee "^0.0.6"
 


### PR DESCRIPTION
We added a geolocation tracking quota flag that says "you can save for free up to X days of geolocation tracking data". This is the implementation of the flag on flagship app side. 

=> Disable geolocation tracking at startup if quota exceeded and show a notification
=> Return quota status when front end ask for geolocation tracking status