### PR TITLE
feat: Remove geolocation tracking quota event emitter

### DIFF
--- a/src/app/domain/geolocation/hooks/tracking.ts
+++ b/src/app/domain/geolocation/hooks/tracking.ts
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 
 import { useClient } from 'cozy-client'
-import Minilog from 'cozy-minilog'
 
 import {
   isGeolocationTrackingEnabled,
@@ -9,28 +8,9 @@ import {
 } from '/app/domain/geolocation/services/tracking'
 import { checkGeolocationQuota } from '/app/domain/geolocation/helpers/quota'
 import { fetchAndStoreWebhook } from '/app/domain/geolocation/helpers/webhook'
-import { GeolocationTrackingEmitter } from '/app/domain/geolocation/tracking/events'
-import { TRIP_END } from '/app/domain/geolocation/tracking/consts'
-
-const log = Minilog('📍 Geolocation')
 
 export const useGeolocationTracking = (): void => {
   const client = useClient()
-
-  useEffect(() => {
-    if (!client) return
-
-    const onTripEnd = (): void => {
-      log.debug('Trip end event received, checking quota')
-      void checkGeolocationQuota(client)
-    }
-
-    GeolocationTrackingEmitter.on(TRIP_END, onTripEnd)
-
-    return () => {
-      GeolocationTrackingEmitter.off(TRIP_END, onTripEnd)
-    }
-  }, [client])
 
   useEffect(() => {
     const initializeTracking = async (): Promise<void> => {

--- a/src/app/domain/geolocation/tracking/consts.js
+++ b/src/app/domain/geolocation/tracking/consts.js
@@ -49,11 +49,6 @@ export const AUTOMOTIVE_SPEED = 13.9
 export const SERVER_URL = 'https://openpath.cozycloud.cc'
 
 /**
- * Available events in GeolocationTrackingEmitter
- */
-export const TRIP_END = 'TRIP_END'
-
-/**
  * CoachCO2 service
  */
 export const FETCH_OPENPATH_TRIPS_SERVICE_NAME = 'fetchOpenPathTripsWebhook'

--- a/src/app/domain/geolocation/tracking/events.js
+++ b/src/app/domain/geolocation/tracking/events.js
@@ -1,3 +1,0 @@
-import { EventEmitter } from 'events'
-
-export const GeolocationTrackingEmitter = new EventEmitter()

--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -30,8 +30,6 @@ export { getOrCreateId, updateId } from '/app/domain/geolocation/tracking/user'
 export { uploadData } from '/app/domain/geolocation/tracking/upload'
 export { GeolocationTrackingHeadlessTask } from '/app/domain/geolocation/tracking/headless'
 export { storeFetchServiceWebHook } from '/app/domain/geolocation/tracking/storage'
-import { GeolocationTrackingEmitter } from '/app/domain/geolocation/tracking/events'
-import { TRIP_END } from '/app/domain/geolocation/tracking/consts'
 import { getOrCreateId } from '/app/domain/geolocation/tracking/user'
 
 export {
@@ -194,7 +192,6 @@ export const handleMotionChange = async event => {
     const stationaryTs = event.location?.timestamp
     Log('Auto uploading from stop')
     await startOpenPathUploadAndPipeline({ untilTs: stationaryTs })
-    GeolocationTrackingEmitter.emit(TRIP_END)
 
     // Disable elasticity to improve next point accuracy
     disableElasticity()
@@ -208,7 +205,6 @@ export const handleConnectivityChange = async event => {
   if (event.connected && (await getFlagFailUpload())) {
     Log('Auto uploading from reconnection and failed last attempt')
     await startOpenPathUploadAndPipeline()
-    GeolocationTrackingEmitter.emit(TRIP_END)
   }
 }
 


### PR DESCRIPTION
This code to check geolocation tracking quota at trip end was not working as we want and very difficult to test. Especially local notification was not displayed on iOS in background.

So we decided to remove this trigger of geolocation tracking quota check.