### PR TITLE
fix: Homogenize quota calculation with coachco2 notification

### DIFF
--- a/src/app/domain/geolocation/helpers/quota.ts
+++ b/src/app/domain/geolocation/helpers/quota.ts
@@ -1,4 +1,4 @@
-import { differenceInDays } from 'date-fns'
+import { differenceInCalendarDays } from 'date-fns'
 
 import { Q } from 'cozy-client'
 import CozyClient from 'cozy-client'
@@ -79,12 +79,14 @@ export const isGeolocationQuotaExceeded = async (
 
   if (!firstTimeserie) return false
 
-  const daysSinceFirstCapture = differenceInDays(
+  const daysSinceFirstCapture = differenceInCalendarDays(
     new Date(),
     new Date(firstTimeserie.startDate)
   )
 
-  return daysSinceFirstCapture > maxDaysToCapture
+  const remainingDays = maxDaysToCapture - daysSinceFirstCapture
+
+  return remainingDays <= 0
 }
 
 export const checkGeolocationQuota = async (


### PR DESCRIPTION
Changements :
- we use "calendar days" instead of "24h days"
- if remaining days <= 0 instead of remaining days < 0 we disable geolocation

```
### 🐛 Bug Fixes

* Homogenize quota calculation with coachco2 notification
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

