### PR TITLE
[VO-258] feat: Allow to send logs my email after clicking on a deep link

### DIFF
--- a/docs/how-to-retrieve-logs-in-release.md
+++ b/docs/how-to-retrieve-logs-in-release.md
@@ -8,6 +8,17 @@ However there are still some solution to retrieve some logs from the device
 
 This document explains how to retrieve them
 
+# Send logs by email
+
+It is possible to send logs by email using the 3 following links:
+
+- https://links.mycozy.cloud/flagship/enablelogs or [cozy://enablelogs](cozy://enablelogs)
+  - tell the app to start recording logs into a local file
+- https://links.mycozy.cloud/flagship/sendlogs or [cozy://sendlogs](cozy://sendlogs)
+  - trigger the OS send email intent pre-filled with log files and Cozy's support email
+- https://links.mycozy.cloud/flagship/disablelogs or [cozy://disablelogs](cozy://disablelogs)
+  - tell the app to stop recording logs
+
 # Android
 
 To retrieve Android logs, you need to use ADB

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -530,6 +530,9 @@ PODS:
     - Firebase/Messaging (= 8.15.0)
     - React-Core
     - RNFBApp
+  - RNFileLogger (0.4.1):
+    - CocoaLumberjack
+    - React
   - RNFileViewer (2.1.5):
     - React-Core
   - RNFS (2.20.0):
@@ -655,6 +658,7 @@ DEPENDENCIES:
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
+  - RNFileLogger (from `../node_modules/react-native-file-logger`)
   - RNFileViewer (from `../node_modules/react-native-file-viewer`)
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
@@ -830,6 +834,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBMessaging:
     :path: "../node_modules/@react-native-firebase/messaging"
+  RNFileLogger:
+    :path: "../node_modules/react-native-file-logger"
   RNFileViewer:
     :path: "../node_modules/react-native-file-viewer"
   RNFS:
@@ -956,6 +962,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
   RNFBApp: e4439717c23252458da2b41b81b4b475c86f90c4
   RNFBMessaging: 40dac204b4197a2661dec5be964780c6ec39bf65
+  RNFileLogger: 9eaf7a6ea709eaaffe646cc485b98ae1dbf1e9f0
   RNFileViewer: ce7ca3ac370e18554d35d6355cffd7c30437c592
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-native-config": "1.5.0",
     "react-native-device-info": "^10.3.0",
     "react-native-document-scanner-plugin": "^0.7.3",
+    "react-native-file-logger": "^0.4.1",
     "react-native-file-viewer": "^2.1.5",
     "react-native-flipper": "^0.146.1",
     "react-native-fs": "^2.20.0",

