### PR TITLE
fix: update scheme android/ios for mabulle (VO-66)

### DIFF
--- a/white_label/brands/mabulle/android/app/brand.gradle
+++ b/white_label/brands/mabulle/android/app/brand.gradle
@@ -2,8 +2,8 @@ android {
   defaultConfig {
       applicationId "io.cozy.flagship.mobile.mabulle"
       manifestPlaceholders = [
-        universalLinkUrl: "links.mabullecozy.cloud",
-        appScheme: "mabulle",
+        universalLinkUrl: "links.cozygrandlyon.cloud",
+        appScheme: "cozygrandlyon",
         reactNativeBackgroundGeolocationKey: "372bdd9fa2cf9c1140cd6fb4cdfe9a18a0d6e8822998205460f925e7a5304157",
       ]
   }

--- a/white_label/brands/mabulle/ios/CozyReactNative/CozyReactNative.entitlements
+++ b/white_label/brands/mabulle/ios/CozyReactNative/CozyReactNative.entitlements
@@ -6,7 +6,7 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:links.mabullecozy.cloud</string>
+		<string>applinks:links.cozygrandlyon.cloud</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/white_label/config.json
+++ b/white_label/config.json
@@ -12,7 +12,7 @@
     "bundleId": "io.cozy.flagship.mobile.mabulle",
     "provisionningProfile": "amiral-mabulle-ci-profile",
     "provisionningDevProfile": "amiral-mabulle-dev-profile",
-    "scheme": "mabulle",
+    "scheme": "cozygrandlyon",
     "userAgent": "io.cozy.mabulle.mobile"
   }
 }


### PR DESCRIPTION
app scheme and universal link urls were wrong.
the only "mabulle" reference left SHOULD be about the application id
and the application id only ("io.cozy.flagship.mobile.mabulle")
Because we cannot change that one