### PR TITLE
[VER-421] fix: Correctly inject body classes when `<body>` has no attributes

### DIFF
--- a/src/libs/httpserver/server-helpers.spec.ts
+++ b/src/libs/httpserver/server-helpers.spec.ts
@@ -34,6 +34,13 @@ it('should return a stringified HTML with added body classes', () => {
   expect(addBodyClasses(html)).toEqual(expected)
 })
 
+it('should return a stringified HTML with added body classes if body has no class attribute but child div has class attribute', () => {
+  const html = `<html><head></head><body><div role="application" class="application"></div></body></html>`
+  const expected = `<html><head></head><body class="flagship-app flagship-os-ios flagship-route-home"><div role="application" class="application"></div></body></html>`
+
+  expect(addBodyClasses(html)).toEqual(expected)
+})
+
 it('should return a stringified HTML with appended body classes', () => {
   const html = `<html class="it"><head class="works"></head><body id="baz" class="foo bar" data-class="test"></body></html>`
   const expected = `<html class="it"><head class="works"></head><body id="baz" class="foo bar flagship-app flagship-os-ios flagship-route-home" data-class="test"></body></html>`

--- a/src/libs/httpserver/server-helpers.ts
+++ b/src/libs/httpserver/server-helpers.ts
@@ -16,7 +16,7 @@ export const addBodyClasses = (HTMLstring: string): string => {
     navigationRef.getCurrentRoute()?.name ?? 'unknown'
   }`
 
-  const hasClasses = /<body.*?class=("|')(.*?)("|')/i.exec(HTMLstring)
+  const hasClasses = /<body[^>]*?class=("|')(.*?)("|')/i.exec(HTMLstring)
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- not sure why a RegExpExecArray value can be undefined
   if (!hasClasses || hasClasses[2] === undefined)


### PR DESCRIPTION
Previous regex would inject body classes in the wrong place if the body has no attributes but its child div has class attribute

In that case, the function would inject the classes in the child div classes

With previous regex the following HTML
```html
<html>
  <head></head>
  <body>
    <div class="application"></div>
  </body>
</html>
```

Would output
```html
<html>
  <head></head>
  <body>
    <div class="application flagship-app flagship-os-ios flagship-route-home"></div>
  </body>
</html>
```

With new regex, it outputs
```html
<html>
  <head></head>
  <body class="flagship-app flagship-os-ios flagship-route-home">
    <div class="application"></div>
  </body>
</html>
```

This also fixes a production bug where we found that a `div` with same value for `role` and `class` would see values injected in its `role` instead of its `class` (this only happens if `role` is declared first)

With previous regex the following HTML
```html
<html>
  <head></head>
  <body>
    <div role="application" class="application"></div>
  </body>
</html>
```

Would output
```html
<html>
  <head></head>
  <body>
    <div role="application flagship-app flagship-os-ios flagship-route-home" class="application"></div>
  </body>
</html>
```

This would break `document.querySelector("[role=application]")` call made by our libraries

This commit fixes this observed bug, but this is a side effect as we now ensure that only the `<body>` tag is impacted

But the bug would reappear if someday some of our apps has similar pattern inside of their `body` tags (this is not the case today)

```
### ✨ Features

*

### 🐛 Bug Fixes

* Fix a bug that prevented Ecolyo to work on Android

### 🔧 Tech

*
```