### PR TITLE
fix: Avoid an error log during app launch without notification

### DIFF
--- a/src/libs/notifications/notifications.ts
+++ b/src/libs/notifications/notifications.ts
@@ -108,7 +108,10 @@ export const handleInitialLocalNotification = async (
 
   const notificationId = notification?.notification.id
 
-  if (notificationId === lastLocalNotificationId) {
+  if (
+    notificationId !== undefined &&
+    notificationId === lastLocalNotificationId
+  ) {
     log.error(
       'Received twice the same notification in handleInitialLocalNotification'
     )


### PR DESCRIPTION
During app launch without notification, notification id is undefined. So let's ignore this value in the comparison.