### PR TITLE
fix: ShareFiles and OsReceive broken because of intent options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.28
+# 1.1.29
 
 ## ✨ Features
 
@@ -7,6 +7,21 @@
 
 
 ## 🔧 Tech
+
+
+# 1.1.28
+
+## ✨ Features
+
+
+## 🐛 Bug Fixes
+* Mes Papiers could crash during a document scan due to low memory ([PR #1208](https://github.com/cozy/cozy-flagship-app/pull/1208))
+* Sharing files to the app was not working properly on Ma Bulle app on iOS ([PR #1213](https://github.com/cozy/cozy-flagship-app/pull/1213))
+
+## 🔧 Tech
+* Partial dark mode support. Not enabled generally for the moment. ([PR #1214](https://github.com/cozy/cozy-flagship-app/pull/1214), [PR #1215](https://github.com/cozy/cozy-flagship-app/pull/1215), [PR #1217](https://github.com/cozy/cozy-flagship-app/pull/1217))
+* Give the list of instance's flags to the context sent to konnectors ([PR #1211](https://github.com/cozy/cozy-flagship-app/pull/1211))
+* Move saved traceFiles into `Settings/Logs` directory to avoid user confusion about the file presence ([PR #1210](https://github.com/cozy/cozy-flagship-app/pull/1210))
 
 # 1.1.27
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,8 +138,8 @@ android {
         namespace = "io.cozy.flagship.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 101270 * 10000 // Legacy version number patch, needed for Play Store version increment
-        versionName "1.1.27"
+        versionCode 101280 * 10000 // Legacy version number patch, needed for Play Store version increment
+        versionName "1.1.28"
         multiDexEnabled true
         resValue "string", "build_config_package", "io.cozy.flagship.mobile"
         missingDimensionStrategy "store", "play"

--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -60,7 +60,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.27</string>
+	<string>1.1.28</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -85,7 +85,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0101271</string>
+	<string>0101280</string>
 	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
 	<true/>
 	<key>FirebaseDataCollectionDefaultEnabled</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-react-native",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "private": true,
   "scripts": {
     "android": "react-native run-android --variant=devDebug --main-activity=MainActivitybase",

--- a/src/app/domain/osReceive/models/OsReceiveState.ts
+++ b/src/app/domain/osReceive/models/OsReceiveState.ts
@@ -1,3 +1,5 @@
+import { PostMeMessageOptions } from 'cozy-intent'
+
 import { AcceptFromFlagshipManifest } from './OsReceiveCozyApp'
 
 import { ReceivedFile } from '/app/domain/osReceive/models/ReceivedFile'
@@ -66,11 +68,12 @@ export interface ServiceResponse<T> {
 
 export interface OsReceiveApiMethods {
   getFilesToHandle: (
+    options: PostMeMessageOptions,
     base64: boolean,
     state: OsReceiveState
   ) => Promise<OsReceiveFile[]>
   hasFilesToHandle: () => Promise<UploadStatus>
-  uploadFiles: (arg: string) => boolean
+  uploadFiles: (options: PostMeMessageOptions, arg: string) => boolean
   resetFilesToHandle: () => Promise<boolean>
   cancelUploadByCozyApp: () => boolean
 }

--- a/src/app/domain/osReceive/models/ShareFiles.ts
+++ b/src/app/domain/osReceive/models/ShareFiles.ts
@@ -1,4 +1,5 @@
 import type CozyClient from 'cozy-client'
+import { PostMeMessageOptions } from 'cozy-intent'
 
 export interface ShareFilesDependencies {
   showOverlay: (message?: string) => void
@@ -9,4 +10,7 @@ export interface ShareFilesDependencies {
 
 export type ShareFilesPayload = string[]
 
-export type ShareFilesIntent = (filesIds: ShareFilesPayload) => Promise<void>
+export type ShareFilesIntent = (
+  options: PostMeMessageOptions,
+  filesIds: ShareFilesPayload
+) => Promise<void>

--- a/src/app/domain/osReceive/services/OsReceiveApi.ts
+++ b/src/app/domain/osReceive/services/OsReceiveApi.ts
@@ -247,8 +247,9 @@ export const OsReceiveApi = (
   dispatch: Dispatch<OsReceiveAction>
 ): OsReceiveApiMethods => ({
   hasFilesToHandle: () => hasFilesToHandle(state),
-  getFilesToHandle: (base64 = false) => getFilesToHandle(base64, state),
-  uploadFiles: arg => uploadFiles(arg, state, client, dispatch),
+  getFilesToHandle: (_options, base64 = false) =>
+    getFilesToHandle(base64, state),
+  uploadFiles: (_options, arg) => uploadFiles(arg, state, client, dispatch),
   resetFilesToHandle: () => resetFilesToHandle(dispatch),
   cancelUploadByCozyApp: () => cancelUploadByCozyApp(dispatch)
 })

--- a/src/app/domain/osReceive/services/shareFilesService.ts
+++ b/src/app/domain/osReceive/services/shareFilesService.ts
@@ -14,6 +14,8 @@ import {
   ShareFilesIntent
 } from '/app/domain/osReceive/models/ShareFiles'
 
+import { PostMeMessageOptions } from 'cozy-intent'
+
 const downloadFilesInParallel = async (
   fileInfos: FileMetadata[],
   headers: string
@@ -116,6 +118,7 @@ export const useShareFiles = (): { shareFiles: ShareFilesIntent } => {
   }
 
   return {
-    shareFiles: filesIds => intentShareFiles(dependencies, filesIds)
+    shareFiles: (_options: PostMeMessageOptions, filesIds) =>
+      intentShareFiles(dependencies, filesIds)
   }
 }


### PR DESCRIPTION
With cozy-intent 2.22, local methods receive an option object as first argument. I forgot to update ShareFiles and OsReceive intents. Fixed here.

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

