### PR TITLE
fix: Disable File logger

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -61,9 +61,12 @@ import LauncherView from '/screens/konnectors/LauncherView'
 import { useShareFiles } from '/app/domain/osReceive/services/shareFilesService'
 import { ClouderyOffer } from '/app/view/IAP/ClouderyOffer'
 import { useDimensions } from '/libs/dimensions'
+// Temporarily disable FileLogger until we fix issue https://github.com/BeTomorrow/react-native-file-logger/issues/64
+/*
 import { configureFileLogger } from '/app/domain/logger/fileLogger'
 
 configureFileLogger()
+//*/
 
 // Polyfill needed for cozy-client connection
 if (!global.btoa) {


### PR DESCRIPTION
In #1137 we implemented a new File logger mechanism

Unfortunately this has a side effect on
react-native-background-geolocation which has a logger mechanism based on the same library and fails to work if we enable our new File logger

A solution is investigated in BeTomorrow/react-native-file-logger#64 but until then we want to disable the feature so we can continue publishing the app

Related PR: #1137
Related Issue: BeTomorrow/react-native-file-logger#64

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

