### PR TITLE
[VO-171] fix: Force android tools version on CI when signing APK

### DIFF
--- a/.github/workflows/build-android-dev.yml
+++ b/.github/workflows/build-android-dev.yml
@@ -109,6 +109,8 @@ jobs:
           alias: ${{ secrets[format('{0}_ANDROID_ALIAS', inputs.brand)] }}
           keyStorePassword: ${{ secrets[format('{0}_ANDROID_KEY_STORE_PASSWORD', inputs.brand)] }}
           keyPassword: ${{ secrets[format('{0}_ANDROID_KEY_PASSWORD', inputs.brand)] }}
+        env:
+          BUILD_TOOLS_VERSION: "33.0.0"
 
       - name: Upload Dev artifact to GitHub
         uses: actions/upload-artifact@v3
@@ -126,6 +128,8 @@ jobs:
           alias: ${{ secrets[format('{0}_ANDROID_ALIAS', inputs.brand)] }}
           keyStorePassword: ${{ secrets[format('{0}_ANDROID_KEY_STORE_PASSWORD', inputs.brand)] }}
           keyPassword: ${{ secrets[format('{0}_ANDROID_KEY_PASSWORD', inputs.brand)] }}
+        env:
+          BUILD_TOOLS_VERSION: "33.0.0"
 
       - name: Upload Prod artifact to GitHub
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -95,6 +95,8 @@ jobs:
           alias: ${{ secrets[format('{0}_ANDROID_ALIAS', inputs.brand)] }}
           keyStorePassword: ${{ secrets[format('{0}_ANDROID_KEY_STORE_PASSWORD', inputs.brand)] }}
           keyPassword: ${{ secrets[format('{0}_ANDROID_KEY_PASSWORD', inputs.brand)] }}
+        env:
+          BUILD_TOOLS_VERSION: "33.0.0"
 
       - name: Upload AAB artifact to GitHub
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Since January 8 the  `ubuntu-latest` image excludes Android SDKs prior to version 31

By default the `r0adkll/sign-android-release` package uses Android SDK 29. So the build would fail

In order to fix that, we can set the `BUILD_TOOLS_VERSION` env variable to define which version `r0adkll/sign-android-release` should use

Related doc:
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

Related issue: r0adkll/sign-android-release#84

> [!IMPORTANT]
> This seems to also fix the bug we had on `prod` build that would instantaneously crash when opening them on Android devices