### PR TITLE
[VER-118] feat: Autofill support email when sending CoachCO2 logs and add app's info in the logs

### DIFF
--- a/src/app/domain/geolocation/helpers/index.ts
+++ b/src/app/domain/geolocation/helpers/index.ts
@@ -1,4 +1,5 @@
 import BackgroundGeolocation from 'react-native-background-geolocation'
+import DeviceInfo from 'react-native-device-info'
 
 import CozyClient, { Q, fetchPolicies } from 'cozy-client'
 import Minilog from 'cozy-minilog'
@@ -31,6 +32,10 @@ export const getAllLogs = async (): Promise<string> => {
 
 export const sendLogFile = async (client?: CozyClient): Promise<boolean> => {
   const emailSupport = await fetchSupportMail(client)
+
+  const appVersion = DeviceInfo.getVersion()
+  const appBuild = DeviceInfo.getBuildNumber()
+  Log(`App info: ${appVersion} (${appBuild})`)
 
   return Logger.emailLog(emailSupport)
 }

--- a/src/app/domain/geolocation/services/tracking.ts
+++ b/src/app/domain/geolocation/services/tracking.ts
@@ -39,8 +39,10 @@ export const setGeolocationTracking = async (
   }
 }
 
-export const sendGeolocationTrackingLogs = async (): Promise<void> => {
-  await sendLogFile()
+export const sendGeolocationTrackingLogs = async (
+  client?: CozyClient
+): Promise<void> => {
+  await sendLogFile(client)
 }
 
 export const forceUploadGeolocationTrackingData = async (): Promise<void> => {

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -330,7 +330,7 @@ export const localMethods = (
     setGeolocationTracking,
     getGeolocationTrackingId,
     setGeolocationTrackingId,
-    sendGeolocationTrackingLogs,
+    sendGeolocationTrackingLogs: () => sendGeolocationTrackingLogs(client),
     forceUploadGeolocationTrackingData,
     getDeviceInfo,
     isAvailable,


### PR DESCRIPTION
When the user clicks on the "send logs" button in CoachCO2, we want the email's recipient to be autofilled with the Cozy's support email (or the Instance's one if a custom support email is set in the instance's context)

Also in order to ease debugging we want the logs to contain the App's version