### PR TITLE
feat: Do not stop backup when unknown error

### DIFF
--- a/src/app/domain/backup/services/uploadMedias.ts
+++ b/src/app/domain/backup/services/uploadMedias.ts
@@ -145,7 +145,8 @@ export const uploadMedias = async (
             t('services.backup.errors.unknownIssue')
         }
       } else {
-        throw new BackupError(t('services.backup.errors.unknownIssue'))
+        firstPartialSuccessMessage =
+          firstPartialSuccessMessage ?? t('services.backup.errors.unknownIssue')
       }
     }
 


### PR DESCRIPTION
Do not stop backup when unknown error. To avoid stopping a huge backup and blocking the user. Error event are already sent to Sentry. 

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

