### PR TITLE
fix: always hide splashscreen on wakeup (VO-267)

### DIFF
--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -5,10 +5,14 @@ import CozyClient, { useClient } from 'cozy-client'
 import Minilog from 'cozy-minilog'
 
 import { StorageKeys, removeData, storeData } from '/libs/localStore/storage'
-import { showSplashScreen } from '/app/theme/SplashScreenService'
+import {
+  hideSplashScreen,
+  showSplashScreen
+} from '/app/theme/SplashScreenService'
 import { handleSecurityFlowWakeUp } from '/app/domain/authorization/services/SecurityService'
 import { devlog } from '/core/tools/env'
 import { synchronizeDevice } from '/app/domain/authentication/services/SynchronizeService'
+import { lockScreens } from '/app/view/Lock/useLockScreenWrapper'
 
 const log = Minilog('useGlobalAppState')
 
@@ -32,6 +36,10 @@ const handleWakeUp = async (
   }
 
   await handleSecurityFlowWakeUp(client)
+
+  // On appStart the homeview will hide the splashscreen
+  // On wakeup, it is more ambiguous so we force it
+  if (!isAppStart) await hideSplashScreen(lockScreens.LOCK_SCREEN)
 }
 
 const isGoingToSleep = (nextAppState: AppStateStatus): boolean =>


### PR DESCRIPTION
On appStart the homeview will hide the splashscreen
On wakeup, it is more ambiguous so we force it