### PR TITLE
[SCR-640] feat: Give list of instance's flags to konnectors context

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -17,6 +17,7 @@ import { sendKonnectorsLogs } from '/libs/konnectors/sendKonnectorsLogs'
 
 import { wrapTimerFactory } from 'cozy-clisk'
 import flag from 'cozy-flags'
+import { listFlags } from 'cozy-flags/dist/flag'
 
 import {
   activateKeepAwake,
@@ -339,13 +340,14 @@ class ReactNativeLauncher extends Launcher {
 
       const { account, trigger, job, manifest } = this.getStartContext()
       const { sourceAccountIdentifier } = this.getUserData()
-
+      const cozyFlags = listFlags()
       const pilotContext = {
         manifest,
         account,
         trigger,
         job,
-        sourceAccountIdentifier
+        sourceAccountIdentifier,
+        flags: cozyFlags
       }
 
       if (hasPermission(manifest, 'io.cozy.files')) {

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -220,6 +220,7 @@ describe('ReactNativeLauncher', () => {
         trigger: fixtures.trigger,
         konnector,
         manifest: konnector,
+        flags: [],
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -301,7 +302,8 @@ describe('ReactNativeLauncher', () => {
           _id: 'normal_job_id'
         },
         sourceAccountIdentifier: 'testsourceaccountidentifier',
-        manifest: konnector
+        manifest: konnector,
+        flags: []
       })
       expect(launcher.pilot.call).not.toHaveBeenCalledWith(
         'ensureNotAuthenticated'
@@ -319,6 +321,7 @@ describe('ReactNativeLauncher', () => {
         trigger: fixtures.trigger,
         konnector,
         manifest: konnector,
+        flags: [],
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -346,6 +349,7 @@ describe('ReactNativeLauncher', () => {
           slug: 'testkonnector',
           name: 'Test Konnector'
         },
+        flags: [],
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -390,6 +394,7 @@ describe('ReactNativeLauncher', () => {
           slug: 'testkonnector',
           name: 'Test Konnector'
         },
+        flags: [],
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -484,6 +489,7 @@ describe('ReactNativeLauncher', () => {
         account: fixtures.account,
         trigger: fixtures.trigger,
         konnector: { slug: 'konnectorslug', clientSide: true },
+        flags: [],
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -526,6 +532,7 @@ describe('ReactNativeLauncher', () => {
         account: fixtures.account,
         trigger: fixtures.trigger,
         konnector: { slug: 'konnectorslug', clientSide: true },
+        flags: [],
         launcherClient: {
           setAppMetadata: () => null
         }

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -18,6 +18,7 @@ jest.mock('./keychain', () => {
     removeCredential: jest.fn()
   }
 })
+jest.mock('cozy-flags/dist/flag')
 import CookieManager from '@react-native-cookies/cookies'
 import { waitFor } from '@testing-library/react-native'
 
@@ -220,7 +221,7 @@ describe('ReactNativeLauncher', () => {
         trigger: fixtures.trigger,
         konnector,
         manifest: konnector,
-        flags: [],
+        flags: {},
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -303,7 +304,7 @@ describe('ReactNativeLauncher', () => {
         },
         sourceAccountIdentifier: 'testsourceaccountidentifier',
         manifest: konnector,
-        flags: []
+        flags: {}
       })
       expect(launcher.pilot.call).not.toHaveBeenCalledWith(
         'ensureNotAuthenticated'
@@ -321,7 +322,7 @@ describe('ReactNativeLauncher', () => {
         trigger: fixtures.trigger,
         konnector,
         manifest: konnector,
-        flags: [],
+        flags: {},
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -349,7 +350,7 @@ describe('ReactNativeLauncher', () => {
           slug: 'testkonnector',
           name: 'Test Konnector'
         },
-        flags: [],
+        flags: {},
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -394,7 +395,7 @@ describe('ReactNativeLauncher', () => {
           slug: 'testkonnector',
           name: 'Test Konnector'
         },
-        flags: [],
+        flags: {},
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -489,7 +490,7 @@ describe('ReactNativeLauncher', () => {
         account: fixtures.account,
         trigger: fixtures.trigger,
         konnector: { slug: 'konnectorslug', clientSide: true },
-        flags: [],
+        flags: {},
         launcherClient: {
           setAppMetadata: () => null
         }
@@ -532,7 +533,7 @@ describe('ReactNativeLauncher', () => {
         account: fixtures.account,
         trigger: fixtures.trigger,
         konnector: { slug: 'konnectorslug', clientSide: true },
-        flags: [],
+        flags: {},
         launcherClient: {
           setAppMetadata: () => null
         }


### PR DESCRIPTION
```
### ✨ Features

* Give the list of instance's flags to the context sent to konnectors

```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [x] Tested on Android
* [x] Test coverage
* [ ] README and documentation

