### PR TITLE
Migrate from SafetyNet to Play Integrity (VO-208)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,6 @@
 # ANDROID_ALIAS="Alias of the signing key"
 # ANDROID_KEY_PASSWORD="Private key password for the signing Keystore"
 # ANDROID_KEY_STORE_PASSWORD="Password to the signing Keystore"
-# ANDROID_SAFETY_NET_API_KEY="SafetyNet Attestation API key"
 # ANDROID_SIGNING_KEY="Base64 encoded signing key used to sign the application"
 
 # --- ANDROID DEPLOY ---

--- a/.github/workflows/build-android-dev.yml
+++ b/.github/workflows/build-android-dev.yml
@@ -81,7 +81,6 @@ jobs:
       - name: 'Create env file'
         run: |
           touch .env
-          echo ANDROID_SAFETY_NET_API_KEY=${{ secrets.ANDROID_SAFETY_NET_API_KEY }} >> .env
 
       - name: Set white label brand
         run: yarn brand:configure:${{ inputs.brand }} --force
@@ -94,7 +93,6 @@ jobs:
           cd android && ./gradlew assembleRelease --no-daemon
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          ANDROID_SAFETY_NET_API_KEY: ${{ secrets.ANDROID_SAFETY_NET_API_KEY }}
 
       - name: Clean Dev APK names and add Commit SHA
         run: for f in android/app/build/outputs/apk/dev/release/*unsigned.apk; do mv "$f" "$(echo "$f" | sed s/unsigned/${{ inputs.brand }}-${{ steps.vars.outputs.sha_short }}/)"; done

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -73,7 +73,6 @@ jobs:
       - name: 'Create env file'
         run: |
           touch .env
-          echo ANDROID_SAFETY_NET_API_KEY=${{ secrets.ANDROID_SAFETY_NET_API_KEY }} >> .env
 
       - name: Set white label brand
         run: yarn brand:configure:${{ inputs.brand }} --force
@@ -86,7 +85,6 @@ jobs:
           cd android && ./gradlew bundleRelease --no-daemon
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          ANDROID_SAFETY_NET_API_KEY: ${{ secrets.ANDROID_SAFETY_NET_API_KEY }}
 
       - name: Sign App Bundle
         id: sign_app

--- a/README.md
+++ b/README.md
@@ -133,24 +133,6 @@ See https://github.com/cozy/react-native-webview/blob/cozy_main/docs/Debugging.m
 - Then run ./scripts/build-debug-offline-apk.sh
 - The output will give you the path to the apk
 
-## How to enable Flagship certification
-
-Flagship certification is the process of verifying that the current running app is a genuine Cozy application.
-
-This verification requires the `cozy-stack` to be configured with the app information.
-
-To enable Flagship certification:
-
-- Retrieve the project's Safetynet Api Key on the pass manager
-  - Or generate a new one following Google documentation: https://developer.android.com/training/safetynet/attestation#add-api-key
-- Put the token in the `ANDROID_SAFETY_NET_API_KEY` variable in your local `.env` file
-- On `src/libs/client.js` set `shouldRequireFlagshipPermissions` to `true`
-- Read `cozy-client` instruction in [flagship-certification/README.md](https://github.com/cozy/cozy-client/blob/master/packages/cozy-client/src/flagship-certification/README.md)
-
-If you want to disable Flagship certification:
-
-- On `src/libs/client.js` set `shouldRequireFlagshipPermissions` to `false`
-
 ## patch-package
 
 After installation of every npm packages, yarn applies patches to react-native-webview.

--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -24,14 +24,6 @@ jest.mock('@sentry/react-native', () => ({
   setTag: jest.fn()
 }))
 
-jest.mock(
-  '../src/constants/api-keys',
-  () => ({
-    androidSafetyNetApiKey: 'foo'
-  }),
-  { virtual: true }
-)
-
 jest.mock('react-native-fs', () => mockRNFS)
 jest.mock('react-native-iap', () => mockRNIAP)
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -265,6 +265,7 @@ dependencies {
             strictly '1.3.1'
         }
     }
+    implementation 'com.google.android.play:integrity:1.3.0'
 }
 }
 

--- a/android/app/src/main/java/io/cozy/flagship/mobile/MainApplication.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import sk.kedros.playintegrity.RNGooglePlayIntegrityPackage;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.rnfs.RNFSPackage;
 import com.reactlibrary.GzipPackage;

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'CozyReactNative'
+include ':react-native-google-play-integrity'
+project(':react-native-google-play-integrity').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-play-integrity/android')
 include ':react-native-device-info'
 project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
 include ':react-native-fs'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -9,5 +9,3 @@ apply from: file("../node_modules/@react-native-community/cli-platform-android/n
 include ':app'
 include ':react-native-fs'
 project(':react-native-fs').projectDir = new File(settingsDir, '../node_modules/react-native-fs/android')
-include ':react-native-google-safetynet'
-project(':react-native-google-safetynet').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-google-safetynet/android')

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "react-native-flipper": "^0.146.1",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "1.10.3",
-    "react-native-google-safetynet": "https://github.com/cozy/cozy-react-native-google-safetynet#feat/upgrade_target_sdk_31",
     "react-native-iap": "^12.11.0",
     "react-native-idle-timer": "^2.2.1",
     "react-native-immersive-bars": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@sentry/integrations": "6.19.2",
     "@sentry/react-native": "3.4.3",
     "base-64": "^1.0.0",
-    "cozy-client": "^45.4.0",
+    "cozy-client": "^45.7.0",
     "cozy-clisk": "^0.30.0",
     "cozy-device-helper": "^2.7.0",
     "cozy-flags": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "1.10.3",
     "react-native-iap": "^12.11.0",
+    "react-native-google-play-integrity": "github:cozy/react-native-google-play-integrity#1.0.1",
     "react-native-idle-timer": "^2.2.1",
     "react-native-immersive-bars": "^1.0.4",
     "react-native-inappbrowser-reborn": "^3.5.1",

--- a/src/constants/api-keys.ts
+++ b/src/constants/api-keys.ts
@@ -1,4 +1,0 @@
-import Config from 'react-native-config'
-
-export const androidSafetyNetApiKey =
-  Config.ANDROID_SAFETY_NET_API_KEY ?? 'testEnvKey'

--- a/src/libs/client.spec.js
+++ b/src/libs/client.spec.js
@@ -47,9 +47,7 @@ describe('client', () => {
       // Then
       expect(CozyClient).toHaveBeenCalledWith({
         oauth: {
-          certificationConfig: {
-            androidSafetyNetApiKey: 'testEnvKey'
-          },
+          certificationConfig: {},
           clientKind: 'mobile',
           clientName: "software.name (Becca's iPhone 6)",
           redirectURI: 'cozy://',

--- a/src/libs/client.spec.js
+++ b/src/libs/client.spec.js
@@ -5,6 +5,7 @@ import {
 } from '/libs/client'
 
 import packageJSON from '../../package.json'
+import googleServicesJson from '/../android/app/src/prod/google-services.json'
 
 import CozyClient from 'cozy-client'
 
@@ -47,7 +48,10 @@ describe('client', () => {
       // Then
       expect(CozyClient).toHaveBeenCalledWith({
         oauth: {
-          certificationConfig: {},
+          certificationConfig: {
+            cloudProjectNumber: googleServicesJson.project_info.project_number,
+            issuer: 'playintegrity'
+          },
           clientKind: 'mobile',
           clientName: "software.name (Becca's iPhone 6)",
           redirectURI: 'cozy://',

--- a/src/libs/clientHelpers/createClient.ts
+++ b/src/libs/clientHelpers/createClient.ts
@@ -1,7 +1,6 @@
 import CozyClient from 'cozy-client'
 import flag from 'cozy-flags'
 
-import { androidSafetyNetApiKey } from '/constants/api-keys'
 import strings from '/constants/strings.json'
 import {
   listenTokenRefresh,
@@ -29,7 +28,7 @@ export const createClient = async (instance: string): Promise<CozyClient> => {
       clientKind: 'mobile',
       clientName: await getClientName(),
       shouldRequireFlagshipPermissions: true,
-      certificationConfig: { androidSafetyNetApiKey }
+      certificationConfig: {}
     },
     appMetadata: {
       slug: 'flagship',

--- a/src/libs/clientHelpers/createClient.ts
+++ b/src/libs/clientHelpers/createClient.ts
@@ -8,6 +8,7 @@ import {
 } from '/libs/clientHelpers/persistClient'
 import { SOFTWARE_ID } from '/libs/constants'
 import { getClientName } from '/app/domain/authentication/services/SynchronizeService'
+import googleServicesJson from '/../android/app/src/prod/google-services.json'
 
 import packageJSON from '../../../package.json'
 
@@ -28,7 +29,10 @@ export const createClient = async (instance: string): Promise<CozyClient> => {
       clientKind: 'mobile',
       clientName: await getClientName(),
       shouldRequireFlagshipPermissions: true,
-      certificationConfig: {}
+      certificationConfig: {
+        cloudProjectNumber: googleServicesJson.project_info.project_number,
+        issuer: 'playintegrity'
+      }
     },
     appMetadata: {
       slug: 'flagship',

--- a/yarn.lock
+++ b/yarn.lock
@@ -16550,6 +16550,10 @@ react-native-gesture-handler@1.10.3:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+"react-native-google-play-integrity@github:cozy/react-native-google-play-integrity#1.0.1":
+  version "1.0.1"
+  resolved "https://codeload.github.com/cozy/react-native-google-play-integrity/tar.gz/ad182ed9e5c83a38e7cd5ee55f1fc06b5ca93e11"
+
 react-native-iap@^12.11.0:
   version "12.11.0"
   resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-12.11.0.tgz#5bb85097a717971371e256a4f48ba91e342a5c4f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6839,7 +6839,7 @@ base-64@^1.0.0:
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
   integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
 
-base64-js@*, base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.2.3, base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.2.3, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -13129,11 +13129,6 @@ jsonify@^0.0.1, jsonify@~0.0.0:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
-jwt-decode@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
-  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
-
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -16555,14 +16550,6 @@ react-native-gesture-handler@1.10.3:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-"react-native-google-safetynet@https://github.com/cozy/cozy-react-native-google-safetynet#feat/upgrade_target_sdk_31":
-  version "1.0.2"
-  resolved "https://github.com/cozy/cozy-react-native-google-safetynet#fd3957a84cf4dbace77186325b0e124ea3c98659"
-  dependencies:
-    base64-js "^1.3.0"
-    jwt-decode "^2.2.0"
-    react-native-securerandom "^0.1.1"
-
 react-native-iap@^12.11.0:
   version "12.11.0"
   resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-12.11.0.tgz#5bb85097a717971371e256a4f48ba91e342a5c4f"
@@ -16658,13 +16645,6 @@ react-native-screens@3.18.2:
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
-
-react-native-securerandom@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz#f130623a412c338b0afadedbc204c5cbb8bf2070"
-  integrity sha1-8TBiOkEsM4sK+t7bwgTFy7i/IHA=
-  dependencies:
-    base64-js "*"
 
 react-native-share@10.0.2:
   version "10.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8000,10 +8000,10 @@ cozy-client@^41.2.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^45.4.0:
-  version "45.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-45.4.0.tgz#3b6442fcbb8048337e78757ff786801e15bdec0d"
-  integrity sha512-3DA5BennYWEMaKPmOLbXif0sDm/JAEf0/Ptg4YPWjJoDJ0eDaCHykDbnCH/sgR3um2eYsGHFntTqyuffhY6Rbw==
+cozy-client@^45.7.0:
+  version "45.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-45.7.0.tgz#6ae92a4e84454c40da92749222d5b8b7e8f592ff"
+  integrity sha512-UrMuSk9cg6OJ5MXp1DAmIMgIxNKPP9dvjBuwITZTFHxkGvpTtA082LSDosMNiFrrc2W3+weCg1ExNF43I1N1Vg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"


### PR DESCRIPTION
Before merging:

- [x] `cozy-flagship-app` has to be updated to the `cozy-client` version using play integration (not published yet)
- [x] integrity flow has to be tested in real world condition when the stack can verify our token