### PR TITLE
feat: add a timeout for splashscreen (VO-321)

### DIFF
--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -112,3 +112,13 @@ jest.mock('react-native/Libraries/Components/Switch/Switch', () => {
 })
 
 jest.mock('@react-native-clipboard/clipboard', () => mockClipboard)
+
+jest.mock('../src/core/tools/env', () => ({
+  ...jest.requireActual('../src/core/tools/env'),
+  isSentryDebugMode: () => true,
+  EnvService: {
+    hasSentryEnabled: true
+  },
+  devlog: jest.fn(),
+  shouldDisableAutolock: jest.fn().mockReturnValue(false)
+}))

--- a/src/app/theme/SplashScreenService.spec.ts
+++ b/src/app/theme/SplashScreenService.spec.ts
@@ -1,0 +1,80 @@
+import RNBootSplash from 'react-native-bootsplash'
+
+import { logToSentry } from '/libs/monitoring/Sentry'
+import config from '/app/theme/config.json'
+import {
+  showSplashScreen,
+  hideSplashScreen,
+  setAutoHideDuration,
+  splashScreens
+} from '/app/theme/SplashScreenService'
+
+jest.mock('react-native-bootsplash', () => ({
+  show: jest.fn(() => Promise.resolve()),
+  hide: jest.fn(() => Promise.resolve()),
+  getVisibilityStatus: jest.fn(() => Promise.resolve('hidden'))
+}))
+
+jest.mock('/app/view/FlagshipUI', () => ({
+  flagshipUIEventHandler: {
+    emit: jest.fn()
+  },
+  flagshipUIEvents: {
+    SET_COMPONENT_COLORS: 'SET_COMPONENT_COLORS'
+  }
+}))
+
+jest.mock('/libs/monitoring/Sentry', () => ({
+  logToSentry: jest.fn()
+}))
+
+describe('SplashScreenService', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    setAutoHideDuration(config.autoHideDuration)
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  it('should show the splash screen and set auto-hide timer', () => {
+    void showSplashScreen(splashScreens.LOCK_SCREEN) // Avoid blocking thread
+    jest.advanceTimersByTime(config.autoHideDuration) // We reached the auto-hide duration
+
+    // Auto-hide should have been called
+    expect(RNBootSplash.hide).toHaveBeenLastCalledWith({
+      bootsplashName: splashScreens.LOCK_SCREEN,
+      fade: true
+    })
+  })
+
+  it('should hide the splash screen and clear the timer', () => {
+    void showSplashScreen(splashScreens.LOCK_SCREEN)
+    void hideSplashScreen(splashScreens.LOCK_SCREEN)
+    jest.advanceTimersByTime(config.autoHideDuration)
+
+    // Auto-hide should not have been called
+    expect(RNBootSplash.hide).toHaveBeenCalledTimes(1)
+  })
+
+  it('should log to Sentry if the splash screen auto-hides', () => {
+    void showSplashScreen()
+    jest.advanceTimersByTime(config.autoHideDuration)
+    expect(logToSentry).toHaveBeenCalledWith(expect.any(Error))
+  })
+
+  it('should allow setting a custom auto-hide duration', () => {
+    const newDuration = 10000
+    setAutoHideDuration(newDuration)
+    void showSplashScreen()
+    jest.advanceTimersByTime(newDuration)
+
+    expect(RNBootSplash.hide).toHaveBeenLastCalledWith({
+      bootsplashName: undefined,
+      fade: true
+    })
+  })
+})

--- a/src/app/theme/SplashScreenService.ts
+++ b/src/app/theme/SplashScreenService.ts
@@ -45,19 +45,23 @@ export const showSplashScreen = (
     clearTimeout(autoHideTimer)
   }
 
-  autoHideTimer = setTimeout(() => {
-    hideSplashScreen(bootsplashName).catch(error => {
-      devlog(`☁️ hideSplashScreen error:`, error)
-    })
+  // Auto-hide the splash screen after a certain duration
+  // This mitigates the issue of the splash screen not being hidden for unforeseen reasons
+  if (bootsplashName !== splashScreens.SECURE_BACKGROUND) {
+    autoHideTimer = setTimeout(() => {
+      hideSplashScreen(bootsplashName).catch(error => {
+        devlog(`☁️ hideSplashScreen error:`, error)
+      })
 
-    logToSentry(
-      new Error(
-        `Splashscreen reached autoHideDuration with bootsplahName: ${
-          bootsplashName ?? 'undefined'
-        } and autoHideDuration: ${autoHideDuration}`
+      logToSentry(
+        new Error(
+          `Splashscreen reached autoHideDuration with bootsplahName: ${
+            bootsplashName ?? 'undefined'
+          } and autoHideDuration: ${autoHideDuration}`
+        )
       )
-    )
-  }, autoHideDuration)
+    }, autoHideDuration)
+  }
 
   return RNBootSplash.show({ fade: true, bootsplashName })
 }
