### PR TITLE
[DAT-26] feat: Pass stored webhook to pipeline execution 

### DIFF
--- a/src/app/domain/geolocation/helpers/index.ts
+++ b/src/app/domain/geolocation/helpers/index.ts
@@ -1,7 +1,7 @@
 import BackgroundGeolocation from 'react-native-background-geolocation'
 import DeviceInfo from 'react-native-device-info'
 
-import CozyClient, { Q, fetchPolicies } from 'cozy-client'
+import CozyClient, { Q, QueryDefinition, fetchPolicies } from 'cozy-client'
 import Minilog from 'cozy-minilog'
 
 import { t } from '/locales/i18n'
@@ -56,10 +56,29 @@ const fetchSupportMail = async (client?: CozyClient): Promise<string> => {
   return result.data?.[0]?.attributes?.support_address ?? t('support.email')
 }
 
+export const buildServiceWebhookQuery = (): Query => {
+  // See https://github.com/cozy/cozy-client/blob/c0c7fbf1307bb383debaa6bdb3c79c29c889dbc8/packages/cozy-stack-client/src/TriggerCollection.js#L132
+  return {
+    definition: Q('io.cozy.triggers').where({
+      worker: 'service',
+      type: '@webhook'
+    }),
+    options: {
+      as: 'io.cozy.triggers/webhook/fetchOpenPathTripsWebhook',
+      fetchPolicy: fetchPolicies.olderThan(60 * 60 * 1000)
+    }
+  }
+}
+
 interface InstanceInfo {
   data?: {
     attributes?: {
       support_address?: string
     }
   }[]
+}
+
+interface Query {
+  definition: QueryDefinition
+  options: object
 }

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -52,3 +52,8 @@ export const SERVER_URL = 'https://openpath.cozycloud.cc'
  * Available events in GeolocationTrackingEmitter
  */
 export const TRIP_END = 'TRIP_END'
+
+/**
+ * CoachCO2 service
+ */
+export const FETCH_OPENPATH_TRIPS_SERVICE_NAME = 'fetchOpenPathTripsWebhook'

--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -2,12 +2,16 @@ import BackgroundGeolocation from 'react-native-background-geolocation'
 
 import Minilog from 'cozy-minilog'
 
-import { uploadData } from '/app/domain/geolocation/tracking/upload'
+import {
+  runOpenPathPipeline,
+  uploadData
+} from '/app/domain/geolocation/tracking/upload'
 import { StorageKeys, storeData, getData } from '/libs/localStore/storage'
 import { Log } from '/app/domain/geolocation/helpers'
 import { saveActivity } from '/app/domain/geolocation/tracking/tracking'
 import {
   clearAllData,
+  getFetchServiceWebHook,
   getFlagFailUpload
 } from '/app/domain/geolocation/tracking/storage'
 import { t } from '/locales/i18n'
@@ -21,13 +25,14 @@ import {
   WALKING_ACTIVITY,
   LOW_CONFIDENCE_THRESHOLD
 } from '/app/domain/geolocation/tracking/consts'
-
 export { Log, getAllLogs, sendLogFile } from '/app/domain/geolocation/helpers'
 export { getOrCreateId, updateId } from '/app/domain/geolocation/tracking/user'
 export { uploadData } from '/app/domain/geolocation/tracking/upload'
 export { GeolocationTrackingHeadlessTask } from '/app/domain/geolocation/tracking/headless'
+export { storeFetchServiceWebHook } from '/app/domain/geolocation/tracking/storage'
 import { GeolocationTrackingEmitter } from '/app/domain/geolocation/tracking/events'
 import { TRIP_END } from '/app/domain/geolocation/tracking/consts'
