### PR TITLE
fix: Dark theme for OsReceive screen

### DIFF
--- a/src/app/view/OsReceive/OsReceiveScreen.styles.tsx
+++ b/src/app/view/OsReceive/OsReceiveScreen.styles.tsx
@@ -1,11 +1,6 @@
 import { FlexAlignType } from 'react-native'
 
-import { palette } from '/ui/palette'
-
 export const osReceiveScreenStyles = {
-  page: {
-    backgroundColor: palette.Common.white
-  },
   disabled: {
     opacity: 0.5
   },

--- a/src/app/view/OsReceive/OsReceiveScreen.tsx
+++ b/src/app/view/OsReceive/OsReceiveScreen.tsx
@@ -35,10 +35,11 @@ import { osReceiveScreenStyles } from '/app/view/OsReceive/OsReceiveScreen.style
 import { useCozyTheme } from '/ui/CozyTheme/CozyTheme'
 import { FileDuotone } from '/ui/Icons/FileDuotone'
 import { FileThumbnail } from '/ui/ImageThumbnail'
+import { getColorScheme } from '/app/theme/colorScheme'
 
 const defaultFlagshipUI: FlagshipUI = {
-  bottomTheme: 'dark',
-  topTheme: 'dark'
+  bottomTheme: getColorScheme() === 'dark' ? 'light' : 'dark',
+  topTheme: getColorScheme() === 'dark' ? 'light' : 'dark'
 }
 
 export const OsReceiveScreen = (): JSX.Element | null => {
@@ -90,7 +91,7 @@ export const OsReceiveScreenView = ({
   const isMultipleFiles = filesToUpload.length > 1
 
   return (
-    <Container style={osReceiveScreenStyles.page}>
+    <Container style={{ backgroundColor: colors.paperBackgroundColor }}>
       <Grid container direction="column" justifyContent="space-between">
         <Grid alignItems="center">
           {isMultipleFiles ? (


### PR DESCRIPTION
```
### ✨ Features

* Dark theme for OsReceive screen

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

