### PR TITLE
fix: avoid path provider authority conflict (VO-570)

### DIFF
--- a/patches/react-native-file-logger+0.4.1.patch
+++ b/patches/react-native-file-logger+0.4.1.patch
@@ -1,3 +1,29 @@
+diff --git a/node_modules/react-native-file-logger/android/src/main/AndroidManifest.xml b/node_modules/react-native-file-logger/android/src/main/AndroidManifest.xml
+index 7aaacbc..80b7c5b 100644
+--- a/node_modules/react-native-file-logger/android/src/main/AndroidManifest.xml
++++ b/node_modules/react-native-file-logger/android/src/main/AndroidManifest.xml
+@@ -4,7 +4,7 @@
+     <application>
+         <provider
+             android:name="androidx.core.content.FileProvider"
+-            android:authorities="${applicationId}.provider"
++            android:authorities="${applicationId}.rnfilelogger.provider"
+             android:exported="false"
+             android:grantUriPermissions="true">
+             <meta-data
+diff --git a/node_modules/react-native-file-logger/android/src/main/java/com/betomorrow/rnfilelogger/FileLoggerModule.java b/node_modules/react-native-file-logger/android/src/main/java/com/betomorrow/rnfilelogger/FileLoggerModule.java
+index 1f3903d..b414954 100644
+--- a/node_modules/react-native-file-logger/android/src/main/java/com/betomorrow/rnfilelogger/FileLoggerModule.java
++++ b/node_modules/react-native-file-logger/android/src/main/java/com/betomorrow/rnfilelogger/FileLoggerModule.java
+@@ -188,7 +188,7 @@ public class FileLoggerModule extends ReactContextBaseJavaModule {
+             for (File file : getLogFiles()) {
+                 Uri fileUri = FileProvider.getUriForFile(
+                         reactContext,
+-                        reactContext.getApplicationContext().getPackageName() + ".provider",
++                        reactContext.getApplicationContext().getPackageName() + ".rnfilelogger.provider",
+                         file);
+                 uris.add(fileUri);
+             }
 diff --git a/node_modules/react-native-file-logger/ios/FileLogger.m b/node_modules/react-native-file-logger/ios/FileLogger.m
 index 7ee491d..978ce4e 100644
 --- a/node_modules/react-native-file-logger/ios/FileLogger.m

--- a/patches/react-native-file-viewer+2.1.5.patch
+++ b/patches/react-native-file-viewer+2.1.5.patch
@@ -1,3 +1,29 @@
+diff --git a/node_modules/react-native-file-viewer/android/src/main/AndroidManifest.xml b/node_modules/react-native-file-viewer/android/src/main/AndroidManifest.xml
+index 8166e4c..4be50e7 100644
+--- a/node_modules/react-native-file-viewer/android/src/main/AndroidManifest.xml
++++ b/node_modules/react-native-file-viewer/android/src/main/AndroidManifest.xml
+@@ -4,7 +4,7 @@
+   package="com.vinzscam.reactnativefileviewer"
+   >
+       <application>
+-        <provider android:name="com.vinzscam.reactnativefileviewer.FileProvider" android:authorities="${applicationId}.provider" android:exported="false" android:grantUriPermissions="true">
++        <provider android:name="com.vinzscam.reactnativefileviewer.FileProvider" android:authorities="${applicationId}.reactnativefileviewer.provider" android:exported="false" android:grantUriPermissions="true">
+               <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_viewer_provider_paths" />
+         </provider>
+       </application>
+diff --git a/node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java b/node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java
+index 93f7881..9293eab 100644
+--- a/node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java
++++ b/node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java
+@@ -59,7 +59,7 @@ public class RNFileViewerModule extends ReactContextBaseJavaModule {
+       }
+       try {
+         final String packageName = currentActivity.getPackageName();
+-        final String authority = new StringBuilder(packageName).append(".provider").toString();
++        final String authority = new StringBuilder(packageName).append(".reactnativefileviewer.provider").toString();
+         contentUri = FileProvider.getUriForFile(currentActivity, authority, newFile);
+       }
+       catch(IllegalArgumentException e) {
 diff --git a/node_modules/react-native-file-viewer/ios/RNFileViewerManager.m b/node_modules/react-native-file-viewer/ios/RNFileViewerManager.m
 index 8149cac..6ea97af 100644
 --- a/node_modules/react-native-file-viewer/ios/RNFileViewerManager.m


### PR DESCRIPTION
fix: avoid path provider authority conflict

These two libraries were accessing the default
appname.provider.
It resulted in file-viewer using the configuration of the logger,
the configuration being not compatible, file-viewer was not operable
We decide to fix this issue by using specific
path providers authorities for 
both these libraries, eliminating
the present conflict and avoiding future ones