### PR TITLE
fix: Display js error when upload fail

### DIFF
--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -118,9 +118,9 @@ export const uploadMedias = async (
       log.warn(
         `❌ ${mediaToUpload.name} (${JSON.stringify(
           mediaToUpload
-        )}) not uploaded or set as backuped correctly (${JSON.stringify(
-          error
-        )})`
+        )}) not uploaded or set as backuped correctly (${
+          error as string
+        } - ${JSON.stringify(error)})`
       )
 
       if (isNetworkError(error)) {


### PR DESCRIPTION
There are two possibilities to enter the catch in prepareAndUploadMedia :
- with a Promise.reject : must be displayed in logs with JSON.stringify : OK
- with a JS error : must be displayed in logs without JSON.stringify : NOT OK

We should standardize every reject/throw in prepareAndUploadMedia but for the moment, let's just log the error stringified and not stringified.