### PR TITLE
fix: Reindex files between the first call to a saveFiles function and the next (SCR-675)

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -34,6 +34,7 @@ export default class Launcher {
     this.setUserData({
       sourceAccountIdentifier: null
     })
+    this._firstFileSave = true
   }
   /**
    * Inject the content script and initialize the bridge to communicate it
@@ -367,7 +368,9 @@ export default class Launcher {
     } = this.getStartContext() || {}
     const { sourceAccountIdentifier } = this.getUserData() || {}
 
-    const existingFilesIndex = await this.getExistingFilesIndex()
+    const existingFilesIndex = await this.getExistingFilesIndex(
+      this.shouldResetFileIndex()
+    )
 
     const result = await saveBills(entries, {
       ...options,
@@ -378,6 +381,7 @@ export default class Launcher {
       sourceAccountIdentifier,
       existingFilesIndex
     })
+
     return result
   }
 
@@ -458,6 +462,15 @@ export default class Launcher {
     return (this.existingFilesIndex = existingFilesIndex)
   }
 
+  shouldResetFileIndex() {
+    if (this._firstFileSave) {
+      this._firstFileSave = false
+      return false
+    } else {
+      return true
+    }
+  }
+
   /**
    * Calls cozy-konnector-libs' saveFiles function
    *
@@ -476,7 +489,9 @@ export default class Launcher {
 
     const folderPath = await this.getFolderPath(trigger.message?.folder_to_save)
 
-    const existingFilesIndex = await this.getExistingFilesIndex()
+    const existingFilesIndex = await this.getExistingFilesIndex(
+      this.shouldResetFileIndex()
+    )
 
     const saveFilesOptions = {
       ...options,

--- a/src/libs/Launcher.spec.js
+++ b/src/libs/Launcher.spec.js
@@ -228,6 +228,51 @@ describe('Launcher', () => {
         })
       )
     })
+    it('should not reset files index on first call but should on second call to saveFiles', async () => {
+      const launcher = new Launcher()
+      jest
+        .spyOn(launcher, 'getExistingFilesIndex')
+        .mockImplementation(
+          () =>
+            new Map([
+              [
+                'fileidattribute',
+                { metadata: { fileIdAttributes: 'fileidattribute' } }
+              ]
+            ])
+        )
+      launcher.setUserData({
+        sourceAccountIdentifier: 'testsourceaccountidentifier'
+      })
+
+      const konnector = { slug: 'testkonnectorslug' }
+      const trigger = {
+        message: {
+          folder_to_save: 'testfolderid',
+          account: 'testaccountid'
+        }
+      }
+      const job = {
+        message: { account: 'testaccountid', folder_to_save: 'testfolderid' }
+      }
+      const client = {
+        query: jest.fn().mockResolvedValue({ data: { path: 'folderPath' } })
+      }
+      launcher.setStartContext({
+        konnector,
+        client,
+        launcherClient: client,
+        trigger,
+        job
+      })
+
+      await launcher.saveFiles([{}], {})
+      expect(launcher.getExistingFilesIndex).toHaveBeenLastCalledWith(false)
+      await launcher.saveFiles([{}], {})
+      expect(launcher.getExistingFilesIndex).toHaveBeenLastCalledWith(true)
+      await launcher.saveBills([{}], {})
+      expect(launcher.getExistingFilesIndex).toHaveBeenLastCalledWith(true)
+    })
     it('should ignore files without metadata or fileIdAttributes in the index', async () => {
       const launcher = new Launcher()
       launcher.setUserData({


### PR DESCRIPTION
This will prevent the clisk konnectors to redownload files with
multiples bills associated, which can make the execution of clisk
konnector longer, and cause some 409 http errors in logs in those cases.

```
### 🐛 Bug Fixes

* clisk konnectors: prevent multiple downloads of the same files when multiple bills are associated to the same file.
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

