### PR TITLE
fix: Correctly handle openpath HTTP errors

### DIFF
--- a/src/app/domain/geolocation/tracking/index.js
+++ b/src/app/domain/geolocation/tracking/index.js
@@ -289,7 +289,7 @@ export const startOpenPathUploadAndPipeline = async ({
       }
     }
   } catch (err) {
-    Log('Failed openpath processing: ' + JSON.stringify(err))
+    Log('Failed openpath processing: ' + err)
     log.error(err)
   }
   return

--- a/src/app/domain/geolocation/tracking/upload.js
+++ b/src/app/domain/geolocation/tracking/upload.js
@@ -34,13 +34,9 @@ export const uploadUserCache = async (content, user) => {
   }
 
   if (!response.ok) {
+    const respText = await response.text()
     throw new Error(
-      String(
-        'Error in request response:',
-        response.status,
-        response.statusText,
-        await response.text()
-      )
+      `Error in usercache upload : ${response.status} - ${respText}`
     )
   }
   Log('Success uploading')
@@ -64,14 +60,8 @@ export const runOpenPathPipeline = async (user, webhook = '') => {
     body: body
   })
   if (!response.ok) {
-    throw new Error(
-      String(
-        'Error in pipeline run:',
-        response.status,
-        response.statusText,
-        await response.text()
-      )
-    )
+    const respText = await response.text()
+    throw new Error(`Error in pipeline run: ${response.status} - ${respText}`)
   }
   return { ok: true }
 }


### PR DESCRIPTION
The HTTP error messages were appearing blank in the logs

```
### ✨ Features

*

### 🐛 Bug Fixes

* Correctly handle openpath HTTP errors

### 🔧 Tech

*
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

