### PR TITLE
fix: persist candidateApps in osreceive state (VO-463)

### DIFF
--- a/src/app/view/OsReceive/OsReceiveProvider.tsx
+++ b/src/app/view/OsReceive/OsReceiveProvider.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, useNavigationState } from '@react-navigation/native'
-import React, { useReducer, useEffect, useRef } from 'react'
+import React, { useReducer, useEffect } from 'react'
 
 import { useClient } from 'cozy-client'
 
@@ -33,7 +33,6 @@ export const OsReceiveProvider = ({
   const { handleError } = useError()
   const navigationState = useNavigationState(state => state)
   const navigation = useNavigation()
-  const didCall = useRef(false)
 
   useEffect(() => {
     const onFilesReceived = (files: OsReceiveFile[]): void => {
@@ -63,7 +62,9 @@ export const OsReceiveProvider = ({
   }, [client?.isLogged])
 
   useEffect(() => {
-    if (!client || didCall.current || state.filesToUpload.length === 0) return
+    // If the candidate apps are already set, we don't need to fetch them again as it would trigger re-rendering
+    if (state.candidateApps !== undefined) return
+    if (!client || state.filesToUpload.length === 0) return
 
     const fetchAppsAndSetCandidates = async (): Promise<void> => {
       const res = (await client.fetchQueryAndGetFromState({
@@ -72,7 +73,6 @@ export const OsReceiveProvider = ({
       })) as { data: AcceptFromFlagshipManifest[] }
 
       if (res.data.length > 0) {
-        didCall.current = true
         dispatch({
           type: OsReceiveActionType.SetCandidateApps,
           payload: res.data

--- a/src/app/view/OsReceive/state/OsReceiveState.ts
+++ b/src/app/view/OsReceive/state/OsReceiveState.ts
@@ -43,11 +43,13 @@ export const osReceiveReducer = (
       nextState = { ...state, errored: action.payload }
       break
     }
+    // When resetting the state, we keep the candidateApps (e.g. when the user successfully uploads a file or cancels the upload)
+    // This is useful to avoid re-fetching the candidate apps when the user starts a new upload after a successful one
+    // This is only persisted in the runtime state and not in the persistent storage to avoid keeping the candidate apps when the user closes the app
+    // The candidate apps are fetched again when the user opens the app after closing it
     case OsReceiveActionType.SetRecoveryState:
-      nextState = initialState
-      break
     case OsReceiveActionType.SetInitialState:
-      nextState = initialState
+      nextState = { ...initialState, candidateApps: state.candidateApps }
       break
     case OsReceiveActionType.UpdateFileStatus: {
       const updateFile = (file: OsReceiveFile): OsReceiveFile => ({


### PR DESCRIPTION
### 🐛 Bug Fixes

* When uploading files to the app multiple times in a row, the button will correctly show the "next" action instead of the "cancel" one
