### PR TITLE
fix: Fail to assemble release due to react-native-gzip

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,8 +5,6 @@ include ':react-native-device-info'
 project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
 include ':react-native-fs'
 project(':react-native-fs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fs/android')
-include ':@fengweichong_react-native-gzip'
-project(':@fengweichong_react-native-gzip').projectDir = new File(rootProject.projectDir, '../node_modules/@fengweichong/react-native-gzip/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')


### PR DESCRIPTION
It seems that these two lines are not needed anymore since we updated to React Native 0.72, AGP 7 & Gradle 8.

Error encountered during `./gradlew assembleRelease --no-daemon` : `Reason: Task
':fengweichong_react-native-gzip:copyReleaseJniLibsProjectAndLocalJars' uses this output of task
':@fengweichong_react-native-gzip:stripReleaseDebugSymbols' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.`

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Fail to assemble release due to react-native-gzip
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