--- a/patches/react-native-file-logger+0.4.1.patch
+++ b/patches/react-native-file-logger+0.4.1.patch
@@ -1,0 +1,86 @@
+diff --git a/node_modules/react-native-file-logger/ios/FileLogger.m b/node_modules/react-native-file-logger/ios/FileLogger.m
+index 7ee491d..978ce4e 100644
+--- a/node_modules/react-native-file-logger/ios/FileLogger.m
++++ b/node_modules/react-native-file-logger/ios/FileLogger.m
+@@ -4,6 +4,7 @@
+ #import <CocoaLumberjack/CocoaLumberjack.h>
+ #import <MessageUI/MessageUI.h>
+ #import "FileLoggerFormatter.h"
++#import "RCTLog.h"
+ 
+ enum LogLevel {
+     LOG_LEVEL_DEBUG,
+@@ -19,6 +20,17 @@ @interface FileLogger () <MFMailComposeViewControllerDelegate>
+ @end
+ 
+ @implementation FileLogger
++{
++    NSMutableDictionary *_promisesList;
++}
++
++- (instancetype)init
++{
++  if ((self = [super init])) {
++      _promisesList = [[NSMutableDictionary alloc] init];
++  }
++  return self;
++}
+ 
+ RCT_EXPORT_MODULE()
+ 
+@@ -101,6 +113,8 @@ - (dispatch_queue_t)methodQueue {
+         [composeViewController setMessageBody:body isHTML:NO];
+     }
+     
++    _promisesList[RCTKeyForInstance(composeViewController)] = @[resolve, reject];
++
+     NSArray<NSString*>* logFiles = self.fileLogger.logFileManager.sortedLogFilePaths;
+     for (NSString* logFile in logFiles) {
+         NSData* data = [NSData dataWithContentsOfFile:logFile];
+@@ -112,13 +126,44 @@ - (dispatch_queue_t)methodQueue {
+         presentingViewController = presentingViewController.presentedViewController;
+     }
+     [presentingViewController presentViewController:composeViewController animated:YES completion:nil];
+-    
+-    resolve(nil);
+ }
+ 
+ - (void)mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error {
++    NSString *key = RCTKeyForInstance(controller);
++    
++    NSMutableArray *promise = _promisesList[key];
++    if (promise) {
++        RCTPromiseResolveBlock resolve = promise[0];
++        RCTPromiseRejectBlock reject = promise[1];
++        switch (result) {
++            case MFMailComposeResultSent:
++            resolve(@"sent");
++            break;
++            case MFMailComposeResultSaved:
++            resolve(@"saved");
++            break;
++            case MFMailComposeResultCancelled:
++            resolve(@"cancelled");
++            break;
++            case MFMailComposeResultFailed:
++            reject(@"failed", error.localizedDescription, nil);
++            break;
++            default:
++            reject(@"error", @"Unknown error", nil);
++            break;
++        }
++        [_promisesList removeObjectForKey:key];
++    } else {
++        RCTLogWarn(@"No promise registered for mail: %@", controller.title);
++    }
++    
+     [controller dismissViewControllerAnimated:YES completion:nil];
+ }
+ 
++static NSString *RCTKeyForInstance(id instance)
++{
++  return [NSString stringWithFormat:@"%p", instance];
++}
++
+ @end
+ 

--- a/src/App.js
+++ b/src/App.js
@@ -61,6 +61,9 @@ import LauncherView from '/screens/konnectors/LauncherView'
 import { useShareFiles } from '/app/domain/osReceive/services/shareFilesService'
 import { ClouderyOffer } from '/app/view/IAP/ClouderyOffer'
 import { useDimensions } from '/libs/dimensions'
+import { configureFileLogger } from '/app/domain/logger/fileLogger'
+
+configureFileLogger()
 
 // Polyfill needed for cozy-client connection
 if (!global.btoa) {

--- a/src/app/domain/geolocation/helpers/index.ts
+++ b/src/app/domain/geolocation/helpers/index.ts
@@ -3,8 +3,8 @@ import DeviceInfo from 'react-native-device-info'
 
 import CozyClient, { Q, QueryDefinition, fetchPolicies } from 'cozy-client'
 
+import { fetchSupportMail } from '/app/domain/logger/supportEmail'
 import { devlog } from '/core/tools/env'
-import { t } from '/locales/i18n'
 
 export const getTs = (location: { timestamp: string }): number => {
   return parseISOString(location.timestamp).getTime() / 1000
@@ -38,22 +38,6 @@ export const sendLogFile = async (client?: CozyClient): Promise<boolean> => {
   return Logger.emailLog(emailSupport)
 }
 
-const fetchSupportMail = async (client?: CozyClient): Promise<string> => {
-  if (!client) {
-    return t('support.email')
-  }
-
-  const result = (await client.fetchQueryAndGetFromState({
-    definition: Q('io.cozy.settings').getById('io.cozy.settings.context'),
-    options: {
-      as: 'io.cozy.settings/io.cozy.settings.context',
-      fetchPolicy: fetchPolicies.olderThan(60 * 60 * 1000)
-    }
-  })) as InstanceInfo
-
-  return result.data?.[0]?.attributes?.support_address ?? t('support.email')
-}
-
 export const buildServiceWebhookQuery = (): Query => {
   // See https://github.com/cozy/cozy-client/blob/c0c7fbf1307bb383debaa6bdb3c79c29c889dbc8/packages/cozy-stack-client/src/TriggerCollection.js#L132
   return {
@@ -66,14 +50,6 @@ export const buildServiceWebhookQuery = (): Query => {
       fetchPolicy: fetchPolicies.olderThan(60 * 60 * 1000)
     }
   }
-}
-
-interface InstanceInfo {
-  data?: {
-    attributes?: {
-      support_address?: string
-    }
-  }[]
 }
 
 interface Query {

--- a/src/app/domain/logger/deeplinkHandler.spec.ts
+++ b/src/app/domain/logger/deeplinkHandler.spec.ts
@@ -1,0 +1,44 @@
+import CozyClient from 'cozy-client'
+
+import { handleLogsDeepLink } from '/app/domain/logger/deeplinkHandler'
+import {
+  disableLogs,
+  enableLogs,
+  sendLogs
+} from '/app/domain/logger/fileLogger'
+
+jest.mock('/app/domain/logger/fileLogger')
+
+describe('deeplinkHandler', () => {
+  describe('handleLogsDeepLink', () => {
+    it('should handle EnableLogs deep links', () => {
+      const client = new CozyClient()
+
+      handleLogsDeepLink(
+        'https://links.mycozy.cloud/flagship/enablelogs',
+        client
+      )
+
+      expect(enableLogs).toHaveBeenCalled()
+    })
+
+    it('should handle DisableLogs deep links', () => {
+      const client = new CozyClient()
+
+      handleLogsDeepLink(
+        'https://links.mycozy.cloud/flagship/disablelogs',
+        client
+      )
+
+      expect(disableLogs).toHaveBeenCalled()
+    })
+
+    it('should handle SendLog deep links', () => {
+      const client = new CozyClient()
+
+      handleLogsDeepLink('https://links.mycozy.cloud/flagship/sendlogs', client)
+
+      expect(sendLogs).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/app/domain/logger/deeplinkHandler.ts
+++ b/src/app/domain/logger/deeplinkHandler.ts
@@ -1,0 +1,60 @@
+import CozyClient from 'cozy-client'
+
+import {
+  disableLogs,
+  enableLogs,
+  sendLogs
+} from '/app/domain/logger/fileLogger'
+import strings from '/constants/strings.json'
+
+export const handleLogsDeepLink = (
+  url: string,
+  client?: CozyClient
+): boolean => {
+  if (isSendLogsDeepLink(url)) {
+    void sendLogs(client)
+
+    return true
+  }
+
+  if (isEnableLogsDeepLink(url)) {
+    void enableLogs()
+
+    return true
+  }
+
+  if (isDisableLogsDeepLink(url)) {
+    void disableLogs()
+
+    return true
+  }
+
+  return false
+}
+
+const isSendLogsDeepLink = (url: string): boolean => {
+  const deepLinks = [
+    `${strings.COZY_SCHEME}sendlogs`,
+    `${strings.UNIVERSAL_LINK_BASE}/sendlogs`
+  ]
+
+  return deepLinks.includes(url.toLowerCase())
+}
+
+const isEnableLogsDeepLink = (url: string): boolean => {
+  const deepLinks = [
+    `${strings.COZY_SCHEME}enablelogs`,
+    `${strings.UNIVERSAL_LINK_BASE}/enablelogs`
+  ]
+
+  return deepLinks.includes(url.toLowerCase())
+}
+
+const isDisableLogsDeepLink = (url: string): boolean => {
+  const deepLinks = [
+    `${strings.COZY_SCHEME}disablelogs`,
+    `${strings.UNIVERSAL_LINK_BASE}/disablelogs`
+  ]
+
+  return deepLinks.includes(url.toLowerCase())
+}

--- a/src/app/domain/logger/fileLogger.spec.ts
+++ b/src/app/domain/logger/fileLogger.spec.ts
@@ -85,10 +85,12 @@ describe('fileLogger', () => {
       await sendLogs(client)
 
       expect(Alert.alert).not.toHaveBeenCalled()
-      expect(sendLogFilesByEmailSpy).toHaveBeenCalledWith({
-        subject: 'Log file for ',
-        to: 'somemail@somedomain.com'
-      })
+      expect(sendLogFilesByEmailSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: 'Log file for ',
+          to: 'somemail@somedomain.com'
+        })
+      )
     })
 
     it('should do nothing and display alert if logs are disabled', async () => {

--- a/src/app/domain/logger/fileLogger.spec.ts
+++ b/src/app/domain/logger/fileLogger.spec.ts
@@ -1,0 +1,162 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { FileLogger } from 'react-native-file-logger'
+import { Alert } from 'react-native'
+
+import CozyClient from 'cozy-client'
+
+import {
+  configureFileLogger,
+  disableLogs,
+  enableLogs,
+  sendLogs
+} from '/app/domain/logger/fileLogger'
+import { fetchSupportMail } from '/app/domain/logger/supportEmail'
+import * as SplashScreenService from '/app/theme/SplashScreenService'
+import {
+  DevicePersistedStorageKeys,
+  getData,
+  storeData
+} from '/libs/localStore'
+
+jest.mock('react-native-file-logger')
+jest.mock('/app/domain/logger/supportEmail')
+jest.mock('/app/theme/SplashScreenService')
+
+jest.spyOn(Alert, 'alert')
+
+// Spies are needed on FileLogger to prevent `unbound-method` eslint error
+const enableConsoleCaptureSpy = jest.spyOn(FileLogger, 'enableConsoleCapture')
+const disableConsoleCaptureSpy = jest.spyOn(FileLogger, 'disableConsoleCapture')
+const deleteLogFilesSpy = jest.spyOn(FileLogger, 'deleteLogFiles')
+const sendLogFilesByEmailSpy = jest.spyOn(FileLogger, 'sendLogFilesByEmail')
+const configureSpy = jest.spyOn(FileLogger, 'configure')
+
+const hideSplashScreenSpy = jest.spyOn(SplashScreenService, 'hideSplashScreen')
+const showSplashScreenSpy = jest.spyOn(SplashScreenService, 'showSplashScreen')
+
+const mockFetchSupportMail = fetchSupportMail as jest.Mock
+
+describe('fileLogger', () => {
+  describe('enableLogs', () => {
+    it('should enable ConsoleCapture', async () => {
+      await enableLogs()
+
+      expect(enableConsoleCaptureSpy).toHaveBeenCalled()
+    })
+
+    it('should store enabled state in AsyncStorage', async () => {
+      await storeData(DevicePersistedStorageKeys.LogsEnabled, false)
+
+      await enableLogs()
+
+      expect(await getData(DevicePersistedStorageKeys.LogsEnabled)).toBe(true)
+    })
+  })
+
+  describe('disableLogs', () => {
+    it('should disable ConsoleCapture', async () => {
+      await disableLogs()
+
+      expect(disableConsoleCaptureSpy).toHaveBeenCalled()
+    })
+
+    it('should store disabled state in AsyncStorage', async () => {
+      await storeData(DevicePersistedStorageKeys.LogsEnabled, true)
+
+      await disableLogs()
+
+      expect(await getData(DevicePersistedStorageKeys.LogsEnabled)).toBe(false)
+    })
+
+    it('should delete log file', async () => {
+      await disableLogs()
+
+      expect(deleteLogFilesSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('sendLogs', () => {
+    it('should send logs', async () => {
+      await storeData(DevicePersistedStorageKeys.LogsEnabled, true)
+      const client = new CozyClient()
+
+      mockFetchSupportMail.mockResolvedValue('somemail@somedomain.com')
+
+      await sendLogs(client)
+
+      expect(Alert.alert).not.toHaveBeenCalled()
+      expect(sendLogFilesByEmailSpy).toHaveBeenCalledWith({
+        subject: 'Log file for ',
+        to: 'somemail@somedomain.com'
+      })
+    })
+
+    it('should do nothing and display alert if logs are disabled', async () => {
+      await storeData(DevicePersistedStorageKeys.LogsEnabled, false)
+      const client = new CozyClient()
+
+      await sendLogs(client)
+
+      expect(Alert.alert).toHaveBeenCalled()
+      expect(sendLogFilesByEmailSpy).not.toHaveBeenCalled()
+    })
+
+    it('should show SplashScreen before sending email and hide it after', async () => {
+      await storeData(DevicePersistedStorageKeys.LogsEnabled, true)
+      const client = new CozyClient()
+
+      await sendLogs(client)
+
+      const showSplashScreenOrder =
+        showSplashScreenSpy.mock.invocationCallOrder[0]
+      const hideSplashScreenOrder =
+        hideSplashScreenSpy.mock.invocationCallOrder[0]
+      const sendLogFilesByEmailOder =
+        sendLogFilesByEmailSpy.mock.invocationCallOrder[0]
+
+      expect(showSplashScreenOrder).toBeLessThan(sendLogFilesByEmailOder)
+      expect(sendLogFilesByEmailOder).toBeLessThan(hideSplashScreenOrder)
+    })
+  })
+
+  describe('configureFileLogger', () => {
+    it('should configure FileLogger and enable ConsoleCapture if logs are enabled', async () => {
+      await storeData(DevicePersistedStorageKeys.LogsEnabled, true)
+
+      await configureFileLogger()
+
+      expect(configureSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          captureConsole: false
+        })
+      )
+      expect(enableConsoleCaptureSpy).toHaveBeenCalled()
+    })
+
+    it('should configure FileLogger with ConsoleCapture disabled if logs are disabled', async () => {
+      await storeData(DevicePersistedStorageKeys.LogsEnabled, false)
+
+      await configureFileLogger()
+
+      expect(configureSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          captureConsole: false
+        })
+      )
+      expect(enableConsoleCaptureSpy).not.toHaveBeenCalled()
+    })
+
+    it('should configure FileLogger with ConsoleCapture disabled if logs are not configured in AsyncStorage', async () => {
+      await AsyncStorage.clear()
+
+      await configureFileLogger()
+
+      expect(configureSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          captureConsole: false
+        })
+      )
+      expect(enableConsoleCaptureSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/app/domain/logger/fileLogger.ts
+++ b/src/app/domain/logger/fileLogger.ts
@@ -1,7 +1,34 @@
 import { FileLogger, LogLevel } from 'react-native-file-logger'
 
+import type CozyClient from 'cozy-client'
+
+import { fetchSupportMail } from '/app/domain/logger/supportEmail'
+import strings from '/constants/strings.json'
+
 export const configureFileLogger = async (): Promise<void> => {
   await FileLogger.configure({
     logLevel: LogLevel.Info
+  })
+}
+
+export const isSendLogsDeepLink = (url: string): boolean => {
+  const deepLinks = [
+    `${strings.COZY_SCHEME}sendlogs`,
+    `${strings.UNIVERSAL_LINK_BASE}/sendlogs`
+  ]
+
+  return deepLinks.includes(url.toLowerCase())
+}
+
+export const sendLogs = async (client?: CozyClient): Promise<void> => {
+  const supportEmail = await fetchSupportMail(client)
+
+  const instance = client?.getStackClient().uri ?? 'not logged app'
+
+  const subject = `Log file for ${instance}`
+
+  await FileLogger.sendLogFilesByEmail({
+    to: supportEmail,
+    subject: subject
   })
 }

--- a/src/app/domain/logger/fileLogger.ts
+++ b/src/app/domain/logger/fileLogger.ts
@@ -1,0 +1,7 @@
+import { FileLogger, LogLevel } from 'react-native-file-logger'
+
+export const configureFileLogger = async (): Promise<void> => {
+  await FileLogger.configure({
+    logLevel: LogLevel.Info
+  })
+}

--- a/src/app/domain/logger/fileLogger.ts
+++ b/src/app/domain/logger/fileLogger.ts
@@ -1,4 +1,5 @@
 import { Alert } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
 import { FileLogger, LogLevel } from 'react-native-file-logger'
 
 import type CozyClient from 'cozy-client'
@@ -52,7 +53,8 @@ export const sendLogs = async (client?: CozyClient): Promise<void> => {
   log.info('Start email intent')
   const emailResult = await FileLogger.sendLogFilesByEmail({
     to: supportEmail,
-    subject: subject
+    subject: subject,
+    body: buildMessageBody()
   })
   log.info('Did finish email intent:', emailResult)
   await hideSplashScreen(splashScreens.SEND_LOG_EMAIL)
@@ -94,4 +96,20 @@ const areLogsEnabledInAsyncStorage = async (): Promise<boolean> => {
   const logsEnabled = await getData(DevicePersistedStorageKeys.LogsEnabled)
 
   return logsEnabled === true
+}
+
+const buildMessageBody = (): string => {
+  const appVersion = DeviceInfo.getVersion()
+  const appBuild = DeviceInfo.getBuildNumber()
+  const bundle = DeviceInfo.getBundleId()
+  const deviceBrand = DeviceInfo.getBrand()
+  const deviceModel = DeviceInfo.getModel()
+  const os = DeviceInfo.getSystemName()
+  const version = DeviceInfo.getSystemVersion()
+
+  const appInfo = `App info: ${appVersion} (${appBuild})`
+  const bundleInfo = `App bundle: ${bundle}`
+  const deviceInfo = `Device info: ${deviceBrand} ${deviceModel} ${os} ${version}`
+
+  return `${appInfo}\n${bundleInfo}\n${deviceInfo}`
 }

--- a/src/app/domain/logger/fileLogger.ts
+++ b/src/app/domain/logger/fileLogger.ts
@@ -6,6 +6,11 @@ import Minilog from 'cozy-minilog'
 
 import { fetchSupportMail } from '/app/domain/logger/supportEmail'
 import {
+  hideSplashScreen,
+  showSplashScreen,
+  splashScreens
+} from '/app/theme/SplashScreenService'
+import {
   DevicePersistedStorageKeys,
   getData,
   storeData
@@ -43,10 +48,14 @@ export const sendLogs = async (client?: CozyClient): Promise<void> => {
 
   const subject = `Log file for ${instance}`
 
-  await FileLogger.sendLogFilesByEmail({
+  await showSplashScreen(splashScreens.SEND_LOG_EMAIL)
+  log.info('Start email intent')
+  const emailResult = await FileLogger.sendLogFilesByEmail({
     to: supportEmail,
     subject: subject
   })
+  log.info('Did finish email intent:', emailResult)
+  await hideSplashScreen(splashScreens.SEND_LOG_EMAIL)
 }
 
 const showDisabledLogsError = (): void => {

--- a/src/app/domain/logger/fileLogger.ts
+++ b/src/app/domain/logger/fileLogger.ts
@@ -1,26 +1,42 @@
+import { Alert } from 'react-native'
 import { FileLogger, LogLevel } from 'react-native-file-logger'
 
 import type CozyClient from 'cozy-client'
+import Minilog from 'cozy-minilog'
 
 import { fetchSupportMail } from '/app/domain/logger/supportEmail'
-import strings from '/constants/strings.json'
+import {
+  DevicePersistedStorageKeys,
+  getData,
+  storeData
+} from '/libs/localStore/storage'
+import { t } from '/locales/i18n'
+
+const log = Minilog('🗒️ File Logger')
 
 export const configureFileLogger = async (): Promise<void> => {
+  log.info('Configure file logger')
   await FileLogger.configure({
-    logLevel: LogLevel.Info
+    logLevel: LogLevel.Info,
+    captureConsole: false
   })
-}
 
-export const isSendLogsDeepLink = (url: string): boolean => {
-  const deepLinks = [
-    `${strings.COZY_SCHEME}sendlogs`,
-    `${strings.UNIVERSAL_LINK_BASE}/sendlogs`
-  ]
-
-  return deepLinks.includes(url.toLowerCase())
+  if (await areLogsEnabledInAsyncStorage()) {
+    log.info('Console capture is enabled')
+    FileLogger.enableConsoleCapture()
+  } else {
+    log.info('Console capture is disabled')
+  }
 }
 
 export const sendLogs = async (client?: CozyClient): Promise<void> => {
+  log.info('Send logs')
+
+  const areLogsEnabled = await areLogsEnabledInAsyncStorage()
+  if (!areLogsEnabled) {
+    return showDisabledLogsError()
+  }
+
   const supportEmail = await fetchSupportMail(client)
 
   const instance = client?.getStackClient().uri ?? 'not logged app'
@@ -31,4 +47,42 @@ export const sendLogs = async (client?: CozyClient): Promise<void> => {
     to: supportEmail,
     subject: subject
   })
+}
+
+const showDisabledLogsError = (): void => {
+  Alert.alert(
+    t('modals.LogDisabledError.title'),
+    t('modals.LogDisabledError.body'),
+    undefined,
+    {
+      cancelable: true
+    }
+  )
+}
+
+export const enableLogs = async (): Promise<void> => {
+  log.info('Enable logs')
+  FileLogger.enableConsoleCapture()
+  await enableLogsInAsyncStorage()
+}
+
+export const disableLogs = async (): Promise<void> => {
+  log.info('Disable logs and delete log files')
+  FileLogger.disableConsoleCapture()
+  await disableLogsInAsyncStorage()
+  await FileLogger.deleteLogFiles()
+}
+
+const enableLogsInAsyncStorage = (): Promise<void> => {
+  return storeData(DevicePersistedStorageKeys.LogsEnabled, true)
+}
+
+const disableLogsInAsyncStorage = (): Promise<void> => {
+  return storeData(DevicePersistedStorageKeys.LogsEnabled, false)
+}
+
+const areLogsEnabledInAsyncStorage = async (): Promise<boolean> => {
+  const logsEnabled = await getData(DevicePersistedStorageKeys.LogsEnabled)
+
+  return logsEnabled === true
 }

--- a/src/app/domain/logger/supportEmail.ts
+++ b/src/app/domain/logger/supportEmail.ts
@@ -1,0 +1,29 @@
+import CozyClient, { Q, fetchPolicies } from 'cozy-client'
+
+import { t } from '/locales/i18n'
+
+export const fetchSupportMail = async (
+  client?: CozyClient
+): Promise<string> => {
+  if (!client) {
+    return t('support.email')
+  }
+
+  const result = (await client.fetchQueryAndGetFromState({
+    definition: Q('io.cozy.settings').getById('io.cozy.settings.context'),
+    options: {
+      as: 'io.cozy.settings/io.cozy.settings.context',
+      fetchPolicy: fetchPolicies.olderThan(60 * 60 * 1000)
+    }
+  })) as InstanceInfo
+
+  return result.data?.[0]?.attributes?.support_address ?? t('support.email')
+}
+
+interface InstanceInfo {
+  data?: {
+    attributes?: {
+      support_address?: string
+    }
+  }[]
+}

--- a/src/app/theme/SplashScreenService.ts
+++ b/src/app/theme/SplashScreenService.ts
@@ -12,6 +12,7 @@ const splashScreenLogger = Minilog('☁️ SplashScreen')
 export const splashScreens = {
   LOCK_SCREEN: 'LOCK_SCREEN',
   SECURE_BACKGROUND: 'secure_background', // this mirrors native declaration
+  SEND_LOG_EMAIL: 'SEND_LOG_EMAIL',
   GLOBAL: 'global'
 } as const
 

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 
 import { deconstructCozyWebLinkWithSlug } from 'cozy-client'
 
-import { isSendLogsDeepLink, sendLogs } from '/app/domain/logger/fileLogger'
+import { handleLogsDeepLink } from '/app/domain/logger/deeplinkHandler'
 import { SentryCustomTags, setSentryTag } from '/libs/monitoring/Sentry'
 import { manageIconCache } from '/libs/functions/iconTable'
 import { getDefaultIconParams } from '/libs/functions/openApp'
@@ -156,8 +156,8 @@ export const useAppBootstrap = client => {
     const subscription = Linking.addEventListener('url', ({ url }) => {
       log.debug(`🔗 Linking URL is ${url}`)
 
-      if (isSendLogsDeepLink(url)) {
-        return sendLogs(client)
+      if (handleLogsDeepLink(url, client)) {
+        return
       }
 
       if (!client) {

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 
 import { deconstructCozyWebLinkWithSlug } from 'cozy-client'
 
+import { isSendLogsDeepLink, sendLogs } from '/app/domain/logger/fileLogger'
 import { SentryCustomTags, setSentryTag } from '/libs/monitoring/Sentry'
 import { manageIconCache } from '/libs/functions/iconTable'
 import { getDefaultIconParams } from '/libs/functions/openApp'
@@ -154,6 +155,10 @@ export const useAppBootstrap = client => {
 
     const subscription = Linking.addEventListener('url', ({ url }) => {
       log.debug(`🔗 Linking URL is ${url}`)
+
+      if (isSendLogsDeepLink(url)) {
+        return sendLogs(client)
+      }
 
       if (!client) {
         const action = parseOnboardLink(url)

--- a/src/hooks/useAppBootstrap.spec.js
+++ b/src/hooks/useAppBootstrap.spec.js
@@ -26,6 +26,10 @@ const APP_ANDROID_SCHEME = `cozy://drive/folder/SOME_FOLDER_ID?fallback=${APP_FA
 const INVALID_LINK = 'https://foo.com'
 const REDIRECTION_URL = 'http://drive.mycozy.test/#/folder'
 
+jest.mock('/app/domain/logger/deeplinkHandler', () => ({
+  handleLogsDeepLink: jest.fn()
+}))
+
 jest.mock('../libs/client', () => ({
   clearClient: jest.fn()
 }))

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -44,6 +44,7 @@ export enum CozyPersistedStorageKeys {
   Not removed at logout.
 */
 export enum DevicePersistedStorageKeys {
+  LogsEnabled = '@cozy_AmiralAppLogsEnabled',
   OnboardingPartner = '@cozy_AmiralAppOnboardingPartnerConfig',
   ClouderyEnv = '@cozy_AmiralAppClouderyEnvConfig',
   Bundle = '@cozy_AmiralAppBundleConfig'
@@ -60,6 +61,7 @@ export interface StorageItems {
   oauth: OauthData
   cookie: Cookies
   clouderyEnv: string
+  logsEnabled: number
 }
 
 export const storeData = async (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -175,6 +175,10 @@
     },
     "IconChangedModal": {
       "description": "The icon of the 'Cozy' application has been modified."
+    },
+    "LogDisabledError": {
+      "title": "Cannot send logs",
+      "body": "Logs are disabled, please enable them first and then send them again"
     }
   },
   "software": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -156,6 +156,10 @@
   "modals": {
     "IconChangedModal": {
       "description": "El ícono de la aplicación 'Cozy' ha sido modificado."
+    },
+    "LogDisabledError": {
+      "title": "No se pueden enviar registros",
+      "body": "Los registros están deshabilitados, por favor habilítelos primero y luego envíelos de nuevo"
     }
   },
   "software": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -177,6 +177,10 @@
       "title": "Accès révoqué",
       "body": "Vous semblez avoir révoqué cet appareil depuis votre Cozy. Pour accéder à nouveau à vos données, veuillez vous reconnecter. Si cette action ne vient pas de vous, n'hésitez pas à nous contacter à <linkTag>email</linkTag>.",
       "button": "Se reconnecter"
+    },
+    "LogDisabledError": {
+      "title": "Envoi impossible",
+      "body": "Les logs sont désactivés, veuillez d'abord activer les logs avant de les envoyer"
     }
   },
   "software": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16369,6 +16369,11 @@ react-native-document-scanner-plugin@^0.7.3:
   resolved "https://registry.yarnpkg.com/react-native-document-scanner-plugin/-/react-native-document-scanner-plugin-0.7.3.tgz#a0212e687681e3b1ed9b4aebcb1e7fc20d52ab50"
   integrity sha512-cddhp1rDK3nwCyi3qhbDsuWzC2svBgoGhHNQRgxJvrgfM4uoQKAGSU3XYY3VXjAZCzlqVZz9PYziYDD6fdEIcw==
 
+react-native-file-logger@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-file-logger/-/react-native-file-logger-0.4.1.tgz#6d4cdfd333489a32b20242f898cff0b196444707"
+  integrity sha512-UpdMtpQvSgOB4ohid2QxwWFkI92gqKEl2woFbcPEWRbmfrwpTZuNPzNEooMTjmIhFBQPfaOcymCL9gK1naE01g==
+
 react-native-file-viewer@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/react-native-file-viewer/-/react-native-file-viewer-2.1.5.tgz#cd4544f573108e79002b5c7e1ebfce4371885250"


### PR DESCRIPTION
In order to allow sending logs whatever if the app is logged or not, or even when the app is stuck on SplashScreen, the easiest way to trigger sending logs is to use deep links

By implementing this, user can now click on `cozy://enablelogs` or `https://links.mycozy.cloud/flagship/enablelogs` links to tell the app to start recording logs into a local file

They can then click on `cozy://sendlogs` or `https://links.mycozy.cloud/flagship/sendlogs` links to trigger the OS send email intent pre-filled with log files and Cozy's  support email

Finally then can click on `cozy://disablelogs` or `https://links.mycozy.cloud/flagship/disablelogs` links to tell the app to stop recording logs

This method is not the most user friendly but it has the advantage to be resilient to UI bugs

We may want to find a more user friendly method in the future and keep this one for exceptional cases (or internal ones)

___

This feature is based on the [react-native-file-logger](https://github.com/BeTomorrow/react-native-file-logger) plugin, that does not need to be configured with cozy-minilog as it captures all console calls and redirect them to a file

By default `react-native-file-logger` will redirect all logs to a file in the app's cache directory

Daily rolling is enabled and the max file size is 5 files of 1MB

We want to decrease the log level to `Info` so all the app's logs are redirected

Finally `${now} [${level}]` is added before all log in the resulting file

___

TODO:

- [x] Test on Android (for now Android's build is broken on master)
- [x] Checks if GPS Memory logs are included
- [x] Prevent `hideSplashscreen()` calls to hide the email pane


Improvement ideas:
- [x] Add another deep link to enable/disable logging to file and disable it by default
- [x] Add useful data in the email body (current OS, current app version etc)