### PR TITLE
[VER-277] fix: Geolocation upload

### DIFF
--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -91,6 +91,7 @@ export const startTracking = async () => {
 
     return true
   } catch (e) {
+    Log('Error on tracking start : ', JSON.stringify(e))
     log.error(e)
 
     return false
@@ -238,7 +239,7 @@ export const handleConnectivityChange = async event => {
 export const startOpenPathUploadAndPipeline = async ({
   untilTs = 0,
   force = false
-}) => {
+} = {}) => {
   try {
     const user = await getOrCreateId()
     Log(`User: ${JSON.stringify(user)}`)


### PR DESCRIPTION
Allow `startOpenPathUploadAndPipeline` call with no param. This is currently done in the `handleConnectivityChange` method, which was failing because of that.

```
### ✨ Features

*

### 🐛 Bug Fixes

* Upload after connectivity failure

### 🔧 Tech

*
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

