### PR TITLE
[VO-428] fix: Prevent the app to stuck on SplashScreen after a restart notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-native-background-geolocation": "^4.13.3",
     "react-native-background-upload": "^6.6.0",
     "react-native-biometrics": "3.0.1",
-    "react-native-bootsplash": "github:cozy/react-native-bootsplash#0.0.2",
+    "react-native-bootsplash": "github:cozy/react-native-bootsplash#0.0.3",
     "react-native-change-icon": "^4.0.0",
     "react-native-config": "1.5.0",
     "react-native-device-info": "^10.3.0",

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import { IconChangedModal } from '/libs/icon/IconChangedModal'
 import { CryptoWebView } from '/components/webviews/CryptoWebView/CryptoWebView'
 import { HomeStateProvider } from '/screens/home/HomeStateProvider'
 import { HttpServerProvider } from '/libs/httpserver/httpServerProvider'
+import { RestartProvider } from '/components/providers/RestartProvider'
 import { SplashScreenProvider } from '/components/providers/SplashScreenProvider'
 import { cleanKonnectorsOnBootInBackground } from '/libs/konnectors/cleanKonnectorsOnBoot'
 import { getClient } from '/libs/client'
@@ -231,29 +232,31 @@ const Wrapper = () => {
 
   return (
     <>
-      {__DEV__ && <FlipperAsyncStorage />}
-      <CryptoWebView setHasCrypto={setHasCrypto} />
-      {hasCrypto && (
-        <Provider store={store}>
-          <PersistGate loading={null} persistor={persistor}>
-            <HttpServerProvider>
-              <HomeStateProvider>
-                <SplashScreenProvider>
-                  <SecureBackgroundSplashScreenWrapper>
-                    <NetStatusBoundary>
-                      <ThemeProvider>
-                        <PermissionsChecker>
-                          <WrappedApp />
-                        </PermissionsChecker>
-                      </ThemeProvider>
-                    </NetStatusBoundary>
-                  </SecureBackgroundSplashScreenWrapper>
-                </SplashScreenProvider>
-              </HomeStateProvider>
-            </HttpServerProvider>
-          </PersistGate>
-        </Provider>
-      )}
+      <RestartProvider>
+        {__DEV__ && <FlipperAsyncStorage />}
+        <CryptoWebView setHasCrypto={setHasCrypto} />
+        {hasCrypto && (
+          <Provider store={store}>
+            <PersistGate loading={null} persistor={persistor}>
+              <HttpServerProvider>
+                <HomeStateProvider>
+                  <SplashScreenProvider>
+                    <SecureBackgroundSplashScreenWrapper>
+                      <NetStatusBoundary>
+                        <ThemeProvider>
+                          <PermissionsChecker>
+                            <WrappedApp />
+                          </PermissionsChecker>
+                        </ThemeProvider>
+                      </NetStatusBoundary>
+                    </SecureBackgroundSplashScreenWrapper>
+                  </SplashScreenProvider>
+                </HomeStateProvider>
+              </HttpServerProvider>
+            </PersistGate>
+          </Provider>
+        )}
+      </RestartProvider>
     </>
   )
 }

