### PR TITLE
fix: never return 0 dimensions on Android (VO-305)

### DIFF
--- a/src/libs/dimensions.ts
+++ b/src/libs/dimensions.ts
@@ -6,6 +6,8 @@ import {
   useSafeAreaInsets
 } from 'react-native-safe-area-context'
 
+import { logToSentry } from '/libs/monitoring/Sentry'
+
 interface DeviceDimensions {
   navbarHeight: number
   screenHeight: number
@@ -57,6 +59,14 @@ const getDimensions = (): DeviceDimensions => {
   // Case when the initial call has no dimensions available on Android
   // We use statusBarHeight as hint because navbar can be legitimately 0
   if (statusBarHeight === 0 && Platform.OS === 'android') {
+    logToSentry(
+      new Error(
+        `getDimensions: no dimensions available at initial call, initialWindowMetrics: ${JSON.stringify(
+          initialWindowMetrics
+        )}`
+      )
+    )
+
     // In that case, we return the official dimensions, so the user never has a 0 height navbar/statusbar
     return {
       navbarHeight: 24, // Official height is 24dp, as is stated on Android Design webpage,

--- a/src/libs/dimensions.ts
+++ b/src/libs/dimensions.ts
@@ -51,12 +51,26 @@ const getDimensions = (): DeviceDimensions => {
     return dimensionsHook
   }
 
+  const navbarHeight = initialWindowMetrics?.insets.bottom ?? 0
+  const statusBarHeight = initialWindowMetrics?.insets.top ?? 0
+
+  // Case when the initial call has no dimensions available on Android
+  // We use statusBarHeight as hint because navbar can be legitimately 0
+  if (statusBarHeight === 0 && Platform.OS === 'android') {
+    // In that case, we return the official dimensions, so the user never has a 0 height navbar/statusbar
+    return {
+      navbarHeight: 24, // Official height is 24dp, as is stated on Android Design webpage,
+      screenHeight: screenHeight,
+      screenWidth: screenWidth,
+      statusBarHeight: 48 // Official height is 48dp, as is stated on Android Design webpage
+    }
+  }
+
   const initialDimensions = {
-    navbarHeight: initialWindowMetrics?.insets.bottom ?? 0,
+    navbarHeight,
     screenHeight: screenHeight,
     screenWidth: screenWidth,
-    statusBarHeight:
-      initialWindowMetrics?.insets.top ?? (Platform.OS === 'android' ? 24 : 0) // Official height is 24dp , as is stated officially by Google on Android Design webpage
+    statusBarHeight
   }
 
   return initialDimensions


### PR DESCRIPTION
Add a navigation bar height fallback

If getDimensions is called and was going to return a 0 height navbar value, but we also detected the statusBar was 0 (meaning all values are false), then we use the default Android nav bar height as fallback