+import { getOrCreateId } from '/app/domain/geolocation/tracking/user'
 
 export {
   clearAllCozyGPSMemoryData,
@@ -102,7 +107,7 @@ export const stopTracking = async () => {
       await BackgroundGeolocation.stop()
       await storeData(StorageKeys.ShouldBeTrackingFlagStorageAdress, false)
       Log('Turned off tracking, uploading...')
-      await uploadData({ force: true }) // Forced end, but if fails no current solution (won't retry until turned back on)
+      await startOpenPathUploadAndPipeline({ force: true }) // Forced end, but no retry if it fails
     } else {
       Log('Tracking already off')
     }
@@ -188,8 +193,9 @@ export const handleMotionChange = async event => {
     // Get the event timestamp to filter out locations tracked after this
     const stationaryTs = event.location?.timestamp
     Log('Auto uploading from stop')
-    await uploadData({ untilTs: stationaryTs })
+    await startOpenPathUploadAndPipeline({ untilTs: stationaryTs })
     GeolocationTrackingEmitter.emit(TRIP_END)
+
     // Disable elasticity to improve next point accuracy
     disableElasticity()
   }
@@ -201,9 +207,45 @@ export const handleConnectivityChange = async event => {
   // Does not work with iOS emulator, event.connected is always false
   if (event.connected && (await getFlagFailUpload())) {
     Log('Auto uploading from reconnection and failed last attempt')
-    await uploadData()
+    await startOpenPathUploadAndPipeline()
     GeolocationTrackingEmitter.emit(TRIP_END)
   }
+}
+
+/**
+ * Upload data and run openpath pipeline
+ * This is the complete openpath process that should eventually
+ * produce new trips that will be retrieved by the coachco2 service
+ * after completion of the pipeline.
+ * A webhook is passed to the openpath server so the service it started
+ * as soon as the trips are ready to be fetched.
+ *
+ * @typedef {object} Params
+ * @property {number} untilTS - Until when the locations points should be fetched. Default is 0
+ * @property {boolean} force - Whether or not the upload should be forced
+ *
+ * @param {Params} - The method parmas
+ */
+export const startOpenPathUploadAndPipeline = async ({
+  untilTs = 0,
+  force = false
+}) => {
+  try {
+    const user = await getOrCreateId()
+    // Upload data to openpath server
+    const uploadedCount = await uploadData(user, { untilTs, force })
+    if (uploadedCount >= 0) {
+      // Start openpath pipeline
+      const webhook = (await getFetchServiceWebHook()) || ''
+      const resp = await runOpenPathPipeline(user, webhook)
+      if (resp?.ok) {
+        Log('Pipeline successfully run')
+      }
+    }
+  } catch (err) {
+    Log('Failed openpath processing: ' + JSON.stringify(err))
+  }
+  return
 }
 
 // Register on activity change

--- a/src/app/domain/geolocation/tracking/storage.js
+++ b/src/app/domain/geolocation/tracking/storage.js
@@ -88,6 +88,14 @@ export const getFlagFailUpload = async () => {
   }
 }
 
+export const getFetchServiceWebHook = async () => {
+  return await getData(StorageKeys.ServiceWebhookURL)
+}
+
+export const storeFetchServiceWebHook = async webhookURL => {
+  return storeData(StorageKeys.ServiceWebhookURL, webhookURL)
+}
+
 export const getId = async () => {
   return await getData(StorageKeys.IdStorageAdress)
 }

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -23,7 +23,8 @@ export enum StorageKeys {
   LastStartTransitionTsKey = 'CozyGPSMemory.LastStartTransitionTsKey',
   GeolocationTrackingConfig = 'CozyGPSMemory.TrackingConfig',
   Activities = 'CozyGPSMemory.Activities',
-  FirstTimeserie = 'CozyGPSMemory.FirstTimeserie'
+  FirstTimeserie = 'CozyGPSMemory.FirstTimeserie',
+  ServiceWebhookURL = 'CozyGPSMemory.ServiceWebhookURL'
 }
 
 export type IconsCache = Record<string, { version: string; xml: string }>


### PR DESCRIPTION
When passing a webhook URL to the pipeline execution request, the server
will request it after its completion.
This webhook is typically the openpath trips fetching. Thanks to this,
we will now be able to retrieve the trips as soon as they are produced.

Related to https://github.com/cozy/coachCO2/pull/370