### PR TITLE
[VO-191] feat: Allow to change HttpServerProvider's default port in white labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,10 @@
 # You will need more credentials if you need to produce actual signed builds.
 
 # Please run `pod install` after editing this file. Otherwise react-native-config
-# won't see the changes on iOS
+# won't see the changes on iOS. In some situation, it may be needed to also clean
+# the XCode build.
+# To verify the good configuration, in XCode check the following file:
+# - Pods/Development Pods/react-native-config/App/GeneratedDotEnv.m
 
 # --- ANDROID BUILD ---
 
@@ -33,4 +36,5 @@
 # --- OTHER SECRETS ---
 
 # USER_AGENT="User agent used by cozy-client and WebView (this value is writen by `yarn brand:configure:<brand_name>` command)"
+# HTTP_SERVER_DEFAULT_PORT="Default port used by the HttpServerProvider (this value is writen by `yarn brand:configure:<brand_name>` command)"
 SENTRY_AUTH_TOKEN="Auth token for Sentry - MANDATORY"

--- a/src/libs/httpserver/httpServerProvider.tsx
+++ b/src/libs/httpserver/httpServerProvider.tsx
@@ -5,6 +5,7 @@ import React, {
   useLayoutEffect,
   useState
 } from 'react'
+import Config from 'react-native-config'
 
 import type CozyClient from 'cozy-client'
 import Minilog from 'cozy-minilog'
@@ -30,7 +31,9 @@ import {
 
 const log = Minilog('HttpServerProvider')
 
-const DEFAULT_PORT = 5757
+const DEFAULT_PORT = Config.HTTP_SERVER_DEFAULT_PORT
+  ? Number(Config.HTTP_SERVER_DEFAULT_PORT)
+  : 5759
 
 interface HttpServerState {
   server: HttpServer | undefined

--- a/white_label/config.json
+++ b/white_label/config.json
@@ -2,6 +2,7 @@
   "cozy" : {
     "appName": "Cozy",
     "bundleId": "io.cozy.flagship.mobile",
+    "httpServerDefaultPort": 5759,
     "provisionningProfile": "amiral-ci-profile",
     "provisionningDevProfile": "amiral-dev-profile",
     "scheme": "cozy",
@@ -10,6 +11,7 @@
   "mabulle": {
     "appName": "Cozy Métropole de Lyon",
     "bundleId": "io.cozy.flagship.mobile.mabulle",
+    "httpServerDefaultPort": 5758,
     "provisionningProfile": "amiral-mabulle-ci-profile",
     "provisionningDevProfile": "amiral-mabulle-dev-profile",
     "scheme": "cozygrandlyon",

--- a/white_label/configure-brand.ts
+++ b/white_label/configure-brand.ts
@@ -123,14 +123,11 @@ const configureEnv = async (brand: string): Promise<void> => {
   const envContent = await fs.readFile('.env', 'utf8')
   let newEnvContent = envContent
 
-  const userAgentRegex = /^USER_AGENT=".*"/m
-  const newUserAgent = `USER_AGENT="${config.userAgent}"`
-
-  if (userAgentRegex.test(newEnvContent)) {
-    newEnvContent = newEnvContent.replace(userAgentRegex, newUserAgent)
-  } else {
-    newEnvContent += `\n${newUserAgent}\n`
-  }
+  newEnvContent = setOrReplaceVariable(
+    newEnvContent,
+    'USER_AGENT',
+    config.userAgent
+  )
 
   if (envContent !== newEnvContent) {
     logger.warn(
@@ -139,6 +136,25 @@ const configureEnv = async (brand: string): Promise<void> => {
   }
 
   await fs.writeFile('.env', newEnvContent)
+}
+
+const setOrReplaceVariable = (
+  envContent: string,
+  variableName: string,
+  value: string
+): string => {
+  let newEnvContent = envContent
+
+  const variableRegex = new RegExp(`^${variableName}=".*"`, 'm')
+  const newVariable = `${variableName}="${value}"`
+
+  if (variableRegex.test(newEnvContent)) {
+    newEnvContent = newEnvContent.replace(variableRegex, newVariable)
+  } else {
+    newEnvContent += `\n${newVariable}\n`
+  }
+
+  return newEnvContent
 }
 
 const executeCommand = async (command: string): Promise<string> => {

--- a/white_label/configure-brand.ts
+++ b/white_label/configure-brand.ts
@@ -129,6 +129,12 @@ const configureEnv = async (brand: string): Promise<void> => {
     config.userAgent
   )
 
+  newEnvContent = setOrReplaceVariable(
+    newEnvContent,
+    'HTTP_SERVER_DEFAULT_PORT',
+    config.httpServerDefaultPort
+  )
+
   if (envContent !== newEnvContent) {
     logger.warn(
       '.env file has been modified, please run `pod install` to apply changes'
@@ -141,7 +147,7 @@ const configureEnv = async (brand: string): Promise<void> => {
 const setOrReplaceVariable = (
   envContent: string,
   variableName: string,
-  value: string
+  value: string | number
 ): string => {
   let newEnvContent = envContent
 


### PR DESCRIPTION
When simultaneously using two different version of the App (i.e. Cozy app and MaBulle app) then respective HttpServers need to use different HTTP ports

This PR uses the existing `.env` file and `react-native-config` plugin to override the port for each brand