### PR TITLE
feat: Handle `planId` parameter in `startIap` url, pass language code to Cloudery and improve IAP

### DIFF
--- a/src/app/view/IAP/hooks/useClouderyOffer.ts
+++ b/src/app/view/IAP/hooks/useClouderyOffer.ts
@@ -1,6 +1,7 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { Platform } from 'react-native'
 import { initConnection, useIAP } from 'react-native-iap'
+import { getLocales } from 'react-native-localize'
 import type { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes'
 
 import { useClient, useInstanceInfo } from 'cozy-client'
@@ -116,9 +117,12 @@ export const useClouderyOffer = (): ClouderyOfferState => {
       setPopupUrl(null)
     } else {
       const offersParam = formatOffers(subscriptions)
+      const lang = getLocales()[0].languageCode
 
       const url = new URL(partialPopupUrl)
       url.searchParams.append('iap_offers', offersParam)
+      url.searchParams.append('lang', lang)
+
       setPopupUrl(url.toString())
     }
   }, [partialPopupUrl, subscriptions])

--- a/src/app/view/IAP/hooks/useClouderyOffer.ts
+++ b/src/app/view/IAP/hooks/useClouderyOffer.ts
@@ -28,13 +28,15 @@ interface BuyingStateIDLE {
 }
 interface BuyingStateBuying {
   state: 'BUYING'
-  itemId: string
+  productId: string
+  planId: string | null
   purchaseToken: string | null
   prorationMode: string | null
 }
 interface BuyingStateError {
   state: 'ERROR'
-  itemId: string
+  productId: string
+  planId: string | null
   purchaseToken: string | null
   prorationMode: string | null
 }
@@ -136,7 +138,8 @@ export const useClouderyOffer = (): ClouderyOfferState => {
 
     void buySubscription(
       client,
-      buyingState.itemId,
+      buyingState.productId,
+      buyingState.planId,
       buyingState.purchaseToken,
       buyingState.prorationMode,
       instancesInfo,


### PR DESCRIPTION
This is the last PR for IAP before merging everything

___
**feat: Handle planId parameter in startIap url**
In previous implementation the cloudery did pass only a `productId`
parameter that would contain a `planId` on Android platform

With the new implementation, the cloudery passes the `planId` in a new
parameter in addition to the `productId` that now always contains the
real `productId` on both platforms

This simplifies the `getSubscriptionOffers` method that does not
require a nested map anymore in order to retrieve the missing
`productId`

___

**feat: Add device's language code to Cloudery url when displaying offers**
The stores require us to display localized prices and descriptions to
the user when displaying IAP options

Our understanding is that descriptions and prices should displayed
using the phone's language (vs the cozy's language)

So we want to provide the phone's language code to the Cloudery using
the `lang` query parameter