### PR TITLE
fix: startTracking should return only when geolocation tracking has been started or has failed

### DIFF
--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -70,10 +70,9 @@ export const startTracking = async () => {
         smallIcon: 'mipmap/ic_stat_ic_notification'
       }
     })
-    BackgroundGeolocation.start(() => {
-      Log('Tracking started')
-      storeData(StorageKeys.ShouldBeTrackingFlagStorageAdress, true)
-    })
+    await BackgroundGeolocation.start()
+    Log('Tracking started')
+    await storeData(StorageKeys.ShouldBeTrackingFlagStorageAdress, true)
     return true
   } catch (e) {
     log.error(e)


### PR DESCRIPTION
Fixes a bug on coachco2 where we enable geolocation, and toggle does not turn on.