### PR TITLE
fix: Use absolute position for all Lock screens

### DIFF
--- a/src/app/view/Lock/LockScreen.tsx
+++ b/src/app/view/Lock/LockScreen.tsx
@@ -3,9 +3,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  StyleSheet,
-  TouchableWithoutFeedback,
-  View
+  TouchableWithoutFeedback
 } from 'react-native'
 import RnMaskInput from 'react-native-mask-input'
 import { FullWindowOverlay } from 'react-native-screens'
@@ -194,37 +192,24 @@ const LockView = ({
 
 export const LockScreen = (): JSX.Element => {
   return (
-    <View style={styles.fullScreen}>
-      <ConditionalWrapper
-        condition={Platform.OS === 'ios'}
-        wrapper={(children): JSX.Element => (
-          <FullWindowOverlay>{children}</FullWindowOverlay>
-        )}
+    <ConditionalWrapper
+      condition={Platform.OS === 'ios'}
+      wrapper={(children): JSX.Element => (
+        <FullWindowOverlay>{children}</FullWindowOverlay>
+      )}
+    >
+      <TouchableWithoutFeedback
+        onPress={Keyboard.dismiss}
+        style={{ backgroundColor: palette.Primary[600], height: '100%' }}
       >
-        <TouchableWithoutFeedback
-          onPress={Keyboard.dismiss}
-          style={{ backgroundColor: palette.Primary[600], height: '100%' }}
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
-          <KeyboardAvoidingView
-            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          >
-            <CozyTheme variant="inverted">
-              <LockView {...useLockScreenProps()} />
-            </CozyTheme>
-          </KeyboardAvoidingView>
-        </TouchableWithoutFeedback>
-      </ConditionalWrapper>
-    </View>
+          <CozyTheme variant="inverted">
+            <LockView {...useLockScreenProps()} />
+          </CozyTheme>
+        </KeyboardAvoidingView>
+      </TouchableWithoutFeedback>
+    </ConditionalWrapper>
   )
 }
-
-const styles = StyleSheet.create({
-  fullScreen: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: ScreenIndexes.LOCK_SCREEN
-  }
-})

--- a/src/app/view/Lock/LockScreenWrapper.tsx
+++ b/src/app/view/Lock/LockScreenWrapper.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react'
+import { StyleSheet, View } from 'react-native'
 
 import { hideSplashScreen } from '/app/theme/SplashScreenService'
+import { ScreenIndexes } from '/app/view/FlagshipUI'
 import { LockScreen } from '/app/view/Lock/LockScreen'
 import {
   lockScreens,
@@ -20,24 +22,52 @@ export const LockScreenWrapper = (): JSX.Element | null => {
     }
   }, [currentSecurityScreen])
 
+  let LockComponent: (() => JSX.Element) | null = null
   switch (currentSecurityScreen) {
     case lockScreens.LOCK_SCREEN: {
-      return <LockScreen />
+      LockComponent = LockScreen
+      break
     }
     case lockScreens.PASSWORD_PROMPT: {
-      return <PasswordPrompt />
+      LockComponent = PasswordPrompt
+      break
     }
     case lockScreens.PIN_PROMPT: {
-      return <PinPrompt />
+      LockComponent = PinPrompt
+      break
     }
     case lockScreens.SET_PASSWORD: {
-      return <SetPasswordView />
+      LockComponent = SetPasswordView
+      break
     }
     case lockScreens.SET_PIN: {
-      return <SetPinView />
+      LockComponent = SetPinView
+      break
     }
     default: {
-      return null
+      LockComponent = null
+      break
     }
   }
+
+  if (!LockComponent) {
+    return null
+  }
+
+  return (
+    <View style={styles.fullScreen}>
+      <LockComponent />
+    </View>
+  )
 }
+
+const styles = StyleSheet.create({
+  fullScreen: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: ScreenIndexes.LOCK_SCREEN
+  }
+})


### PR DESCRIPTION
in 9472f4eb4e200a688968d92f7743f4ed08a71577 we fixed a bug on the Lock screen that would display the Home view and the Lock screen side by side on some devices

To fix it we set the Lock screen view with absolute positioning

Since we found the same bug on the SetPin view. We also found that this bug only happens when the keyboard is displayed

This increase our comprehension of the bug as the impacted view seems to all have a `KeyboardAvoidingView` in their tree

We choose to fix the bug higher in the tree view by setting the `LockScreenWrapper` with absolute positioning. This would allow to fix the bug on all Lock related screens

Related commit: 9472f4eb4e200a688968d92f7743f4ed08a71577