--- a/src/app/domain/authorization/services/SecurityService.ts
+++ b/src/app/domain/authorization/services/SecurityService.ts
@@ -63,6 +63,7 @@ export const determineSecurityFlow = async (
     devlog('🔏', 'Application does not have autolock activated')
     devlog('🔏', 'Device is secured')
     devlog('🔏', 'No security action taken')
+    await hideSplashScreen(splashScreens.LOCK_SCREEN)
   } else {
     devlog('🔏', 'Application does not have autolock activated')
     devlog('🔏', 'Device is unsecured')

--- a/src/app/theme/SplashScreenService.ts
+++ b/src/app/theme/SplashScreenService.ts
@@ -1,5 +1,8 @@
 import { AppState } from 'react-native'
-import RNBootSplash, { VisibilityStatus } from 'react-native-bootsplash'
+import RNBootSplash, {
+  ResultStatus,
+  VisibilityStatus
+} from 'react-native-bootsplash'
 
 import Minilog from 'cozy-minilog'
 
@@ -65,8 +68,10 @@ export const showSplashScreen = async (
   setTimeoutForSplashScreen(bootsplashName)
 
   try {
-    await RNBootSplash.show({ fade: true, bootsplashName })
-    return splashScreenLogger.info(`Splash screen shown "${bootsplashName}"`)
+    const result = await RNBootSplash.show({ fade: true, bootsplashName })
+    splashScreenLogger.info(
+      `Splash screen shown "${bootsplashName}" (${result.toString()})`
+    )
   } catch (error) {
     splashScreenLogger.error(
       `Error showing splash screen: ${bootsplashName}`,
@@ -96,8 +101,10 @@ export const hideSplashScreen = async (
   )
 
   try {
-    await manageTimersAndHideSplashScreen(bootsplashName)
-    return splashScreenLogger.info(`Splash screen hidden "${bootsplashName}"`)
+    const result = await manageTimersAndHideSplashScreen(bootsplashName)
+    splashScreenLogger.info(
+      `Splash screen hidden "${bootsplashName}" (${result.toString()})`
+    )
   } catch (error) {
     splashScreenLogger.error(
       `Error hiding splash screen: ${bootsplashName}`,
@@ -143,18 +150,19 @@ export const setTimeoutForSplashScreen = (
 const manageTimersAndHideSplashScreen = async (
   bootsplashName: SplashScreenEnum | undefined = splashScreens.GLOBAL,
   fromTimeout = false
-): Promise<void> => {
+): Promise<ResultStatus> => {
   if (bootsplashName !== splashScreens.SECURE_BACKGROUND)
     destroyTimer(bootsplashName, fromTimeout)
 
   try {
-    await RNBootSplash.hide({ fade: true, bootsplashName })
+    return await RNBootSplash.hide({ fade: true, bootsplashName })
   } catch (error) {
     splashScreenLogger.error(
       `Error managing timers and hiding splash screen "${bootsplashName}"`,
       error
     )
     logToSentry(error)
+    return false
   }
 }
 

--- a/src/app/view/Lock/LockScreenWrapper.tsx
+++ b/src/app/view/Lock/LockScreenWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { StyleSheet, View } from 'react-native'
 
-import { hideSplashScreen } from '/app/theme/SplashScreenService'
+import { hideSplashScreen, splashScreens } from '/app/theme/SplashScreenService'
 import { ScreenIndexes } from '/app/view/FlagshipUI'
 import { LockScreen } from '/app/view/Lock/LockScreen'
 import {
@@ -18,7 +18,8 @@ export const LockScreenWrapper = (): JSX.Element | null => {
 
   useEffect(() => {
     if (currentSecurityScreen) {
-      void hideSplashScreen()
+      void hideSplashScreen(splashScreens.GLOBAL)
+      void hideSplashScreen(splashScreens.LOCK_SCREEN)
     }
   }, [currentSecurityScreen])
 

--- a/src/components/providers/RestartProvider.tsx
+++ b/src/components/providers/RestartProvider.tsx
@@ -1,0 +1,50 @@
+import React, { ReactNode, useContext, useState } from 'react'
+
+import Minilog from 'cozy-minilog'
+
+export const log = Minilog('🔃 RestartProvider')
+
+interface RestartContextInterface {
+  unmountAppForRestart: () => void
+}
+
+const RestartContext = React.createContext<RestartContextInterface | undefined>(
+  undefined
+)
+
+export const useRestartContext = (): RestartContextInterface => {
+  const restartContext = useContext(RestartContext)
+
+  if (!restartContext) {
+    throw new Error(
+      'useHomeStateContext has to be used within <HomeStateProvider>'
+    )
+  }
+
+  return restartContext
+}
+
+interface Props {
+  children: JSX.Element
+}
+
+export const RestartProvider: React.FC<Props> = (props: {
+  children: ReactNode
+}): JSX.Element => {
+  const [shouldUnmount, setShouldUnmount] = useState<boolean>(false)
+
+  const unmount = (): void => {
+    log.debug('Unmount app for restart')
+    setShouldUnmount(true)
+  }
+
+  return (
+    <RestartContext.Provider
+      value={{
+        unmountAppForRestart: unmount
+      }}
+    >
+      {!shouldUnmount ? props.children : null}
+    </RestartContext.Provider>
+  )
+}

--- a/src/components/providers/RestartProvider.tsx
+++ b/src/components/providers/RestartProvider.tsx
@@ -1,11 +1,14 @@
 import React, { ReactNode, useContext, useState } from 'react'
+import RNRestart from 'react-native-restart'
 
 import Minilog from 'cozy-minilog'
+
+import { showSplashScreen } from '/app/theme/SplashScreenService'
 
 export const log = Minilog('🔃 RestartProvider')
 
 interface RestartContextInterface {
-  unmountAppForRestart: () => void
+  restartApp: () => Promise<void>
 }
 
 const RestartContext = React.createContext<RestartContextInterface | undefined>(
@@ -33,15 +36,17 @@ export const RestartProvider: React.FC<Props> = (props: {
 }): JSX.Element => {
   const [shouldUnmount, setShouldUnmount] = useState<boolean>(false)
 
-  const unmount = (): void => {
+  const unmountAndRestart = async (): Promise<void> => {
     log.debug('Unmount app for restart')
+    await showSplashScreen()
     setShouldUnmount(true)
+    RNRestart.Restart()
   }
 
   return (
     <RestartContext.Provider
       value={{
-        unmountAppForRestart: unmount
+        restartApp: unmountAndRestart
       }}
     >
       {!shouldUnmount ? props.children : null}

--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -9,14 +9,10 @@ import {
   removeData,
   storeData
 } from '/libs/localStore/storage'
-import {
-  hideSplashScreen,
-  showSplashScreen
-} from '/app/theme/SplashScreenService'
+import { showSplashScreen, splashScreens } from '/app/theme/SplashScreenService'
 import { handleSecurityFlowWakeUp } from '/app/domain/authorization/services/SecurityService'
 import { devlog } from '/core/tools/env'
 import { synchronizeDevice } from '/app/domain/authentication/services/SynchronizeService'
-import { lockScreens } from '/app/view/Lock/useLockScreenWrapper'
 
 const log = Minilog('useGlobalAppState')
 
@@ -24,7 +20,7 @@ const log = Minilog('useGlobalAppState')
 let appState: AppStateStatus = AppState.currentState
 
 const handleSleep = (): void => {
-  showSplashScreen('LOCK_SCREEN')
+  showSplashScreen(splashScreens.LOCK_SCREEN)
     .then(async () => {
       return await storeData(
         CozyPersistedStorageKeys.LastActivity,
@@ -43,10 +39,6 @@ const handleWakeUp = async (
   }
 
   await handleSecurityFlowWakeUp(client)
-
-  // On appStart the homeview will hide the splashscreen
-  // On wakeup, it is more ambiguous so we force it
-  if (!isAppStart) await hideSplashScreen(lockScreens.LOCK_SCREEN)
 }
 
 const isGoingToSleep = (nextAppState: AppStateStatus): boolean =>

--- a/src/hooks/useGlobalAppState.ts
+++ b/src/hooks/useGlobalAppState.ts
@@ -107,6 +107,7 @@ export const useGlobalAppState = (): void => {
 
     return () => {
       appState = AppState.currentState
+      subscription?.remove()
     }
   }, [client])
 }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -6,7 +6,6 @@ import { useClient } from 'cozy-client'
 import { useRestartContext } from '/components/providers/RestartProvider'
 import { useSplashScreen } from '/hooks/useSplashScreen'
 import { removeNotificationDeviceToken } from '/libs/client'
-import { useHttpServerContext } from '/libs/httpserver/httpServerProvider'
 import {
   handleInitialToken,
   handleNotificationTokenReceiving,
@@ -23,17 +22,15 @@ export const useNotifications = (): void => {
 
   const [areNotificationsEnabled, setAreNotificationsEnabled] = useState(false)
 
-  const httpServerContext = useHttpServerContext()
   const { unmountAppForRestart } = useRestartContext()
 
   const { showSplashScreen } = useSplashScreen()
 
   const restart = useCallback(async () => {
     await showSplashScreen()
-    httpServerContext?.stop()
     unmountAppForRestart()
     RNRestart.Restart()
-  }, [showSplashScreen, httpServerContext, unmountAppForRestart])
+  }, [showSplashScreen, unmountAppForRestart])
 
   useEffect(() => {
     const initializeNotifications = async (): Promise<void> => {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,10 +1,8 @@
-import { useCallback, useState, useEffect } from 'react'
-import RNRestart from 'react-native-restart'
+import { useState, useEffect } from 'react'
 
 import { useClient } from 'cozy-client'
 
 import { useRestartContext } from '/components/providers/RestartProvider'
-import { useSplashScreen } from '/hooks/useSplashScreen'
 import { removeNotificationDeviceToken } from '/libs/client'
 import {
   handleInitialToken,
@@ -22,15 +20,7 @@ export const useNotifications = (): void => {
 
   const [areNotificationsEnabled, setAreNotificationsEnabled] = useState(false)
 
-  const { unmountAppForRestart } = useRestartContext()
-
-  const { showSplashScreen } = useSplashScreen()
-
-  const restart = useCallback(async () => {
-    await showSplashScreen()
-    unmountAppForRestart()
-    RNRestart.Restart()
-  }, [showSplashScreen, unmountAppForRestart])
+  const { restartApp } = useRestartContext()
 
   useEffect(() => {
     const initializeNotifications = async (): Promise<void> => {
@@ -53,17 +43,17 @@ export const useNotifications = (): void => {
     if (!client) return
 
     void handleInitialToken(client)
-    void handleInitialServerNotification(client, restart)
-    void handleInitialLocalNotification(client, restart)
+    void handleInitialServerNotification(client, restartApp)
+    void handleInitialLocalNotification(client, restartApp)
 
     const removeTokenReceivingHandler = handleNotificationTokenReceiving(client)
     const removeOpeningHandler = handleServerNotificationOpening(
       client,
-      restart
+      restartApp
     )
     const removeLocalNotificationHandler = handleLocalNotificationOpening(
       client,
-      restart
+      restartApp
     )
     const removeServerForegroundHandler = handleServerNotificationOnForeground()
 
@@ -73,5 +63,5 @@ export const useNotifications = (): void => {
       removeServerForegroundHandler()
       removeLocalNotificationHandler()
     }
-  }, [client, areNotificationsEnabled, restart])
+  }, [client, areNotificationsEnabled, restartApp])
 }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -3,6 +3,7 @@ import RNRestart from 'react-native-restart'
 
 import { useClient } from 'cozy-client'
 
+import { useRestartContext } from '/components/providers/RestartProvider'
 import { useSplashScreen } from '/hooks/useSplashScreen'
 import { removeNotificationDeviceToken } from '/libs/client'
 import { useHttpServerContext } from '/libs/httpserver/httpServerProvider'
@@ -23,14 +24,16 @@ export const useNotifications = (): void => {
   const [areNotificationsEnabled, setAreNotificationsEnabled] = useState(false)
 
   const httpServerContext = useHttpServerContext()
+  const { unmountAppForRestart } = useRestartContext()
 
   const { showSplashScreen } = useSplashScreen()
 
   const restart = useCallback(async () => {
     await showSplashScreen()
     httpServerContext?.stop()
+    unmountAppForRestart()
     RNRestart.Restart()
-  }, [showSplashScreen, httpServerContext])
+  }, [showSplashScreen, httpServerContext, unmountAppForRestart])
 
   useEffect(() => {
     const initializeNotifications = async (): Promise<void> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16332,9 +16332,9 @@ react-native-biometrics@3.0.1:
   resolved "https://registry.yarnpkg.com/react-native-biometrics/-/react-native-biometrics-3.0.1.tgz#23c5a0bdbae1fcb1e08b22936223fe0fc4af846e"
   integrity sha512-Ru80gXRa9KG04sl5AB9HyjLjVbduhqZVjA+AiOSGqr+fNqCDmCu9y5WEksnjbnniNLmq1yGcw+qcLXmR1ddLDQ==
 
-"react-native-bootsplash@github:cozy/react-native-bootsplash#0.0.2":
+"react-native-bootsplash@github:cozy/react-native-bootsplash#0.0.3":
   version "3.2.4"
-  resolved "https://codeload.github.com/cozy/react-native-bootsplash/tar.gz/f5eb7d6fd628d27f61cc6df2e69d20b0b6960ebe"
+  resolved "https://codeload.github.com/cozy/react-native-bootsplash/tar.gz/bb60ff4b00d665324d24b8d15c2ed4aceefb99ea"
   dependencies:
     chalk "^4.1.0"
     fs-extra "^9.1.0"


### PR DESCRIPTION
On Android, when the app request a restart, the current Activity is not
directly destroyed and the app react as if it was sent to `background`

This triggers the `useGlobalAppState` hooks which shows the
`LOCK_SCREEN` splashScreen

The after the app effectively restarted, it fails to hide all
splashScreens because the `LOCK_SCREEN` one is not expected to be
displayed (but it is)

To prevent this kind of side effects, we want to fully unmount the
components tree, so all hooks would unregister themselves

This PR also fix some hideSplashScreen scenario and improve logs

```
### ✨ Features

* Update the existing IAP entry with this PR (was not in production yet)

```

___

TODO:

- [x] Upgrade react-native-bootsplash after cozy/react-native-bootsplash#4 being merged
