### PR TITLE
[VIO-129] feat: Extract Lock related screens from router

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import { NavigationContainer } from '@react-navigation/native'
 import { decode, encode } from 'base-64'
 import React, { useEffect, useState } from 'react'
 import { StatusBar, StyleSheet, View } from 'react-native'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
 import FlipperAsyncStorage from 'rn-flipper-async-storage-advanced'
@@ -44,6 +45,7 @@ import {
   useOsReceiveState
 } from '/app/view/OsReceive/state/OsReceiveState'
 import { useOsReceiveApi } from '/app/view/OsReceive/hooks/useOsReceiveApi'
+import { LockScreenWrapper } from '/app/view/Lock/LockScreenWrapper'
 import { useSecureBackgroundSplashScreen } from '/hooks/useSplashScreen'
 import { hideSplashScreen } from '/app/theme/SplashScreenService'
 
@@ -144,7 +146,10 @@ const InnerNav = ({ client, setClient }) => {
         />
         <IconChangedModal />
         <LauncherContextProvider>
-          <App setClient={setClient} />
+          <SafeAreaProvider>
+            <App setClient={setClient} />
+            <LockScreenWrapper />
+          </SafeAreaProvider>
         </LauncherContextProvider>
       </View>
     </NativeIntentProvider>

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -12,10 +12,6 @@ import { OnboardingScreen } from '/screens/login/OnboardingScreen'
 import { WelcomeScreen } from '/screens/welcome/WelcomeScreen'
 import { routes } from '/constants/routes'
 import { OsReceiveScreen } from '/app/view/OsReceive/OsReceiveScreen'
-import { PasswordPrompt } from '/app/view/Secure/PasswordPrompt'
-import { PinPrompt } from '/app/view/Secure/PinPrompt'
-import { SetPasswordView } from '/app/view/Secure/SetPasswordView'
-import { SetPinView } from '/app/view/Secure/SetPinView'
 
 const Root = createStackNavigator()
 const Stack = createStackNavigator()
@@ -110,11 +106,6 @@ export const RootNavigator = ({ initialRoute, setClient }) => (
         animationEnabled: false
       }}
     />
-
-    <Root.Screen name={routes.promptPassword} component={PasswordPrompt} />
-    <Root.Screen name={routes.promptPin} component={PinPrompt} />
-    <Root.Screen name={routes.setPin} component={SetPinView} />
-    <Root.Screen name={routes.setPassword} component={SetPasswordView} />
   </Root.Navigator>
 )
 

--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -1,4 +1,3 @@
-import type { NavigationContainerRef, Route } from '@react-navigation/native'
 import { Platform } from 'react-native'
 
 import CozyClient from 'cozy-client'
@@ -25,13 +24,11 @@ import {
   showSecurityScreen
 } from '/app/view/Lock/useLockScreenWrapper'
 import { devlog, shouldDisableAutolock } from '/core/tools/env'
-import { getCurrentRoute, navigate, navigationRef } from '/libs/RootNavigation'
+import { navigationRef } from '/libs/RootNavigation'
 import { getInstanceAndFqdnFromClient } from '/libs/client'
 import { authConstants } from '/app/domain/authorization/constants'
 import { safePromise } from '/utils/safePromise'
-import { navigateToApp } from '/libs/functions/openApp'
 import { hideSplashScreen, splashScreens } from '/app/theme/SplashScreenService'
-import { SecurityNavigationService } from '/app/domain/authorization/services/SecurityNavigationService'
 import { getData, StorageKeys } from '/libs/localStore'
 
 // Can use mock functions in dev environment
