### PR TITLE
fix: Do not manage shareFiles errors in flagship app

### DIFF
--- a/src/app/domain/osReceive/models/ShareFiles.ts
+++ b/src/app/domain/osReceive/models/ShareFiles.ts
@@ -3,7 +3,6 @@ import type CozyClient from 'cozy-client'
 export interface ShareFilesDependencies {
   showOverlay: (message?: string) => void
   hideOverlay: () => void
-  handleError: (message: string) => void
   t: (key: string, opts?: Record<string, unknown>) => string
   client: CozyClient | null
 }


### PR DESCRIPTION
We need on the front side to know if :
- share succeeded
- share was canceled
- share failed

So let's not catch everything here.