### PR TITLE
fix: don't hide splashcreen by default on sec flow (VO-197)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react-native-background-geolocation": "^4.13.3",
     "react-native-background-upload": "^6.6.0",
     "react-native-biometrics": "3.0.1",
-    "react-native-bootsplash": "github:cozy/react-native-bootsplash#0.0.1",
+    "react-native-bootsplash": "github:cozy/react-native-bootsplash#0.0.2",
     "react-native-change-icon": "^4.0.0",
     "react-native-config": "1.5.0",
     "react-native-device-info": "^10.3.0",

--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -75,8 +75,6 @@ export const determineSecurityFlow = async (
       return showSecurityScreen(lockScreens.PIN_PROMPT)
     }
   }
-
-  return hideSplashScreen(splashScreens.LOCK_SCREEN)
 }
 
 export const getSecFlowInitParams = async (

--- a/src/app/theme/SplashScreenService.ts
+++ b/src/app/theme/SplashScreenService.ts
@@ -18,7 +18,7 @@ export class SplashScreenService {
 export const showSplashScreen = (
   bootsplashName?: SplashScreenEnum
 ): Promise<void> => {
-  devlog('☁️ showSplashScreen called')
+  devlog(`☁️ showSplashScreen called with ${bootsplashName ?? 'undefined'}`)
 
   flagshipUIEventHandler.emit(
     flagshipUIEvents.SET_COMPONENT_COLORS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16368,9 +16368,9 @@ react-native-biometrics@3.0.1:
   resolved "https://registry.yarnpkg.com/react-native-biometrics/-/react-native-biometrics-3.0.1.tgz#23c5a0bdbae1fcb1e08b22936223fe0fc4af846e"
   integrity sha512-Ru80gXRa9KG04sl5AB9HyjLjVbduhqZVjA+AiOSGqr+fNqCDmCu9y5WEksnjbnniNLmq1yGcw+qcLXmR1ddLDQ==
 
-"react-native-bootsplash@github:cozy/react-native-bootsplash#0.0.1":
-  version "3.2.3"
-  resolved "https://codeload.github.com/cozy/react-native-bootsplash/tar.gz/1418382cf5d267199fb63f943e75edf42289f21e"
+"react-native-bootsplash@github:cozy/react-native-bootsplash#0.0.2":
+  version "3.2.4"
+  resolved "https://codeload.github.com/cozy/react-native-bootsplash/tar.gz/f5eb7d6fd628d27f61cc6df2e69d20b0b6960ebe"
   dependencies:
     chalk "^4.1.0"
     fs-extra "^9.1.0"


### PR DESCRIPTION
It resulted in splashscreen being hidden before the
home webview finished loading
