### PR TITLE
[VO-170] fix: Set white background on MaBulle Android's bootsplash

### DIFF
--- a/white_label/brands/mabulle/android/app/src/main/res/values/colors.xml
+++ b/white_label/brands/mabulle/android/app/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <resources>
-    <color name="bootsplash_background">#0066FF</color>
+    <color name="bootsplash_background">#FFFFFF</color>
     <color name="black">#000000</color>
     <color name="base_background">#FFFFFF</color>
 </resources>


### PR DESCRIPTION
This had been forgotten in #1101