### PR TITLE
fix: Correctly initialize File logger on iOS

### DIFF
--- a/patches/react-native-file-logger+0.4.1.patch
+++ b/patches/react-native-file-logger+0.4.1.patch
@@ -78,7 +78,7 @@ index 1f3903d..9200e11 100644
                  uris.add(fileUri);
              }
 diff --git a/node_modules/react-native-file-logger/ios/FileLogger.m b/node_modules/react-native-file-logger/ios/FileLogger.m
-index 7ee491d..978ce4e 100644
+index 7ee491d..329c09a 100644
 --- a/node_modules/react-native-file-logger/ios/FileLogger.m
 +++ b/node_modules/react-native-file-logger/ios/FileLogger.m
 @@ -4,6 +4,7 @@
@@ -107,7 +107,27 @@ index 7ee491d..978ce4e 100644
  
  RCT_EXPORT_MODULE()
  
-@@ -101,6 +113,8 @@ - (dispatch_queue_t)methodQueue {
+@@ -32,6 +44,10 @@ - (dispatch_queue_t)methodQueue {
+     NSNumber* maximumNumberOfFiles = options[@"maximumNumberOfFiles"];
+     NSString* logsDirectory = options[@"logsDirectory"];
+     
++    if (self.fileLogger) {
++        [DDLog removeLogger:self.fileLogger];
++    }
++
+     id<DDLogFileManager> fileManager = [[DDLogFileManagerDefault alloc] initWithLogsDirectory:logsDirectory];
+     fileManager.maximumNumberOfLogFiles = [maximumNumberOfFiles unsignedIntegerValue];
+     fileManager.logFilesDiskQuota = 0;
+@@ -40,7 +56,7 @@ - (dispatch_queue_t)methodQueue {
+     fileLogger.logFormatter = [[FileLoggerFormatter alloc] init];
+     fileLogger.rollingFrequency = [dailyRolling boolValue] ? 24 * 60 * 60 : 0;
+     fileLogger.maximumFileSize = [maximumFileSize unsignedIntegerValue];
+-    [DDLog removeAllLoggers];
++
+     [DDLog addLogger:fileLogger];
+     self.fileLogger = fileLogger;
+     
+@@ -101,6 +117,8 @@ - (dispatch_queue_t)methodQueue {
          [composeViewController setMessageBody:body isHTML:NO];
      }
      
@@ -116,7 +136,7 @@ index 7ee491d..978ce4e 100644
      NSArray<NSString*>* logFiles = self.fileLogger.logFileManager.sortedLogFilePaths;
      for (NSString* logFile in logFiles) {
          NSData* data = [NSData dataWithContentsOfFile:logFile];
-@@ -112,13 +126,44 @@ - (dispatch_queue_t)methodQueue {
+@@ -112,13 +130,44 @@ - (dispatch_queue_t)methodQueue {
          presentingViewController = presentingViewController.presentedViewController;
      }
      [presentingViewController presentViewController:composeViewController animated:YES completion:nil];


### PR DESCRIPTION
In #1187 we fixed the new File logger initialization on Android as it would break the react-native-background-geolocation plugin's internal File logger

This was because react-native-file-logger would reset all log appenders during initialisation which would prevent native-background-geolocation to work

This bug was also present in iOS but appeared latter so we did not notice it and so we did not fix it on initial PR

This commit applies the fix from BeTomorrow/react-native-file-logger#69 (we cannot update the lib as we are still using ReactNative old architecture)

Related PR: #1187
Related PR: #1183
Related issue: BeTomorrow/react-native-file-logger#64
Related issue: BeTomorrow/react-native-file-logger#66
Related issue: BeTomorrow/react-native-file-logger#69

```
### ✨ Features

*

### 🐛 Bug Fixes

* Fix a bug that prevented geolocalization logs to be sent by email ([PR #1201](https://github.com/cozy/cozy-flagship-app/pull/1201))

### 🔧 Tech

*
```