### PR TITLE
[DAT-18] feat: Run openpath pipeline after upload

### DIFF
--- a/src/app/domain/geolocation/tracking/tracking.js
+++ b/src/app/domain/geolocation/tracking/tracking.js
@@ -1,4 +1,7 @@
-import { uploadUserCache } from '/app/domain/geolocation/tracking/upload'
+import {
+  runOpenPathPipeline,
+  uploadUserCache
+} from '/app/domain/geolocation/tracking/upload'
 import { getOrCreateUser } from '/app/domain/geolocation/tracking/user'
 import { getTs, Log, parseISOString } from '/app/domain/geolocation/helpers'
 import {
@@ -74,6 +77,7 @@ export const smartSend = async (locations, user, { force = false } = {}) => {
       }
     }
     Log('Uploaded last batch')
+    await runOpenPathPipeline(user)
   }
 }
 
@@ -282,6 +286,7 @@ const uploadWithNoNewPoints = async ({ user, force = false }) => {
   } else {
     if (lastPoint == undefined) {
       Log('No previous location either, no upload')
+      return
     } else {
       let deltaT = Date.now() / 1000 - getTs(lastPoint)
       if (deltaT > LARGE_TEMPORAL_DELTA) {

--- a/src/app/domain/geolocation/tracking/upload.js
+++ b/src/app/domain/geolocation/tracking/upload.js
@@ -48,6 +48,32 @@ export const uploadUserCache = async (content, user) => {
   return { ok: true }
 }
 
+export const runOpenPathPipeline = async user => {
+  Log('Request to run pipeline')
+  const request = {
+    user: user
+  }
+  const body = JSON.stringify(request)
+  const response = await fetch(SERVER_URL + '/cozy/run/pipeline', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: body
+  })
+  if (!response.ok) {
+    throw new Error(
+      String(
+        'Error in pipeline run:',
+        response.status,
+        response.statusText,
+        await response.text()
+      )
+    )
+  }
+  return { ok: true }
+}
+
 /**
  * Make sure the content is correctly formatted, to prevent
  * upload failures


### PR DESCRIPTION
This allows to start the openpath pipeline after an upload, thanks to a newly deployed API
This will speed up user retrieval of trips, and avoid to execute periodic pipeline for all the users 