### PR TITLE
fix: handle some dimensions race conditions (VO-264)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,6 +57,7 @@ import {
 import LauncherView from '/screens/konnectors/LauncherView'
 import { useShareFiles } from '/app/domain/osReceive/services/shareFilesService'
 import { ClouderyOffer } from '/app/view/IAP/ClouderyOffer'
+import { useDimensions } from '/libs/dimensions'
 
 // Polyfill needed for cozy-client connection
 if (!global.btoa) {
@@ -120,6 +121,7 @@ const App = ({ setClient }) => {
 }
 
 const InnerNav = ({ client, setClient }) => {
+  useDimensions()
   const colors = getColors()
   const osReceiveState = useOsReceiveState()
   const osReceiveDispatch = useOsReceiveDispatch()

--- a/src/app/view/IAP/ClouderyOffer.tsx
+++ b/src/app/view/IAP/ClouderyOffer.tsx
@@ -17,12 +17,6 @@ import { useI18n } from '/locales/i18n'
 import { getColors } from '/ui/colors'
 
 const colors = getColors()
-const { statusBarHeight } = getDimensions()
-
-const HEADER_PADDING_TOP = statusBarHeight + 8
-const HEADER_PADDING_BOTTOM = 8
-const HEADER_LINE_HEIGHT = 16
-const TOUCHABLE_VERTICAL_PADDING = 8
 
 const ClouderyOfferWithIAPContext = (): JSX.Element | null => {
   const {
@@ -79,7 +73,7 @@ const WebViewWithLoadingOverlay = ({
   )
 
   return (
-    <View style={styles.dialog}>
+    <View style={makeStyles().dialog}>
       <BackButton onPress={hidePopup} />
       {popupUrl && (
         <WebView
@@ -108,7 +102,7 @@ const LoadingOverlay = (): JSX.Element => {
   return (
     <View
       style={[
-        styles.loadingOverlay,
+        makeStyles().loadingOverlay,
         {
           backgroundColor: colors.primaryColor
         }
@@ -125,14 +119,14 @@ const BackButton = ({ onPress }: BackButtonProps): JSX.Element => {
   const { t } = useI18n()
 
   return (
-    <View style={styles.headerStyle}>
+    <View style={makeStyles().headerStyle}>
       <TouchableOpacity
         activeOpacity={0.5}
         onPress={onPress}
-        style={styles.headerTouchableStyle}
+        style={makeStyles().headerTouchableStyle}
       >
         <BackTo color={colors.primaryColor} width={16} height={16} />
-        <Text style={styles.headerTextStyle}>
+        <Text style={makeStyles().headerTextStyle}>
           {t('screens.clouderyOffer.backButton')}
         </Text>
       </TouchableOpacity>
@@ -140,39 +134,50 @@ const BackButton = ({ onPress }: BackButtonProps): JSX.Element => {
   )
 }
 
-const styles = StyleSheet.create({
-  dialog: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0
-  },
-  loadingOverlay: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0
-  },
-  headerStyle: {
-    alignContent: 'center',
-    backgroundColor: colors.paperBackgroundColor,
-    flexDirection: 'row',
-    paddingBottom: HEADER_PADDING_BOTTOM,
-    paddingHorizontal: 8,
-    paddingTop: HEADER_PADDING_TOP
-  },
-  headerTouchableStyle: {
-    flexDirection: 'row',
-    paddingVertical: TOUCHABLE_VERTICAL_PADDING,
-    paddingHorizontal: 6
-  },
-  headerTextStyle: {
-    marginLeft: 10,
-    fontSize: 13,
-    fontFamily: 'Lato-Bold',
-    lineHeight: HEADER_LINE_HEIGHT,
-    color: colors.primaryColor
-  }
-})
+// We just want inference here
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const makeStyles = () => {
+  const { statusBarHeight } = getDimensions()
+
+  const HEADER_PADDING_TOP = statusBarHeight + 8
+  const HEADER_PADDING_BOTTOM = 8
+  const HEADER_LINE_HEIGHT = 16
+  const TOUCHABLE_VERTICAL_PADDING = 8
+
+  return StyleSheet.create({
+    dialog: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0
+    },
+    loadingOverlay: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0
+    },
+    headerStyle: {
+      alignContent: 'center',
+      backgroundColor: colors.paperBackgroundColor,
+      flexDirection: 'row',
+      paddingBottom: HEADER_PADDING_BOTTOM,
+      paddingHorizontal: 8,
+      paddingTop: HEADER_PADDING_TOP
+    },
+    headerTouchableStyle: {
+      flexDirection: 'row',
+      paddingVertical: TOUCHABLE_VERTICAL_PADDING,
+      paddingHorizontal: 6
+    },
+    headerTextStyle: {
+      marginLeft: 10,
+      fontSize: 13,
+      fontFamily: 'Lato-Bold',
+      lineHeight: HEADER_LINE_HEIGHT,
+      color: colors.primaryColor
+    }
+  })
+}

--- a/src/libs/dimensions.ts
+++ b/src/libs/dimensions.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Dimensions } from 'react-native'
 import {
   initialWindowMetrics,
@@ -22,6 +23,15 @@ const useDimensions = (): DeviceDimensions => {
   const insets = useSafeAreaInsets()
   const frame = useSafeAreaFrame()
 
+  useEffect(() => {
+    setDimensions({
+      navbarHeight: insets.bottom,
+      screenHeight: frame.height,
+      screenWidth: frame.width,
+      statusBarHeight: insets.top
+    })
+  }, [insets, frame])
+
   return {
     navbarHeight: insets.bottom,
     screenHeight: frame.height,
@@ -30,17 +40,29 @@ const useDimensions = (): DeviceDimensions => {
   }
 }
 
+let dimensionsHook: DeviceDimensions | undefined = undefined
+
 /**
  * Get device's dimensions (screen, navigationBar and statusBar sizes)
  * @returns device's dimensions
  */
 const getDimensions = (): DeviceDimensions => {
-  return {
+  if (dimensionsHook) {
+    return dimensionsHook
+  }
+
+  const initialDimensions = {
     navbarHeight: initialWindowMetrics?.insets.bottom ?? 0,
     screenHeight: screenHeight,
     screenWidth: screenWidth,
     statusBarHeight: initialWindowMetrics?.insets.top ?? 0
   }
+
+  return initialDimensions
+}
+
+export const setDimensions = (dimensions: DeviceDimensions): void => {
+  dimensionsHook = dimensions
 }
 
 export { useDimensions, getDimensions }

--- a/src/libs/dimensions.ts
+++ b/src/libs/dimensions.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Dimensions } from 'react-native'
+import { Dimensions, Platform } from 'react-native'
 import {
   initialWindowMetrics,
   useSafeAreaFrame,
@@ -55,7 +55,8 @@ const getDimensions = (): DeviceDimensions => {
     navbarHeight: initialWindowMetrics?.insets.bottom ?? 0,
     screenHeight: screenHeight,
     screenWidth: screenWidth,
-    statusBarHeight: initialWindowMetrics?.insets.top ?? 0
+    statusBarHeight:
+      initialWindowMetrics?.insets.top ?? (Platform.OS === 'android' ? 24 : 0) // Official height is 24dp , as is stated officially by Google on Android Design webpage
   }
 
   return initialDimensions

--- a/src/screens/cozy-app/CozyAppScreen.functions.ts
+++ b/src/screens/cozy-app/CozyAppScreen.functions.ts
@@ -14,8 +14,6 @@ export const handleError = ({ nativeEvent }: WebViewErrorEvent): void => {
     NetService.handleOffline(routes.home)
 }
 
-const { screenHeight, screenWidth } = getDimensions()
-
 export const config = {
   duration: 300,
   width: '44%',
@@ -62,17 +60,26 @@ export const getTranslateInput = (params: {
   y: number
   height: number
   width: number
-}): { x: number; y: number } => ({
-  x:
-    params.x - styles.fadingContainer.left - (screenWidth - params.width) * 0.5,
-  y:
-    params.y - styles.fadingContainer.top - (screenHeight - params.height) * 0.5
-})
+}): { x: number; y: number } => {
+  const { screenHeight, screenWidth } = getDimensions()
+
+  return {
+    x:
+      params.x -
+      styles.fadingContainer.left -
+      (screenWidth - params.width) * 0.5,
+    y:
+      params.y -
+      styles.fadingContainer.top -
+      (screenHeight - params.height) * 0.5
+  }
+}
 
 export const getScaleInput = (params: {
   width: number
   height: number
-}): { x: number; y: number } => ({
-  x: params.width / screenWidth,
-  y: params.height / screenHeight
-})
+}): { x: number; y: number } => {
+  const { screenHeight, screenWidth } = getDimensions()
+
+  return { x: params.width / screenWidth, y: params.height / screenHeight }
+}

--- a/src/screens/login/components/assets/PasswordView/htmlPasswordInjection.ts
+++ b/src/screens/login/components/assets/PasswordView/htmlPasswordInjection.ts
@@ -29,8 +29,6 @@ const strSubmit = 'SE CONNECTER'
 
 const locale = 'fr'
 
-const dimensions = getDimensions()
-
 const getCustomThemeLink = (clouderyTheme: ClouderyTheme): string =>
   clouderyTheme.themeUrl
     ? `<link rel="stylesheet" media="screen" href="${clouderyTheme.themeUrl}">`
@@ -53,7 +51,7 @@ export const getHtml = (
 ): string => {
   const avatarUrl = new URL(instance)
   avatarUrl.pathname = 'public/avatar'
-
+  const dimensions = getDimensions()
   const avatarSvgUrl = getAvatarDataUri()
 
   return `

--- a/src/screens/login/components/transitions/TransitionToPasswordView.js
+++ b/src/screens/login/components/transitions/TransitionToPasswordView.js
@@ -1,14 +1,13 @@
-import Minilog from 'cozy-minilog'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Animated, Dimensions, Easing, StyleSheet, View } from 'react-native'
 
+import Minilog from 'cozy-minilog'
+
 import { getDimensions } from '/libs/dimensions'
-
-import { CozyIcon } from './transitions-icons/CozyIcon'
-
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
 import { isLightBackground } from '/screens/login/components/functions/clouderyBackgroundFetcher'
 import { getColors } from '/ui/colors'
+import { CozyIcon } from '/screens/login/components/transitions/transitions-icons/CozyIcon'
 
 const log = Minilog('TransitionToPasswordView')
 


### PR DESCRIPTION
This will use the hook return values if possible, otherwise use 24px as default height on Android.
This will remove cases where the dimensions were wrongfully set at the start of the app to be 0, resulting in overlap in statusbar and application
This PR also ensures all getDimensions() call that were at the module level are now moved into the application lifecycle