### PR TITLE
fix: Add by default the flagship UA on SupervisedWebview

### DIFF
--- a/src/components/webviews/ReloadInterceptorWebView.js
+++ b/src/components/webviews/ReloadInterceptorWebView.js
@@ -3,7 +3,6 @@ import React, { useState } from 'react'
 import { useClient, useInstanceInfo } from 'cozy-client'
 
 import { SupervisedWebView } from '/components/webviews/SupervisedWebView'
-import { APPLICATION_NAME_FOR_USER_AGENT } from '/constants/userAgent'
 import { ProgressContainer } from '/components/ProgressContainer'
 import {
   interceptNavigation,
@@ -27,7 +26,6 @@ const ReloadInterceptorWebView = React.forwardRef((props, ref) => {
       <ProgressContainer progress={progress}>
         <SupervisedWebView
           {...props}
-          applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
           ref={ref}
           onShouldStartLoadWithRequest={initialRequest => {
             return interceptNavigation({
@@ -61,7 +59,6 @@ const ReloadInterceptorWebView = React.forwardRef((props, ref) => {
     <ProgressContainer progress={progress}>
       <SupervisedWebView
         {...props}
-        applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
         ref={ref}
         key={timestamp}
         onShouldStartLoadWithRequest={initialRequest => {

--- a/src/components/webviews/SupervisedWebView.js
+++ b/src/components/webviews/SupervisedWebView.js
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { WebView } from 'react-native-webview'
-import Minilog from 'cozy-minilog'
 
+import Minilog from 'cozy-minilog'
 import { useClient } from 'cozy-client'
 
 import { RemountProgress } from '/app/view/Loading/RemountProgress'
 import { resyncCookies } from '/libs/httpserver/httpCookieManager'
+import { APPLICATION_NAME_FOR_USER_AGENT } from '/constants/userAgent'
 
 const log = Minilog('SupervisedWebView')
 
@@ -108,6 +109,7 @@ export const SupervisedWebView = React.forwardRef((props, ref) => {
   return (
     <>
       <WebView
+        applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
         {...otherProps}
         ref={ref}
         key={key}

--- a/src/screens/login/components/ClouderyCreateInstanceView.js
+++ b/src/screens/login/components/ClouderyCreateInstanceView.js
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react'
 import { KeyboardAvoidingView, Platform, StyleSheet, View } from 'react-native'
+
 import Minilog from 'cozy-minilog'
 
 import {
@@ -19,7 +20,6 @@ import {
 import { getOnboardingDataFromRequest } from '/screens/login/components/functions/getOnboardingDataFromRequest'
 import { openWindowWithInAppBrowser } from '/screens/login/components/functions/interceptExternalLinks'
 import { jsPaddingInjection } from '/screens/login/components/functions/webViewPaddingInjection'
-import { APPLICATION_NAME_FOR_USER_AGENT } from '/constants/userAgent'
 
 const log = Minilog('ClouderyCreateInstanceView')
 
@@ -106,7 +106,6 @@ export const ClouderyCreateInstanceView = ({
       behavior="height"
     >
       <SupervisedWebView
-        applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
         source={{ uri: clouderyUrl }}
         ref={webviewRef}
         onShouldStartLoadWithRequest={handleNavigation}

--- a/src/screens/login/components/ClouderyViewSwitch.tsx
+++ b/src/screens/login/components/ClouderyViewSwitch.tsx
@@ -37,7 +37,6 @@ import {
 } from '/screens/login/components/functions/interceptExternalLinks'
 import { LOGIN_FLAGSHIP_URL } from '/screens/login/components/functions/oidc'
 import { jsPaddingInjection } from '/screens/login/components/functions/webViewPaddingInjection'
-import { APPLICATION_NAME_FOR_USER_AGENT } from '/constants/userAgent'
 import { navigationRef } from '/libs/RootNavigation'
 
 const log = Minilog('ClouderyViewSwitchProps')
@@ -132,7 +131,6 @@ export const ClouderyViewSwitch = forwardRef(
             testID="ViewSignin"
           >
             <ClouderyWebView
-              applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
               ref={webviewSigninRef}
               uri={urls.signinUrl}
               key="WebViewSignin"
@@ -157,7 +155,6 @@ export const ClouderyViewSwitch = forwardRef(
             testID="ViewLogin"
           >
             <ClouderyWebView
-              applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
               ref={webviewLoginRef}
               uri={urls.loginUrl}
               key="WebViewLogin"
@@ -229,7 +226,6 @@ const ClouderyWebView = forwardRef(
 
     return (
       <SupervisedWebView
-        applicationNameForUserAgent={APPLICATION_NAME_FOR_USER_AGENT}
         source={{ uri: uri }}
         ref={webviewRef}
         onNavigationStateChange={(event: WebViewNavigation): void => {


### PR DESCRIPTION
We saw in our log that some requests didn't have the flagship UA. Mostly the ones on the PasswordView:

`
2024-02-06T06:22:02.095Z  200  Mozilla  GET
https://XXX.mycozy.cloud/assets/fonts/Lato-Bold.immutable.woff2 `

It was hard for us to know whether a user had only used the flagship app or not.

So instead of adding the userAgent on each webview, I decided to add it to the SupervisedWebview since each webview rely on it. Like that, if we want to override the props, we can, but by default the flagship UA agent is set.

So I removed all the `applicationNameForUserAgent` that call the SupervisedWebview

I didn't test anything. 

#### Checklist

Before merging this PR, the following things must have been done:

* [ ] Faithful integration of the mockups at all screen sizes
* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Localized in English and French
* [ ] All changes have test coverage
* [ ] Updated README & CHANGELOG, if necessary