@@ -71,6 +75,7 @@ export const showSplashScreen = (
 export const hideSplashScreen = (
   bootsplashName?: SplashScreenEnum
 ): Promise<void> => {
+  // Clear the auto-hide timer as we don't want to hide the splash screen twice
   if (autoHideTimer) {
     clearTimeout(autoHideTimer)
     autoHideTimer = null

--- a/src/app/theme/config.json
+++ b/src/app/theme/config.json
@@ -1,0 +1,3 @@
+{
+  "autoHideDuration": 15000
+}

--- a/src/app/view/Secure/PinPrompt.spec.tsx
+++ b/src/app/view/Secure/PinPrompt.spec.tsx
@@ -17,10 +17,6 @@ jest.mock('/app/domain/authorization/utils/devMode.ts', () => {
     getDevModeFunctions: jest.fn().mockReturnValue(false)
   }
 })
-jest.mock('/core/tools/env', () => ({
-  devlog: jest.fn(),
-  shouldDisableAutolock: jest.fn().mockReturnValue(false)
-}))
 jest.mock('/app/view/Lock/useLockScreenWrapper', () => ({
   ...jest.requireActual('/app/view/Lock/useLockScreenWrapper'),
   hideSecurityScreen: jest.fn(),

--- a/src/components/providers/SplashScreenProvider.tsx
+++ b/src/components/providers/SplashScreenProvider.tsx
@@ -1,12 +1,20 @@
 import React, { ReactNode } from 'react'
 
-import { SplashScreenService } from '/app/theme/SplashScreenService'
+import {
+  hideSplashScreen,
+  showSplashScreen
+} from '/app/theme/SplashScreenService'
 import { SplashScreenContext } from '/libs/contexts/SplashScreenContext'
 
 export const SplashScreenProvider = (props: {
   children: ReactNode
 }): JSX.Element => (
-  <SplashScreenContext.Provider value={new SplashScreenService()}>
+  <SplashScreenContext.Provider
+    value={{
+      show: showSplashScreen,
+      hide: hideSplashScreen
+    }}
+  >
     {props.children}
   </SplashScreenContext.Provider>
 )

--- a/src/hooks/useSplashScreen.ts
+++ b/src/hooks/useSplashScreen.ts
@@ -8,11 +8,20 @@ import { safePromise } from '/utils/safePromise'
 export const useSplashScreen = (): {
   hideSplashScreen: () => Promise<void>
   showSplashScreen: () => Promise<void>
-} => ({
-  hideSplashScreen: useContext(SplashScreenContext).hide,
-  showSplashScreen: useContext(SplashScreenContext).show
-})
+} => {
+  const context = useContext(SplashScreenContext)
 
+  if (!context) {
+    throw new Error(
+      'useSplashScreen must be used within a SplashScreenProvider'
+    )
+  }
+
+  return {
+    hideSplashScreen: context.hide,
+    showSplashScreen: context.show
+  }
+}
 export const useSecureBackgroundSplashScreen = (): void => {
   useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {

--- a/src/libs/contexts/SplashScreenContext.ts
+++ b/src/libs/contexts/SplashScreenContext.ts
@@ -1,7 +1,14 @@
 import React from 'react'
 
-import { SplashScreenService } from '/app/theme/SplashScreenService'
+import type {
+  showSplashScreen,
+  hideSplashScreen
+} from '/app/theme/SplashScreenService'
 
-export const SplashScreenContext = React.createContext<SplashScreenService>(
-  {} as SplashScreenService
-)
+export const SplashScreenContext = React.createContext<
+  | {
+      show: typeof showSplashScreen
+      hide: typeof hideSplashScreen
+    }
+  | undefined
+>(undefined)


### PR DESCRIPTION
Due to instability we decide to hide the splashcreen after a set value
(here 15s).
A message will also be sent to Sentry should that error arise.
This is mainly to prevent infinitely stuck splashscreen while the app
below is still functioning
