### PR TITLE
feat: remove draft status when publishing (VO-345)

### DIFF
--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -112,4 +112,3 @@ jobs:
           packageName: ${{ inputs.brand != 'cozy' && format('io.cozy.flagship.mobile.{0}', inputs.brand) || 'io.cozy.flagship.mobile' }}
           releaseFiles: android/app/build/outputs/bundle/prodRelease/*.aab
           track: internal
-          status:  ${{ inputs.brand != 'cozy' && 'draft' || 'completed' }}


### PR DESCRIPTION
### 🔧 Tech

* This will automatically publish pushed apps in internal track without
the draft status that was previously applied
on all non-cozy apps (was needed at first because GL wasn't
deployed to production yet)