@@ -83,26 +80,8 @@ export const getIsSecurityFlowPassed = async (): Promise<boolean> => {
 }
 
 export const determineSecurityFlow = async (
-  client: CozyClient,
-  navigationObject?: {
-    navigation: NavigationContainerRef<Record<string, unknown>>
-    href: string
-    slug: string
-  },
+  client: CozyClient
 ): Promise<void> => {
-  const callbackNav = async (): Promise<void> => {
-    try {
-      if (navigationObject) {
-        await navigateToApp(navigationObject)
-      } else navigate(routes.home)
-    } catch (error) {
-      devlog('🔏', 'Error navigating to app, defaulting to home', error)
-      navigate(routes.home)
-    } finally {
-      setIsSecurityFlowPassed(true)
-    }
-  }
-
   if (await fns.isAutoLockEnabled()) {
     devlog('🔏', 'Application has autolock activated')
     devlog('🔏', 'Device should be secured or autolock would not work')

--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -51,34 +51,6 @@ const fns = getDevModeFunctions(
   }
 )
 
-let isSecurityFlowPassed = false
-
-export const setIsSecurityFlowPassed = (value: boolean): void => {
-  isSecurityFlowPassed = value
-}
-
-export const getIsSecurityFlowPassed = async (): Promise<boolean> => {
-  if (isSecurityFlowPassed) return isSecurityFlowPassed
-
-  try {
-    const [isSecured, isAutoLock] = await Promise.all([
-      fns.isDeviceSecured(),
-      fns.isAutoLockEnabled()
-    ])
-
-    setIsSecurityFlowPassed(isSecured && !isAutoLock)
-
-    return isSecurityFlowPassed
-  } catch (error) {
-    // This would be a huge error blocking the user from the application
-    // In this case let's assume the security flow is passed to avoid locking the user out
-    // In theory, this should never happen, but async functions can be unpredictable
-    devlog('🔏', 'Error getting security flow status', error)
-    setIsSecurityFlowPassed(true)
-    return isSecurityFlowPassed
-  }
-}
-
 export const determineSecurityFlow = async (
   client: CozyClient
 ): Promise<void> => {

--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -100,7 +100,6 @@ export const determineSecurityFlow = async (
       navigate(routes.home)
     } finally {
       setIsSecurityFlowPassed(true)
-      SecurityNavigationService.stopListening()
     }
   }
 
@@ -113,8 +112,6 @@ export const determineSecurityFlow = async (
     devlog('🔏', 'Application does not have autolock activated')
     devlog('🔏', 'Device is secured')
     devlog('🔏', 'No security action taken')
-
-    SecurityNavigationService.stopListening()
   } else {
     devlog('🔏', 'Application does not have autolock activated')
     devlog('🔏', 'Device is unsecured')

--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -181,10 +181,7 @@ export const getSecFlowInitParams = async (
   }
 }
 
-export const savePinCode = async (
-  pinCode: string,
-  onSuccess: () => void
-): Promise<void> => {
+export const savePinCode = async (pinCode: string): Promise<void> => {
   try {
     await toggleSetting('PINLock', { pinCode })
   } catch (error) {
@@ -204,8 +201,7 @@ export const doPinCodeAutoLock = async (): Promise<void> => {
 
 async function safeSetKeysAsync(
   client: CozyClient,
-  keys: SetKeys,
-  onSuccess?: () => void
+  keys: SetKeys
 ): Promise<void> {
   try {
     devlog('🔏', 'Saving password', keys)
@@ -223,10 +219,7 @@ async function safeSetKeysAsync(
   }
 }
 
-export const getPasswordParams = (
-  client: CozyClient,
-  onSuccess?: () => void
-): PasswordParams => {
+export const getPasswordParams = (client: CozyClient): PasswordParams => {
   const { uri: instance, normalizedFqdn: fqdn } =
     getInstanceAndFqdnFromClient(client)
 
@@ -240,7 +233,7 @@ export const getPasswordParams = (
     setKeys: (keys: SetKeys): void => {
       // Errors to be handled in `safeSetKeysAsync()`
       const setKeys = safePromise(safeSetKeysAsync)
-      setKeys(client, keys, onSuccess)
+      setKeys(client, keys)
     }
   }
 }

--- a/src/app/theme/SplashScreenService.ts
+++ b/src/app/theme/SplashScreenService.ts
@@ -4,9 +4,11 @@ import { flagshipUIEventHandler, flagshipUIEvents } from '/app/view/FlagshipUI'
 import { devlog } from '/core/tools/env'
 
 export const splashScreens = {
-  LOCK_SCREEN: 'LOCK_SCREEN'
+  LOCK_SCREEN: 'LOCK_SCREEN',
+  SECURE_BACKGROUND: 'secure_background' // this mirrors native declaration
 } as const
-export type SplashScreenEnum = keyof typeof splashScreens
+type SplashScreenEnumKeys = keyof typeof splashScreens
+export type SplashScreenEnum = (typeof splashScreens)[SplashScreenEnumKeys]
 
 export class SplashScreenService {
   show = showSplashScreen

--- a/src/app/theme/SplashScreenService.ts
+++ b/src/app/theme/SplashScreenService.ts
@@ -3,12 +3,19 @@ import RNBootSplash, { VisibilityStatus } from 'react-native-bootsplash'
 import { flagshipUIEventHandler, flagshipUIEvents } from '/app/view/FlagshipUI'
 import { devlog } from '/core/tools/env'
 
+export const splashScreens = {
+  LOCK_SCREEN: 'LOCK_SCREEN'
+} as const
+export type SplashScreenEnum = keyof typeof splashScreens
+
 export class SplashScreenService {
   show = showSplashScreen
   hide = hideSplashScreen
 }
 
-export const showSplashScreen = (bootsplashName?: string): Promise<void> => {
+export const showSplashScreen = (
+  bootsplashName?: SplashScreenEnum
+): Promise<void> => {
   devlog('☁️ showSplashScreen called')
 
   flagshipUIEventHandler.emit(
@@ -23,7 +30,9 @@ export const showSplashScreen = (bootsplashName?: string): Promise<void> => {
   return RNBootSplash.show({ fade: true, bootsplashName })
 }
 
-export const hideSplashScreen = (bootsplashName?: string): Promise<void> => {
+export const hideSplashScreen = (
+  bootsplashName?: SplashScreenEnum
+): Promise<void> => {
   flagshipUIEventHandler.emit(
     flagshipUIEvents.SET_COMPONENT_COLORS,
     `Splashscreen`,

--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -3,7 +3,9 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  TouchableWithoutFeedback
+  StyleSheet,
+  TouchableWithoutFeedback,
+  View
 } from 'react-native'
 import RnMaskInput from 'react-native-mask-input'
 import { FullWindowOverlay } from 'react-native-screens'
@@ -192,24 +194,37 @@ const LockView = ({
 
 export const LockScreen = (): JSX.Element => {
   return (
-    <ConditionalWrapper
-      condition={Platform.OS === 'ios'}
-      wrapper={(children): JSX.Element => (
-        <FullWindowOverlay>{children}</FullWindowOverlay>
-      )}
-    >
-      <TouchableWithoutFeedback
-        onPress={Keyboard.dismiss}
-        style={{ backgroundColor: palette.Primary[600], height: '100%' }}
+    <View style={styles.fullScreen}>
+      <ConditionalWrapper
+        condition={Platform.OS === 'ios'}
+        wrapper={(children): JSX.Element => (
+          <FullWindowOverlay>{children}</FullWindowOverlay>
+        )}
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        <TouchableWithoutFeedback
+          onPress={Keyboard.dismiss}
+          style={{ backgroundColor: palette.Primary[600], height: '100%' }}
         >
-          <CozyTheme variant="inverted">
-            <LockView {...useLockScreenProps()} />
-          </CozyTheme>
-        </KeyboardAvoidingView>
-      </TouchableWithoutFeedback>
-    </ConditionalWrapper>
+          <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          >
+            <CozyTheme variant="inverted">
+              <LockView {...useLockScreenProps()} />
+            </CozyTheme>
+          </KeyboardAvoidingView>
+        </TouchableWithoutFeedback>
+      </ConditionalWrapper>
+    </View>
   )
 }
+
+const styles = StyleSheet.create({
+  fullScreen: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 10
+  }
+})

--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -24,7 +24,7 @@ import { Grid } from '/ui/Grid'
 import { Icon } from '/ui/Icon'
 import { IconButton } from '/ui/IconButton'
 import { Link } from '/ui/Link'
-import { LockViewProps, LockScreenProps } from '/app/view/Lock/LockScreenTypes'
+import { LockViewProps } from '/app/view/Lock/LockScreenTypes'
 import { LogoutFlipped } from '/ui/Icons/LogoutFlipped'
 import { TextField } from '/ui/TextField'
 import { Tooltip } from '/ui/Tooltip'
@@ -210,7 +210,7 @@ export const LockScreen = (props: LockScreenProps): React.ReactNode => {
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
           <CozyTheme variant="inverted">
-            <LockView {...useLockScreenProps(props)} />
+            <LockView {...useLockScreenProps()} />
           </CozyTheme>
         </KeyboardAvoidingView>
       </TouchableWithoutFeedback>

--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -11,8 +11,6 @@ import { FullWindowOverlay } from 'react-native-screens'
 import { FlagshipUI } from 'cozy-intent'
 
 import { ScreenIndexes, useFlagshipUI } from '/app/view/FlagshipUI'
-import { routes } from '/constants/routes'
-import { navigationRef } from '/libs/RootNavigation'
 import { Button } from '/ui/Button'
 import { ConditionalWrapper } from '/components/ConditionalWrapper'
 import { ConfirmDialog } from '/ui/CozyDialogs/ConfirmDialog'
@@ -192,12 +190,10 @@ const LockView = ({
   )
 }
 
-export const LockScreen = (props: LockScreenProps): React.ReactNode => {
-  const currentRouteName = navigationRef.current?.getCurrentRoute()?.name ?? ''
-
+export const LockScreen = (): JSX.Element => {
   return (
     <ConditionalWrapper
-      condition={Platform.OS === 'ios' && currentRouteName === routes.lock}
+      condition={Platform.OS === 'ios'}
       wrapper={(children): JSX.Element => (
         <FullWindowOverlay>{children}</FullWindowOverlay>
       )}

--- a/src/app/view/Lock/LockScreenTypes.ts
+++ b/src/app/view/Lock/LockScreenTypes.ts
@@ -1,12 +1,5 @@
-import { RouteProp } from '@react-navigation/native'
 import { TextInputProps, TouchableWithoutFeedbackProps } from 'react-native'
 import { BiometryType } from 'react-native-biometrics'
-
-type RootStackParamList = Record<string, undefined | { onSuccess: () => void }>
-
-export interface LockScreenProps {
-  route: RouteProp<RootStackParamList, 'lock'>
-}
 
 export interface LockViewProps {
   biometryEnabled: boolean

--- a/src/app/view/Lock/LockScreenWrapper.tsx
+++ b/src/app/view/Lock/LockScreenWrapper.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect } from 'react'
+
+import { hideSplashScreen } from '/app/theme/SplashScreenService'
+import { LockScreen } from '/app/view/Lock/LockScreen'
+import {
+  lockScreens,
+  useLockScreenWrapper
+} from '/app/view/Lock/useLockScreenWrapper'
+import { PasswordPrompt } from '/app/view/Secure/PasswordPrompt'
+import { PinPrompt } from '/app/view/Secure/PinPrompt'
+import { SetPasswordView } from '/app/view/Secure/SetPasswordView'
+import { SetPinView } from '/app/view/Secure/SetPinView'
+
+export const LockScreenWrapper = (): JSX.Element | null => {
+  const { currentSecurityScreen } = useLockScreenWrapper()
+
+  useEffect(() => {
+    if (currentSecurityScreen) {
+      void hideSplashScreen()
+    }
+  }, [currentSecurityScreen])
+
+  switch (currentSecurityScreen) {
+    case lockScreens.LOCK_SCREEN: {
+      return <LockScreen />
+    }
+    case lockScreens.PASSWORD_PROMPT: {
+      return <PasswordPrompt />
+    }
+    case lockScreens.PIN_PROMPT: {
+      return <PinPrompt />
+    }
+    case lockScreens.SET_PASSWORD: {
+      return <SetPasswordView />
+    }
+    case lockScreens.SET_PIN: {
+      return <SetPinView />
+    }
+    default: {
+      return null
+    }
+  }
+}

--- a/src/app/view/Lock/useLockScreen.ts
+++ b/src/app/view/Lock/useLockScreen.ts
@@ -10,8 +10,6 @@ import { getData, StorageKeys } from '/libs/localStore/storage'
 import { getInstanceAndFqdnFromClient } from '/libs/client'
 import { getVaultInformation } from '/libs/keychain'
 import { openForgotPasswordLink } from '/libs/functions/openForgotPasswordLink'
-import { reset } from '/libs/RootNavigation'
-import { routes } from '/constants/routes'
 import {
   ensureLockScreenUi,
   getBiometryType,
@@ -22,6 +20,10 @@ import {
 } from '/app/domain/authorization/services/LockScreenService'
 import { useI18n } from '/locales/i18n'
 import { SecurityNavigationService } from '/app/domain/authorization/services/SecurityNavigationService'
+import {
+  hideSecurityScreen,
+  lockScreens
+} from '/app/view/Lock/useLockScreenWrapper'
 
 export const useLockScreenProps = (props: LockScreenProps): LockViewProps => {
   const [biometryEnabled, setBiometryEnabled] = useState(false)
@@ -48,10 +50,8 @@ export const useLockScreenProps = (props: LockScreenProps): LockViewProps => {
   })
 
   const onUnlock = useCallback((): void => {
-    if (!props.route.params?.onSuccess) return reset(routes.home)
-
-    props.route.params.onSuccess()
-  }, [props.route.params])
+    hideSecurityScreen(lockScreens.LOCK_SCREEN)
+  }, [])
 
   const tryBiometry = useCallback((): Promise<void> => {
     const handleBiometryParam = async (): Promise<void> => {

--- a/src/app/view/Lock/useLockScreen.ts
+++ b/src/app/view/Lock/useLockScreen.ts
@@ -5,7 +5,7 @@ import { BiometryType } from 'react-native-biometrics'
 
 import { useClient } from 'cozy-client'
 
-import { LockScreenProps, LockViewProps } from '/app/view/Lock/LockScreenTypes'
+import { LockViewProps } from '/app/view/Lock/LockScreenTypes'
 import { getData, StorageKeys } from '/libs/localStore/storage'
 import { getInstanceAndFqdnFromClient } from '/libs/client'
 import { getVaultInformation } from '/libs/keychain'
@@ -25,7 +25,7 @@ import {
   lockScreens
 } from '/app/view/Lock/useLockScreenWrapper'
 
-export const useLockScreenProps = (props: LockScreenProps): LockViewProps => {
+export const useLockScreenProps = (): LockViewProps => {
   const [biometryEnabled, setBiometryEnabled] = useState(false)
   const [biometryType, setBiometryType] = useState<BiometryType | null>(null)
   const [hasLogoutDialog, toggleLogoutDialog] = useState(false)

--- a/src/app/view/Lock/useLockScreenWrapper.ts
+++ b/src/app/view/Lock/useLockScreenWrapper.ts
@@ -1,0 +1,67 @@
+import { EventEmitter } from 'events'
+
+import { useEffect, useState } from 'react'
+
+const lockScreenEventHandler = new EventEmitter()
+
+const lockScreenEvents = {
+  SHOW: 'SHOW',
+  HIDE: 'HIDE'
+} as const
+
+export const lockScreens = {
+  LOCK_SCREEN: 'LOCK_SCREEN',
+  PASSWORD_PROMPT: 'PASSWORD_PROMPT',
+  PIN_PROMPT: 'PIN_PROMPT',
+  SET_PASSWORD: 'SET_PASSWORD',
+  SET_PIN: 'SET_PIN'
+} as const
+
+export type LockScreenEnum = keyof typeof lockScreens
+
+export const showSecurityScreen = (screen: LockScreenEnum): void => {
+  lockScreenEventHandler.emit(lockScreenEvents.SHOW, screen)
+}
+export const hideSecurityScreen = (screen: LockScreenEnum): void => {
+  lockScreenEventHandler.emit(lockScreenEvents.HIDE, screen)
+}
+
+interface LockScreenState {
+  currentSecurityScreen: LockScreenEnum | undefined
+}
+
+export const useLockScreenWrapper = (): LockScreenState => {
+  const [currentScreen, setCurrentScreen] = useState<
+    LockScreenEnum | undefined
+  >(undefined)
+
+  useEffect(() => {
+    const showHandler = (screen: LockScreenEnum): void => {
+      setCurrentScreen(screen)
+    }
+
+    const hideHandler = (): void => {
+      // for now we don't display multiple secure screens simultaneously
+      // so let's hide them all
+      setCurrentScreen(undefined)
+    }
+
+    const subscriptionShow = lockScreenEventHandler.addListener(
+      lockScreenEvents.SHOW,
+      showHandler
+    )
+    const subscriptionHide = lockScreenEventHandler.addListener(
+      lockScreenEvents.HIDE,
+      hideHandler
+    )
+
+    return (): void => {
+      subscriptionShow.removeListener(lockScreenEvents.SHOW, showHandler)
+      subscriptionHide.removeListener(lockScreenEvents.HIDE, hideHandler)
+    }
+  }, [])
+
+  return {
+    currentSecurityScreen: currentScreen
+  }
+}

--- a/src/app/view/Secure/PasswordPrompt.spec.tsx
+++ b/src/app/view/Secure/PasswordPrompt.spec.tsx
@@ -1,19 +1,13 @@
 import { render, fireEvent } from '@testing-library/react-native'
-import '@testing-library/jest-native/extend-expect'
 import React from 'react'
 
+import { showSecurityScreen } from '/app/view/Lock/useLockScreenWrapper'
 import { PasswordPrompt } from '/app/view/Secure/PasswordPrompt'
-import { routes } from '/constants/routes'
-import { navigate } from '/libs/RootNavigation'
 
-// Mock the navigation and logging dependencies
-jest.mock('/libs/RootNavigation', () => ({
-  ...jest.requireActual('/libs/RootNavigation'),
-  navigate: jest.fn()
-}))
-
-jest.mock('/core/tools/env', () => ({
-  devlog: jest.fn()
+jest.mock('/app/view/Lock/useLockScreenWrapper', () => ({
+  ...jest.requireActual('/app/view/Lock/useLockScreenWrapper'),
+  hideSecurityScreen: jest.fn(),
+  showSecurityScreen: jest.fn()
 }))
 
 // This suite tests the PasswordPrompt component
@@ -21,41 +15,11 @@ describe('PasswordPrompt', () => {
   // This test ensures that the handleSetPassword function
   // correctly navigates to the setPassword route when pressed
   it('handleSetPassword navigates to setPassword route', () => {
-    const onSuccess = jest.fn()
-
-    const { getByText } = render(
-      <PasswordPrompt
-        route={{ params: { onSuccess }, key: '', name: 'pinPrompt' }}
-      />
-    )
+    const { getByText } = render(<PasswordPrompt />)
 
     fireEvent.press(getByText('screens.SecureScreen.passwordprompt_cta'))
 
     // The onSuccess prop should be passed through to the setPassword route
-    expect(navigate).toHaveBeenCalledWith(routes.setPassword, { onSuccess })
-  })
-
-  // This test ensures that the handleSetPassword function
-  // correctly handles errors and navigates to the setPassword route
-  // with a home redirect when an error occurs
-  it('handleSetPassword navigates to setPassword with home redirect on error', () => {
-    // Mock a failing onSuccess function
-    const onSuccess = jest.fn().mockImplementation(() => {
-      throw new Error('No onSuccess callback given to PinPrompt')
-    })
-
-    const { getByText } = render(
-      <PasswordPrompt
-        route={{ params: { onSuccess }, key: '', name: 'pinPrompt' }}
-      />
-    )
-
-    fireEvent.press(getByText('screens.SecureScreen.passwordprompt_cta'))
-
-    // In case of an error, the setPassword route should be called with a new function
-    // that redirects to the home route
-    expect(navigate).toHaveBeenCalledWith(routes.setPassword, {
-      onSuccess: expect.any(Function) as () => void
-    })
+    expect(showSecurityScreen).toHaveBeenCalledWith('SET_PASSWORD')
   })
 })

--- a/src/app/view/Secure/PasswordPrompt.tsx
+++ b/src/app/view/Secure/PasswordPrompt.tsx
@@ -1,18 +1,11 @@
-import { RouteProp } from '@react-navigation/native'
 import React from 'react'
 
 import { usePasswordPrompt } from '/app/view/Secure/hooks/usePasswordPrompt'
 import { PromptingPage } from '/components/templates/PromptingPage'
 import { useI18n } from '/locales/i18n'
 
-type RootStackParamList = Record<string, { onSuccess: () => void }>
-
-interface PasswordPromptProps {
-  route: RouteProp<RootStackParamList, 'pinPrompt'>
-}
-
-export const PasswordPrompt = ({ route }: PasswordPromptProps): JSX.Element => {
-  const handleSetPassword = usePasswordPrompt(route.params.onSuccess)
+export const PasswordPrompt = (): JSX.Element => {
+  const handleSetPassword = usePasswordPrompt()
   const { t } = useI18n()
 
   return (

--- a/src/app/view/Secure/PinPrompt.spec.tsx
+++ b/src/app/view/Secure/PinPrompt.spec.tsx
@@ -3,8 +3,10 @@ import '@testing-library/jest-native/extend-expect'
 import React from 'react'
 
 import { PinPrompt } from '/app/view/Secure/PinPrompt'
-import { routes } from '/constants/routes'
-import { navigate } from '/libs/RootNavigation'
+import {
+  hideSecurityScreen,
+  showSecurityScreen
+} from '/app/view/Lock/useLockScreenWrapper'
 
 // @TODO
 // We need to mock these core services for the test to work
@@ -15,61 +17,36 @@ jest.mock('/app/domain/authorization/utils/devMode.ts', () => {
     getDevModeFunctions: jest.fn().mockReturnValue(false)
   }
 })
-jest.mock('/libs/RootNavigation', () => ({
-  ...jest.requireActual('/libs/RootNavigation'),
-  navigate: jest.fn()
-}))
 jest.mock('/core/tools/env', () => ({
   devlog: jest.fn(),
   shouldDisableAutolock: jest.fn().mockReturnValue(false)
 }))
+jest.mock('/app/view/Lock/useLockScreenWrapper', () => ({
+  ...jest.requireActual('/app/view/Lock/useLockScreenWrapper'),
+  hideSecurityScreen: jest.fn(),
+  showSecurityScreen: jest.fn()
+}))
 
 // This is our main test suite for the PinPrompt component
 describe('PinPrompt', () => {
-  // This test verifies that the PinPrompt properly navigates to the setPin route
+  // This test verifies that the PinPrompt properly trigger displaying the setPin view
   // when the "Set Pin Code" button is pressed.
   it('handleSetPinCode navigates to setPin route', () => {
-    const onSuccess = jest.fn()
-
     // We're rendering the component and then simulating a button press
-    const { getByText } = render(
-      <PinPrompt
-        route={{ key: 'pinPrompt', name: 'pinPrompt', params: { onSuccess } }}
-      />
-    )
+    const { getByText } = render(<PinPrompt />)
 
     fireEvent.press(getByText('screens.SecureScreen.pinprompt_cta'))
 
-    // We're verifying that the navigate function was called with the expected arguments
-    expect(navigate).toHaveBeenCalledWith(routes.setPin, { onSuccess })
+    expect(showSecurityScreen).toHaveBeenCalledWith('SET_PIN')
   })
 
-  // This test verifies that the PinPrompt's "Ignore" button behaves correctly.
-  // We're verifying two scenarios:
-  // 1. The onSuccess callback was called correctly.
-  // 2. The component properly handles an error and navigates to the home screen when an error is thrown in the onSuccess callback.
+  // This test verifies that the PinPrompt's "Ignore" button correctly hide the pin prompt.
   it('handleIgnorePinCode behaves correctly', () => {
-    const onSuccess = jest.fn()
-
-    const { getByText } = render(
-      <PinPrompt
-        route={{ key: 'pinPrompt', name: 'pinPrompt', params: { onSuccess } }}
-      />
-    )
+    const { getByText } = render(<PinPrompt />)
 
     fireEvent.press(getByText('screens.SecureScreen.pinprompt_refusal'))
 
     // Verifying that the onSuccess callback was called correctly.
-    expect(onSuccess).toHaveBeenCalled()
-
-    // Now we're simulating an error being thrown in the onSuccess callback,
-    // and verifying that the component handles it properly by navigating to the home screen.
-    onSuccess.mockImplementation(() => {
-      throw new Error('An error occurred in onSuccess callback')
-    })
-
-    fireEvent.press(getByText('screens.SecureScreen.pinprompt_refusal'))
-
-    expect(navigate).toHaveBeenCalledWith(routes.home)
+    expect(hideSecurityScreen).toHaveBeenCalledWith('PIN_PROMPT')
   })
 })

--- a/src/app/view/Secure/PinPrompt.tsx
+++ b/src/app/view/Secure/PinPrompt.tsx
@@ -1,4 +1,3 @@
-import { RouteProp } from '@react-navigation/native'
 import React from 'react'
 
 import { PromptingPage } from '/components/templates/PromptingPage'
@@ -6,16 +5,8 @@ import { usePinPrompt } from '/app/view/Secure/hooks/usePinPrompt'
 import { useI18n } from '/locales/i18n'
 import { CozyTheme } from '/ui/CozyTheme/CozyTheme'
 
-type RootStackParamList = Record<string, undefined | { onSuccess: () => void }>
-
-interface PinPromptProps {
-  route: RouteProp<RootStackParamList, 'pinPrompt'>
-}
-
-export const PinPrompt = (props: PinPromptProps): JSX.Element => {
-  const { handleSetPinCode, handleIgnorePinCode } = usePinPrompt(
-    props.route.params?.onSuccess
-  )
+export const PinPrompt = (): JSX.Element => {
+  const { handleSetPinCode, handleIgnorePinCode } = usePinPrompt()
   const { t } = useI18n()
 
   return (

--- a/src/app/view/Secure/SetPasswordView.tsx
+++ b/src/app/view/Secure/SetPasswordView.tsx
@@ -1,4 +1,3 @@
-import { RouteProp } from '@react-navigation/native'
 import React from 'react'
 
 import { usePasswordState } from './hooks/usePasswordState'
@@ -7,16 +6,8 @@ import { usePasswordService } from '/app/view/Secure/hooks/usePasswordProps'
 import { OnboardingPasswordView } from '/screens/login/components/OnboardingPasswordView'
 import { Container } from '/ui/Container'
 
-type RootStackParamList = Record<string, { onSuccess: () => void }>
-
-interface SetPasswordViewProps {
-  route: RouteProp<RootStackParamList, 'pinPrompt'>
-}
-
-export const SetPasswordView = ({
-  route
-}: SetPasswordViewProps): JSX.Element => {
-  const props = usePasswordService(route.params.onSuccess)
+export const SetPasswordView = (): JSX.Element => {
+  const props = usePasswordService()
   const state = usePasswordState()
 
   return props ? (

--- a/src/app/view/Secure/SetPinView.spec.tsx
+++ b/src/app/view/Secure/SetPinView.spec.tsx
@@ -10,20 +10,12 @@ jest.mock('/app/domain/authorization/services/SecurityService', () => ({
 
 describe('SetPinView', () => {
   it('renders correctly', () => {
-    const { getByTestId } = render(
-      <SetPinView
-        route={{ key: '', name: 'pinView', params: { onSuccess: jest.fn() } }}
-      />
-    )
+    const { getByTestId } = render(<SetPinView />)
     expect(getByTestId('pin-input')).toBeTruthy()
   })
 
   it('advances to the next step when the Next button is pressed', () => {
-    const { getByTestId } = render(
-      <SetPinView
-        route={{ key: '', name: 'pinView', params: { onSuccess: jest.fn() } }}
-      />
-    )
+    const { getByTestId } = render(<SetPinView />)
 
     fireEvent.changeText(getByTestId('pin-input'), '1234')
     fireEvent.press(getByTestId('pin-next'))

--- a/src/app/view/Secure/SetPinView.tsx
+++ b/src/app/view/Secure/SetPinView.tsx
@@ -1,4 +1,3 @@
-import { RouteProp } from '@react-navigation/native'
 import React, { useState } from 'react'
 import {
   Platform,
@@ -23,11 +22,7 @@ import { palette } from '/ui/palette'
 import { useI18n } from '/locales/i18n'
 import { CozyTheme } from '/ui/CozyTheme/CozyTheme'
 
-const SetPinViewSimple = ({
-  onSuccess
-}: {
-  onSuccess: () => void
-}): JSX.Element => {
+const SetPinViewSimple = (): JSX.Element => {
   const [step, setStep] = useState(1)
   const [firstInput, setFirstInput] = useState('')
   const [secondInput, setSecondInput] = useState('')
@@ -40,7 +35,7 @@ const SetPinViewSimple = ({
 
   const handleSecondInputSubmit = (): void => {
     if (secondInput === firstInput) {
-      void savePinCode(secondInput, onSuccess)
+      void savePinCode(secondInput)
     } else {
       setError(t('screens.SecureScreen.confirm_pin_error'))
     }
@@ -152,13 +147,7 @@ const SetPinViewSimple = ({
   )
 }
 
-type RootStackParamList = Record<string, { onSuccess: () => void }>
-
-interface SetPinProps {
-  route: RouteProp<RootStackParamList, 'pinView'>
-}
-
-export const SetPinView = (props: SetPinProps): JSX.Element => (
+export const SetPinView = (): JSX.Element => (
   <TouchableWithoutFeedback
     onPress={Keyboard.dismiss}
     style={{ backgroundColor: palette.Primary[600], height: '100%' }}
@@ -167,7 +156,7 @@ export const SetPinView = (props: SetPinProps): JSX.Element => (
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
       <CozyTheme variant="inverted">
-        <SetPinViewSimple {...props} onSuccess={props.route.params.onSuccess} />
+        <SetPinViewSimple />
       </CozyTheme>
     </KeyboardAvoidingView>
   </TouchableWithoutFeedback>

--- a/src/app/view/Secure/hooks/usePasswordPrompt.ts
+++ b/src/app/view/Secure/hooks/usePasswordPrompt.ts
@@ -4,6 +4,10 @@ import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
 import { devlog } from '/core/tools/env'
 import { hideSplashScreen } from '/app/theme/SplashScreenService'
+import {
+  lockScreens,
+  showSecurityScreen
+} from '/app/view/Lock/useLockScreenWrapper'
 
 export const usePasswordPrompt = (onSuccess: () => void): (() => void) => {
   // The HomeView should have called hideSplashScreen() already,
@@ -24,12 +28,12 @@ export const usePasswordPrompt = (onSuccess: () => void): (() => void) => {
 
       // User acknowledged the prompt, so we can navigate to the password setting screen
       // We pass the onSuccess callback to the password setting screen so that it can be called when the password is set
-      navigate(routes.setPassword, { onSuccess })
+      showSecurityScreen(lockScreens.SET_PASSWORD)
     } catch (error) {
       devlog(error)
 
       // If there is any kind of error, we fallback to the home screen as a last resort to avoid the user being stuck
-      navigate(routes.setPassword, { onSuccess: () => navigate(routes.home) })
+      showSecurityScreen(lockScreens.SET_PASSWORD)
     }
   }
 

--- a/src/app/view/Secure/hooks/usePasswordPrompt.ts
+++ b/src/app/view/Secure/hooks/usePasswordPrompt.ts
@@ -1,7 +1,5 @@
 import { useEffect } from 'react'
 
-import { navigate } from '/libs/RootNavigation'
-import { routes } from '/constants/routes'
 import { devlog } from '/core/tools/env'
 import { hideSplashScreen } from '/app/theme/SplashScreenService'
 import {
@@ -9,7 +7,7 @@ import {
   showSecurityScreen
 } from '/app/view/Lock/useLockScreenWrapper'
 
-export const usePasswordPrompt = (onSuccess: () => void): (() => void) => {
+export const usePasswordPrompt = (): (() => void) => {
   // The HomeView should have called hideSplashScreen() already,
   // but in case it didn't, we do it here as a fallback as it is critical
   useEffect(() => {
@@ -18,23 +16,7 @@ export const usePasswordPrompt = (onSuccess: () => void): (() => void) => {
   }, [])
 
   const handleSetPassword = (): void => {
-    try {
-      // It should be impossible according to the typings for onSuccess to be undefined,
-      // but it feels safer with a strict check at runtime too. If it is undefined at this point,
-      // it will cause critical errors at a later point which can not be allowed.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (!onSuccess)
-        throw new Error('No onSuccess callback given to PasswordPrompt')
-
-      // User acknowledged the prompt, so we can navigate to the password setting screen
-      // We pass the onSuccess callback to the password setting screen so that it can be called when the password is set
-      showSecurityScreen(lockScreens.SET_PASSWORD)
-    } catch (error) {
-      devlog(error)
-
-      // If there is any kind of error, we fallback to the home screen as a last resort to avoid the user being stuck
-      showSecurityScreen(lockScreens.SET_PASSWORD)
-    }
+    showSecurityScreen(lockScreens.SET_PASSWORD)
   }
 
   return handleSetPassword

--- a/src/app/view/Secure/hooks/usePasswordProps.ts
+++ b/src/app/view/Secure/hooks/usePasswordProps.ts
@@ -5,15 +5,13 @@ import React, { useEffect } from 'react'
 import { PasswordParams } from '/app/domain/authentication/models/User'
 import { getPasswordParams } from '/app/domain/authorization/services/SecurityService'
 
-export const usePasswordService = (
-  onSuccess: () => void
-): PasswordParams | undefined => {
+export const usePasswordService = (): PasswordParams | undefined => {
   const [props, setProps] = React.useState<PasswordParams>()
   const client = useClient()
 
   useEffect(() => {
-    if (client) setProps(getPasswordParams(client, onSuccess))
-  }, [client, onSuccess])
+    if (client) setProps(getPasswordParams(client))
+  }, [client])
 
   return props
 }

--- a/src/app/view/Secure/hooks/usePinPrompt.ts
+++ b/src/app/view/Secure/hooks/usePinPrompt.ts
@@ -3,17 +3,16 @@ import { useEffect } from 'react'
 import { devlog } from '/core/tools/env'
 import { doPinCodeAutoLock } from '/app/domain/authorization/services/SecurityService'
 import { hideSplashScreen } from '/app/theme/SplashScreenService'
-import { navigate } from '/libs/RootNavigation'
-import { routes } from '/constants/routes'
 import {
   hideSecurityScreen,
   lockScreens,
   showSecurityScreen
 } from '/app/view/Lock/useLockScreenWrapper'
 
-export const usePinPrompt = (
-  onSuccess?: () => void
-): { handleSetPinCode: () => void; handleIgnorePinCode: () => void } => {
+export const usePinPrompt = (): {
+  handleSetPinCode: () => void
+  handleIgnorePinCode: () => void
+} => {
   // The HomeView should have called hideSplashScreen() already,
   // but in case it didn't, we do it here as a fallback as it is critical
   useEffect(() => {
@@ -24,30 +23,19 @@ export const usePinPrompt = (
   const handleSetPinCode = (): void => {
     try {
       void doPinCodeAutoLock()
-
-      showSecurityScreen(lockScreens.SET_PIN)
     } catch (error) {
       devlog(error)
-
-      // Navigate to the setPin route as a fallback
-      // with a dummy onSuccess callback returning to the home route
-      showSecurityScreen(lockScreens.SET_PIN)
     }
+    showSecurityScreen(lockScreens.SET_PIN)
   }
 
   const handleIgnorePinCode = (): void => {
     try {
-      if (!onSuccess)
-        throw new Error('No onSuccess callback given to PinPrompt')
-
       void doPinCodeAutoLock()
-      hideSecurityScreen(lockScreens.PIN_PROMPT)
     } catch (error) {
       devlog(error)
-
-    // Navigate to the home route as a fallback
-    hideSecurityScreen(lockScreens.PIN_PROMPT)
     }
+    hideSecurityScreen(lockScreens.PIN_PROMPT)
   }
 
   return {

--- a/src/app/view/Secure/hooks/usePinPrompt.ts
+++ b/src/app/view/Secure/hooks/usePinPrompt.ts
@@ -5,6 +5,11 @@ import { doPinCodeAutoLock } from '/app/domain/authorization/services/SecuritySe
 import { hideSplashScreen } from '/app/theme/SplashScreenService'
 import { navigate } from '/libs/RootNavigation'
 import { routes } from '/constants/routes'
+import {
+  hideSecurityScreen,
+  lockScreens,
+  showSecurityScreen
+} from '/app/view/Lock/useLockScreenWrapper'
 
 export const usePinPrompt = (
   onSuccess?: () => void
@@ -20,13 +25,13 @@ export const usePinPrompt = (
     try {
       void doPinCodeAutoLock()
 
-      navigate(routes.setPin, { onSuccess })
+      showSecurityScreen(lockScreens.SET_PIN)
     } catch (error) {
       devlog(error)
 
       // Navigate to the setPin route as a fallback
       // with a dummy onSuccess callback returning to the home route
-      navigate(routes.setPin, { onSuccess: () => navigate(routes.home) })
+      showSecurityScreen(lockScreens.SET_PIN)
     }
   }
 
@@ -36,12 +41,12 @@ export const usePinPrompt = (
         throw new Error('No onSuccess callback given to PinPrompt')
 
       void doPinCodeAutoLock()
-      onSuccess()
+      hideSecurityScreen(lockScreens.PIN_PROMPT)
     } catch (error) {
       devlog(error)
 
-      // Navigate to the home route as a fallback
-      navigate(routes.home)
+    // Navigate to the home route as a fallback
+    hideSecurityScreen(lockScreens.PIN_PROMPT)
     }
   }
 

--- a/src/hooks/useGlobalAppState.spec.ts
+++ b/src/hooks/useGlobalAppState.spec.ts
@@ -1,56 +1,32 @@
 import { Platform } from 'react-native'
 
 import { _shouldLockApp } from '/app/domain/authorization/services/SecurityService'
-import { routes } from '/constants/routes'
 
 afterAll(jest.resetModules)
 
 it('should always lock the application on iOS devices when running through the autolock check, ignoring timer', () => {
   Platform.OS = 'ios'
 
-  const parsedRoute = { name: 'test', key: 'test' }
   const timeSinceLastActivity = 1
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
+  const result = _shouldLockApp(timeSinceLastActivity)
 
   expect(result).toBe(true)
-})
-
-it('should never lock the application on iOS devices when waking up to the lock screen route', () => {
-  Platform.OS = 'ios'
-
-  const parsedRoute = { name: routes.lock, key: 'test' }
-  const timeSinceLastActivity = 333333
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
-
-  expect(result).toBe(false)
 })
 
 it('should always lock the application on Android devices when running through the autolock check with an inactivity timer >= 5 minutes', () => {
   Platform.OS = 'android'
 
-  const parsedRoute = { name: 'test', key: 'test' }
   const timeSinceLastActivity = 300001
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
+  const result = _shouldLockApp(timeSinceLastActivity)
 
   expect(result).toBe(true)
-})
-
-it('should never lock the application on Android devices when waking up to the lock screen route', () => {
-  Platform.OS = 'android'
-
-  const parsedRoute = { name: routes.lock, key: 'test' }
-  const timeSinceLastActivity = 333333
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
-
-  expect(result).toBe(false)
 })
 
 it('should never lock the application on Android devices when running through the autolock check with an inactivity timer <= 5 minutes', () => {
   Platform.OS = 'android'
 
-  const parsedRoute = { name: 'test', key: 'test' }
   const timeSinceLastActivity = 300000
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
+  const result = _shouldLockApp(timeSinceLastActivity)
 
   expect(result).toBe(false)
 })
@@ -58,9 +34,8 @@ it('should never lock the application on Android devices when running through th
 it('should lock the application on Android devices when running through the autolock check with an inactivity timer just above 5 minutes', () => {
   Platform.OS = 'android'
 
-  const parsedRoute = { name: 'test', key: 'test' }
   const timeSinceLastActivity = 300001 // Just over 5 minutes
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
+  const result = _shouldLockApp(timeSinceLastActivity)
 
   expect(result).toBe(true)
 })
@@ -68,9 +43,8 @@ it('should lock the application on Android devices when running through the auto
 it('should not lock the application on Android devices when running through the autolock check with an inactivity timer just below 5 minutes', () => {
   Platform.OS = 'android'
 
-  const parsedRoute = { name: 'test', key: 'test' }
   const timeSinceLastActivity = 299999 // Just below 5 minutes
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
+  const result = _shouldLockApp(timeSinceLastActivity)
 
   expect(result).toBe(false)
 })
@@ -78,53 +52,10 @@ it('should not lock the application on Android devices when running through the 
 it('should handle negative time since last activity', () => {
   Platform.OS = 'android'
 
-  const parsedRoute = { name: 'test', key: 'test' }
   const timeSinceLastActivity = -300001
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
+  const result = _shouldLockApp(timeSinceLastActivity)
 
   // This is a weird case, but it should be handled (it can happen when the user changes the time on his device)
   // As the time is negative, it should be considered as 0
-  expect(result).toBe(true)
-})
-
-it('should handle undefined route name on Android devices', () => {
-  Platform.OS = 'android'
-
-  const parsedRoute = { name: undefined, key: 'test' } // name is undefined
-  const timeSinceLastActivity = 300001
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-  const result = _shouldLockApp(parsedRoute as any, timeSinceLastActivity)
-
-  expect(result).toBe(true)
-})
-
-it('should handle non-string route name on Android devices', () => {
-  Platform.OS = 'android'
-
-  const parsedRoute = { name: 12345, key: 'test' } // name is not a string
-  const timeSinceLastActivity = 300001
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-  const result = _shouldLockApp(parsedRoute as any, timeSinceLastActivity)
-
-  expect(result).toBe(true)
-})
-
-it('should handle an empty route name', () => {
-  Platform.OS = 'android'
-
-  const parsedRoute = { name: '', key: 'test' }
-  const timeSinceLastActivity = 300001
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
-
-  expect(result).toBe(true)
-})
-
-it('should handle no route', () => {
-  Platform.OS = 'android'
-
-  const parsedRoute = undefined as unknown as { name: string; key: string }
-  const timeSinceLastActivity = 300001
-  const result = _shouldLockApp(parsedRoute, timeSinceLastActivity)
-
   expect(result).toBe(true)
 })

--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -6,11 +6,7 @@ import Minilog from 'cozy-minilog'
 
 import { StorageKeys, storeData } from '/libs/localStore/storage'
 import { showSplashScreen } from '/app/theme/SplashScreenService'
-import {
-  getIsSecurityFlowPassed,
-  handleSecurityFlowWakeUp,
-  setIsSecurityFlowPassed
-} from '/app/domain/authorization/services/SecurityService'
+import { handleSecurityFlowWakeUp } from '/app/domain/authorization/services/SecurityService'
 import { devlog } from '/core/tools/env'
 import { synchronizeDevice } from '/app/domain/authentication/services/SynchronizeService'
 
@@ -22,7 +18,6 @@ let appState: AppStateStatus = AppState.currentState
 const handleSleep = (): void => {
   showSplashScreen('LOCK_SCREEN')
     .then(async () => {
-      setIsSecurityFlowPassed(false)
       return await storeData(StorageKeys.LastActivity, Date.now().toString())
     })
     .catch(reason => log.error('Failed when going to sleep', reason))
@@ -92,20 +87,4 @@ export const useGlobalAppState = (): void => {
       appState = AppState.currentState
     }
   }, [client])
-
-  // On app start
-  useEffect(() => {
-    const appStart = async (): Promise<void> => {
-      if (await getIsSecurityFlowPassed()) {
-        log.info('useGlobalAppState: app start, security flow passed')
-      } else {
-        log.info('useGlobalAppState: app start, security flow not passed')
-      }
-    }
-
-    if (!hasExecuted.current) {
-      log.info('useGlobalAppState: app start')
-      void appStart()
-    }
-  }, [])
 }

--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -57,8 +57,6 @@ const onStateChange = (
  */
 
 export const useGlobalAppState = (): void => {
-  // Ref to track if the logic has already been executed
-  const hasExecuted = useRef(false)
   const client = useClient()
 
   useEffect(() => {
@@ -72,7 +70,7 @@ export const useGlobalAppState = (): void => {
 
     // If there's no client, we don't need to listen to app state changes
     // because we can't lock the app anyway
-    if (!hasExecuted.current && client && !subscription) {
+    if (client && !subscription) {
       devlog(
         'useGlobalAppState: subscribing to AppState changes, synchronizing device'
       )

--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -20,7 +20,7 @@ const log = Minilog('useGlobalAppState')
 let appState: AppStateStatus = AppState.currentState
 
 const handleSleep = (): void => {
-  showSplashScreen()
+  showSplashScreen('LOCK_SCREEN')
     .then(async () => {
       setIsSecurityFlowPassed(false)
       return await storeData(StorageKeys.LastActivity, Date.now().toString())

--- a/src/hooks/useSplashScreen.ts
+++ b/src/hooks/useSplashScreen.ts
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from 'react'
 import { AppState } from 'react-native'
 
-import { hideSplashScreen } from '/app/theme/SplashScreenService'
+import { hideSplashScreen, splashScreens } from '/app/theme/SplashScreenService'
 import { SplashScreenContext } from '/libs/contexts/SplashScreenContext'
 import { safePromise } from '/utils/safePromise'
 
@@ -17,11 +17,11 @@ export const useSecureBackgroundSplashScreen = (): void => {
   useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
       if (nextAppState === 'active') {
-        safePromise(hideSplashScreen)('secure_background')
+        safePromise(hideSplashScreen)(splashScreens.SECURE_BACKGROUND)
       }
     })
 
-    safePromise(hideSplashScreen)('secure_background')
+    safePromise(hideSplashScreen)(splashScreens.SECURE_BACKGROUND)
 
     return () => {
       subscription.remove()

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -65,3 +65,11 @@ export const clearData = async (): Promise<void> => {
     log.error(`Failed to clear data from persistent storage`, error)
   }
 }
+
+export const removeData = async (name: StorageKeys): Promise<void> => {
+  try {
+    await removeItem(name)
+  } catch (error) {
+    log.error(`Failed to remove key "${name}" from persistent storage`, error)
+  }
+}

--- a/src/screens/home/components/HomeView.js
+++ b/src/screens/home/components/HomeView.js
@@ -12,13 +12,13 @@ import { useNativeIntent } from 'cozy-intent'
 import Minilog from 'cozy-minilog'
 
 import { CozyProxyWebView } from '/components/webviews/CozyProxyWebView'
+import { navigateToApp } from '/libs/functions/openApp'
 import {
   consumeRouteParameter,
   useInitialParam
 } from '/libs/functions/routeHelpers'
 import { useSession } from '/hooks/useSession'
 import { useHomeStateContext } from '/screens/home/HomeStateProvider'
-import { determineSecurityFlow } from '/app/domain/authorization/services/SecurityService'
 import { devlog } from '/core/tools/env'
 import { ScreenIndexes, useFlagshipUI } from '/app/view/FlagshipUI'
 import { OsReceiveScreen } from '/app/view/OsReceive/OsReceiveScreen'
@@ -177,8 +177,6 @@ const HomeView = ({ route, navigation }) => {
     )
 
     async function handleSecurityFlowAndCozyAppFallback() {
-      let navigationObject = null
-
       if (uri) {
         const cozyAppFallbackURL = cozyAppFallbackURLInitialParam.consume()
 
@@ -191,12 +189,11 @@ const HomeView = ({ route, navigation }) => {
             cozyAppFallbackURL,
             subdomainType
           )
-
-          navigationObject = {
+          navigateToApp({
             navigation,
             href: cozyAppFallbackURL,
             slug
-          }
+          })
         } else {
           if (shouldWaitCozyApp === undefined) {
             setShouldWaitCozyApp(false)
@@ -213,12 +210,6 @@ const HomeView = ({ route, navigation }) => {
         )
 
         hasRenderedOnce.current = true
-
-        await determineSecurityFlow(
-          client,
-          hasFilesToUpload ? undefined : navigationObject, // If there are files to upload, we don't want to navigate to the cozy app
-          true
-        )
 
         // If there are files to upload, we don't want to wait for the cozy app to render at all
         // We want to hide the splash screen as soon as possible and display the HomeView with the files to upload screen


### PR DESCRIPTION
The Lock related screens are responsible to lock the app when it goes to OS background and to display a CTA to the user when their phone is not protected

Previous implementation declared those screens inside of the App's router

This had numerous caveats:
- It was difficult to keep track of when the app would need to be locked
- It was difficult to keep track of where the user was before the app being locked
  - For example we needed to wait for the HomeView to be initialized and check if a cozy-app or the OSReceive screen should be displayed to give it to the Lock screen as a context (cf [here](https://github.com/cozy/cozy-flagship-app/blob/master/src/screens/home/components/HomeView.js#L209-L230))
- It was difficult to keep track of when hiding the splashscreen
- If a component was calling `navigate()` in reaction of an event while behind the lock screen then the app would leave the lock screen
  - For example this occurred in [OauthClientsLimitService](https://github.com/cozy/cozy-flagship-app/blob/master/src/app/domain/limits/OauthClientsLimitService.ts#L28) when the following conditions were met:
    - the OAuth client limit was exceeded
    - the default app was a cozy-app
    - the app was configured to display the lock screen
- We had to rely on some tricks to ensure the navigation to be done on HomeScreen first and then on the Lock screen so the HomeScreen's webview can start loading while the user enters their credentials 
- In some situation, the Lock screen was impacted by re-renders of the app
  - This was visible when the Biometry was triggered on iOS. Sometime it would appear 2 times, sometimes it would directly dismiss with the following error in the console: `Canceled by another authentication`
 
This PR removes those screen outside of the router

With the new implementation, those screen are now displayed on top of the UI without interaction with the router

This allow the application to live behind the Lockscreen, so:
- The HomeScreen is, by default, pre-loading behind the lock screen
- If the app should start on the HomeScreen, on an AppScreen, or on the OSReceiveScreen has no impact anymore on the LockScreen flow
- There is no need to track where the user was, when hiding the lock screen, the app is already where it was before displaying the lock screen
- There is no risk to have `navigate()` collision anymore, the app can do navigation in background based on events and this won't affect the fact that the Lock screen is always displayed until the user enters their credentials
- The Lock screens are rendrered in parallel of the `<App />` component, so there should be no risk of rerender side effects between each-other

___

TODO:

- [x] clean remaining trace of security flow in HomeView (`hasRenderedOnce` ref, `useEffect` name and logs)
- [x] fix unit tests