### PR TITLE
feat: Allow cozy-apps to access files offline

### DIFF
--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -111,6 +111,7 @@ declare module 'cozy-client' {
   export interface FileCollectionGetResult {
     data: {
       _id: string
+      _rev: string
       name: string
       path: string
       metadata?: {

--- a/src/App.js
+++ b/src/App.js
@@ -59,6 +59,7 @@ import {
   LauncherContextProvider
 } from '/screens/home/hooks/useLauncherContext'
 import LauncherView from '/screens/konnectors/LauncherView'
+import { makeImportantFilesAvailableOfflineInBackground } from '/app/domain/io.cozy.files/importantFiles'
 import { useShareFiles } from '/app/domain/osReceive/services/shareFilesService'
 import { ClouderyOffer } from '/app/view/IAP/ClouderyOffer'
 import { useDimensions } from '/libs/dimensions'
@@ -111,6 +112,13 @@ const App = ({ setClient }) => {
     resetLauncherContext,
     setLauncherContext
   } = useLauncherContext()
+
+  useEffect(() => {
+    if (!client) {
+      return
+    }
+    makeImportantFilesAvailableOfflineInBackground(client)
+  }, [client])
 
   if (isLoading) {
     return null

--- a/src/app/domain/authentication/services/BiometryService.spec.ts
+++ b/src/app/domain/authentication/services/BiometryService.spec.ts
@@ -28,6 +28,10 @@ jest.mock('react-native-keychain')
 
 jest.mock('@react-native-cookies/cookies', () => ({}))
 
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
+
 it('should not throw with a null hasBiometry', async () => {
   const result = await makeFlagshipMetadataInjection()
   expect(result).toStrictEqual(

--- a/src/app/domain/authorization/services/LockScreenService.spec.ts
+++ b/src/app/domain/authorization/services/LockScreenService.spec.ts
@@ -40,6 +40,10 @@ jest.mock('cozy-client', () => ({
   }))
 }))
 
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
+
 describe('validatePassword', () => {
   // Mocks and common setup
   let client: CozyClient

--- a/src/app/domain/io.cozy.files/importantFiles.ts
+++ b/src/app/domain/io.cozy.files/importantFiles.ts
@@ -1,0 +1,44 @@
+import CozyClient from 'cozy-client'
+import Minilog from 'cozy-minilog'
+
+import { downloadFile } from '/app/domain/io.cozy.files/offlineFiles'
+import {
+  getOfflineFilesConfiguration,
+  removeOfflineFileFromConfiguration
+} from '/app/domain/io.cozy.files/offlineFilesConfiguration'
+import { getImportantFiles } from '/app/domain/io.cozy.files/remoteFiles'
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+const log = Minilog('📁 Offline Files')
+
+const IMPORTANT_FILES_DOWNLOAD_DELAY_IN_MS = 100
+
+export const makeImportantFilesAvailableOfflineInBackground = (
+  client: CozyClient
+): Promise<void> => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      makeImportantFilesAvailableOffline(client)
+        .then(resolve)
+        .catch(error => {
+          const errorMessage = getErrorMessage(error)
+          log.error(
+            `Something went wrong while making important files available offline: ${errorMessage}`,
+            resolve()
+          )
+        })
+    }, IMPORTANT_FILES_DOWNLOAD_DELAY_IN_MS)
+  })
+}
+
+const makeImportantFilesAvailableOffline = async (
+  client: CozyClient
+): Promise<void> => {
+  log.debug('Start downloading important files for offline support')
+  const importantFiles = await getImportantFiles(client)
+
+  for (const importantFile of importantFiles) {
+    log.debug(`Start downloading file ${importantFile._id}`)
+    await downloadFile(importantFile, client)
+  }
+}

--- a/src/app/domain/io.cozy.files/importantFiles.ts
+++ b/src/app/domain/io.cozy.files/importantFiles.ts
@@ -1,4 +1,8 @@
+import { differenceInMonths } from 'date-fns'
+import RNFS from 'react-native-fs'
+
 import CozyClient from 'cozy-client'
+import type { FileDocument } from 'cozy-client/types/types'
 import Minilog from 'cozy-minilog'
 
 import { downloadFile } from '/app/domain/io.cozy.files/offlineFiles'
@@ -12,6 +16,7 @@ import { getErrorMessage } from '/libs/functions/getErrorMessage'
 const log = Minilog('📁 Offline Files')
 
 const IMPORTANT_FILES_DOWNLOAD_DELAY_IN_MS = 100
+const NB_OF_MONTH_BEFORE_EXPIRATION = 1
 
 export const makeImportantFilesAvailableOfflineInBackground = (
   client: CozyClient
@@ -37,8 +42,47 @@ const makeImportantFilesAvailableOffline = async (
   log.debug('Start downloading important files for offline support')
   const importantFiles = await getImportantFiles(client)
 
+  await cleanOldNonImportantFiles(importantFiles)
+
   for (const importantFile of importantFiles) {
     log.debug(`Start downloading file ${importantFile._id}`)
     await downloadFile(importantFile, client)
+  }
+}
+
+const cleanOldNonImportantFiles = async (
+  importantFiles: FileDocument[]
+): Promise<void> => {
+  try {
+    const offlineFiles = await getOfflineFilesConfiguration()
+    const offlineFilesMap = Array.from(offlineFiles)
+
+    const importantFilesIds = importantFiles.map(file => file._id)
+
+    const now = new Date()
+
+    for (const [, offlineFile] of offlineFilesMap) {
+      const lastOpened = offlineFile.lastOpened
+      if (
+        !importantFilesIds.includes(offlineFile.id) &&
+        (differenceInMonths(lastOpened, now) > NB_OF_MONTH_BEFORE_EXPIRATION ||
+          !lastOpened)
+      ) {
+        log.debug(
+          `Remove old unimportant file ${
+            offlineFile.id
+          } (last opened on ${lastOpened.toString()})`
+        )
+        if (await RNFS.exists(offlineFile.path)) {
+          await RNFS.unlink(offlineFile.path)
+        }
+        await removeOfflineFileFromConfiguration(offlineFile.id)
+      }
+    }
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error(
+      `Something went wrong while cleaning non-important files: ${errorMessage}`
+    )
   }
 }

--- a/src/app/domain/io.cozy.files/offlineFiles.spec.ts
+++ b/src/app/domain/io.cozy.files/offlineFiles.spec.ts
@@ -1,0 +1,246 @@
+import RNFS from 'react-native-fs'
+
+import CozyClient, { createMockClient } from 'cozy-client'
+import { FileDocument } from 'cozy-client/types/types'
+
+import {
+  downloadFile,
+  getFilesFolder
+} from '/app/domain/io.cozy.files/offlineFiles'
+import {
+  addOfflineFileToConfiguration,
+  getOfflineFileFromConfiguration,
+  OfflineFile
+} from '/app/domain/io.cozy.files/offlineFilesConfiguration'
+import {
+  getDownloadUrlById,
+  getFileById
+} from '/app/domain/io.cozy.files/remoteFiles'
+
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
+jest.mock('/app/domain/io.cozy.files/offlineFilesConfiguration', () => ({
+  addOfflineFileToConfiguration: jest.fn(),
+  getOfflineFileFromConfiguration: jest.fn()
+}))
+jest.mock('/app/domain/io.cozy.files/remoteFiles', () => ({
+  getFileById: jest.fn(),
+  getDownloadUrlById: jest.fn()
+}))
+
+jest.mock('react-native-fs', () => {
+  return {
+    DocumentDirectoryPath: '/mockedDocumentDirectoryPath',
+    downloadFile: jest.fn().mockImplementation(() => ({
+      promise: Promise.resolve({
+        jobId: 1,
+        statusCode: 200,
+        bytesWritten: 100,
+        path: () => 'mocked-file-path'
+      })
+    })),
+    mkdir: jest.fn(),
+    unlink: jest.fn()
+  }
+})
+
+const mockGetOfflineFileFromConfiguration =
+  getOfflineFileFromConfiguration as jest.MockedFunction<
+    typeof getOfflineFileFromConfiguration
+  >
+const mockGetFileById = getFileById as jest.MockedFunction<typeof getFileById>
+const mockGetDownloadUrlById = getDownloadUrlById as jest.MockedFunction<
+  typeof getDownloadUrlById
+>
+
+describe('offlineFiles', () => {
+  let mockClient: jest.Mocked<CozyClient>
+
+  beforeEach(() => {
+    const options = {
+      clientOptions: {
+        uri: 'http://claude.mycozy.cloud'
+      }
+    } as object
+    mockClient = createMockClient(
+      options
+    ) as Partial<CozyClient> as jest.Mocked<CozyClient>
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getFilesFolder', () => {
+    it('should return File path relative to instance url', () => {
+      const result = getFilesFolder(mockClient)
+
+      expect(result).toBe(
+        '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files'
+      )
+    })
+  })
+
+  describe('downloadFile', () => {
+    it('should download file if not existing', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_REV',
+        name: 'SOME_FILE_NAME'
+      })
+      mockDownloadUrl('SOME_FILE_DOWNLOAD_URL')
+      mockFileFromConfiguration(undefined)
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      const result = await downloadFile(file, mockClient)
+
+      expect(RNFS.downloadFile).toHaveBeenCalledWith({
+        fromUrl: 'SOME_FILE_DOWNLOAD_URL',
+        toFile:
+          '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        begin: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progress: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progressInterval: expect.anything()
+      })
+      expect(result).toBe(
+        '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME'
+      )
+      expect(addOfflineFileToConfiguration).toHaveBeenCalledWith({
+        id: 'SOME_FILE_ID',
+        path: '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME',
+        rev: 'SOME_REV'
+      })
+    })
+
+    it('should not download file if existing', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_REV',
+        name: 'SOME_FILE_NAME'
+      })
+      mockFileFromConfiguration({
+        id: 'SOME_FILE_ID',
+        rev: 'SOME_REV',
+        path: 'SOME_EXISTING_PATH_FROM_CACHE',
+        lastOpened: new Date()
+      })
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      const result = await downloadFile(file, mockClient)
+
+      expect(RNFS.downloadFile).not.toHaveBeenCalled()
+      expect(result).toBe('SOME_EXISTING_PATH_FROM_CACHE')
+      expect(addOfflineFileToConfiguration).not.toHaveBeenCalled()
+    })
+
+    it('should download file if existing but with different rev', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_NEW_REV',
+        name: 'SOME_FILE_NAME'
+      })
+      mockDownloadUrl('SOME_NEW_FILE_DOWNLOAD_URL')
+      mockFileFromConfiguration({
+        id: 'SOME_FILE_ID',
+        rev: 'SOME_REV',
+        path: 'SOME_EXISTING_PATH_FROM_CACHE',
+        lastOpened: new Date()
+      })
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      const result = await downloadFile(file, mockClient)
+
+      expect(RNFS.downloadFile).toHaveBeenCalledWith({
+        fromUrl: 'SOME_NEW_FILE_DOWNLOAD_URL',
+        toFile:
+          '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        begin: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progress: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progressInterval: expect.anything()
+      })
+      expect(result).toBe(
+        '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME'
+      )
+      expect(addOfflineFileToConfiguration).toHaveBeenCalledWith({
+        id: 'SOME_FILE_ID',
+        path: '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME',
+        rev: 'SOME_NEW_REV'
+      })
+    })
+
+    it('should use new file name new rev with different name', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_NEW_REV',
+        name: 'SOME_NEW_FILE_NAME'
+      })
+      mockDownloadUrl('SOME_NEW_FILE_DOWNLOAD_URL')
+      mockFileFromConfiguration({
+        id: 'SOME_FILE_ID',
+        rev: 'SOME_REV',
+        path: 'SOME_EXISTING_PATH_FROM_CACHE',
+        lastOpened: new Date()
+      })
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      const result = await downloadFile(file, mockClient)
+
+      expect(RNFS.downloadFile).toHaveBeenCalledWith({
+        fromUrl: 'SOME_NEW_FILE_DOWNLOAD_URL',
+        toFile:
+          '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_NEW_FILE_NAME',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        begin: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progress: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progressInterval: expect.anything()
+      })
+      expect(RNFS.unlink).toHaveBeenCalledWith('SOME_EXISTING_PATH_FROM_CACHE')
+      expect(result).toBe(
+        '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_NEW_FILE_NAME'
+      )
+      expect(addOfflineFileToConfiguration).toHaveBeenCalledWith({
+        id: 'SOME_FILE_ID',
+        path: '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_NEW_FILE_NAME',
+        rev: 'SOME_NEW_REV'
+      })
+    })
+  })
+})
+
+const mockFileFromConfiguration = (file: OfflineFile | undefined): void => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  mockGetOfflineFileFromConfiguration.mockResolvedValue(file)
+}
+
+const mockRemoteFile = (file: RemoteFile): void => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  mockGetFileById.mockResolvedValue(file as unknown as FileDocument)
+}
+
+const mockDownloadUrl = (url: string): void => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  mockGetDownloadUrlById.mockResolvedValue(url)
+}
+
+interface RemoteFile {
+  _id: string
+  _rev: string
+  name: string
+}

--- a/src/app/domain/io.cozy.files/offlineFiles.spec.ts
+++ b/src/app/domain/io.cozy.files/offlineFiles.spec.ts
@@ -10,7 +10,8 @@ import {
 import {
   addOfflineFileToConfiguration,
   getOfflineFileFromConfiguration,
-  OfflineFile
+  OfflineFile,
+  updateLastOpened
 } from '/app/domain/io.cozy.files/offlineFilesConfiguration'
 import {
   getDownloadUrlById,
@@ -22,7 +23,8 @@ jest.mock('react-native-file-viewer', () => ({
 }))
 jest.mock('/app/domain/io.cozy.files/offlineFilesConfiguration', () => ({
   addOfflineFileToConfiguration: jest.fn(),
-  getOfflineFileFromConfiguration: jest.fn()
+  getOfflineFileFromConfiguration: jest.fn(),
+  updateLastOpened: jest.fn()
 }))
 jest.mock('/app/domain/io.cozy.files/remoteFiles', () => ({
   getFileById: jest.fn(),
@@ -139,6 +141,27 @@ describe('offlineFiles', () => {
       expect(RNFS.downloadFile).not.toHaveBeenCalled()
       expect(result).toBe('SOME_EXISTING_PATH_FROM_CACHE')
       expect(addOfflineFileToConfiguration).not.toHaveBeenCalled()
+    })
+
+    it('should update lastOpened attribute if file exists', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_REV',
+        name: 'SOME_FILE_NAME'
+      })
+      mockFileFromConfiguration({
+        id: 'SOME_FILE_ID',
+        rev: 'SOME_REV',
+        path: 'SOME_EXISTING_PATH_FROM_CACHE',
+        lastOpened: new Date()
+      })
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      await downloadFile(file, mockClient)
+
+      expect(updateLastOpened).toHaveBeenCalledWith('SOME_FILE_ID')
     })
 
     it('should download file if existing but with different rev', async () => {

--- a/src/app/domain/io.cozy.files/offlineFiles.ts
+++ b/src/app/domain/io.cozy.files/offlineFiles.ts
@@ -7,7 +7,8 @@ import Minilog from 'cozy-minilog'
 
 import {
   addOfflineFileToConfiguration,
-  getOfflineFileFromConfiguration
+  getOfflineFileFromConfiguration,
+  updateLastOpened
 } from '/app/domain/io.cozy.files/offlineFilesConfiguration'
 import {
   getDownloadUrlById,
@@ -50,6 +51,7 @@ export const downloadFile = async (
 
     if (existingFile && existingFile.rev === remoteFile._rev) {
       log.debug(`File ${file._id} already exist, returning existing one`)
+      await updateLastOpened(file._id)
       return existingFile.path
     }
 

--- a/src/app/domain/io.cozy.files/offlineFiles.ts
+++ b/src/app/domain/io.cozy.files/offlineFiles.ts
@@ -1,0 +1,115 @@
+import FileViewer from 'react-native-file-viewer'
+import RNFS from 'react-native-fs'
+
+import CozyClient from 'cozy-client'
+import type { FileDocument } from 'cozy-client/types/types'
+import Minilog from 'cozy-minilog'
+
+import {
+  addOfflineFileToConfiguration,
+  getOfflineFileFromConfiguration
+} from '/app/domain/io.cozy.files/offlineFilesConfiguration'
+import {
+  getDownloadUrlById,
+  getFileById
+} from '/app/domain/io.cozy.files/remoteFiles'
+import { getInstanceAndFqdnFromClient } from '/libs/client'
+import { normalizeFqdn } from '/libs/functions/stringHelpers'
+
+const log = Minilog('📁 Offline Files')
+
+export const getFilesFolder = (client: CozyClient): string => {
+  const { fqdn } = getInstanceAndFqdnFromClient(client)
+
+  const normalizedFqdn = normalizeFqdn(fqdn)
+
+  const destinationPath = `${RNFS.DocumentDirectoryPath}/${normalizedFqdn}/Files`
+
+  return destinationPath
+}
+
+const ensureFilesFolder = async (client: CozyClient): Promise<void> => {
+  await RNFS.mkdir(getFilesFolder(client))
+}
+
+export const downloadFile = async (
+  file: FileDocument,
+  client: CozyClient,
+  setDownloadProgress?: (progress: number) => void
+): Promise<string> => {
+  try {
+    log.debug('Download file', file._id)
+
+    await ensureFilesFolder(client)
+
+    const filesFolder = getFilesFolder(client)
+
+    const existingFile = await getOfflineFileFromConfiguration(file._id)
+
+    const remoteFile = await getFileById(client, file._id)
+
+    if (existingFile && existingFile.rev === remoteFile._rev) {
+      log.debug(`File ${file._id} already exist, returning existing one`)
+      return existingFile.path
+    }
+
+    const filename = remoteFile.name
+
+    const downloadURL = await getDownloadUrlById(client, file._id, filename)
+
+    const destinationPath = `${filesFolder}/${filename}`
+
+    const result = await RNFS.downloadFile({
+      fromUrl: downloadURL,
+      toFile: `${filesFolder}/${filename}`,
+      begin: () => undefined,
+      progress: res => {
+        const progressPercent = res.bytesWritten / res.contentLength
+        setDownloadProgress?.(progressPercent)
+      },
+      progressInterval: 100
+    }).promise
+
+    log.debug(`Donload result is ${JSON.stringify(result)}`)
+
+    const { statusCode } = result
+
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`Status code: ${statusCode}`)
+    }
+
+    setDownloadProgress?.(0)
+
+    await addOfflineFileToConfiguration({
+      id: file._id,
+      rev: remoteFile._rev,
+      path: destinationPath
+    })
+
+    // If the file's new Rev has a new name, we should delete old file version as file path also changed
+    if (existingFile && existingFile.path !== destinationPath) {
+      await RNFS.unlink(existingFile.path)
+    }
+
+    return destinationPath
+    // return destinationPath
+  } catch (error) {
+    log.error('Something went wrong while downloading file', error)
+    throw error
+  }
+}
+
+export const downloadFileAndPreview = async (
+  file: FileDocument,
+  client: CozyClient | undefined
+): Promise<null> => {
+  if (!client) {
+    throw new Error('You must be logged in to use backup feature')
+  }
+
+  const filePath = await downloadFile(file, client)
+
+  await FileViewer.open(filePath)
+
+  return null
+}

--- a/src/app/domain/io.cozy.files/offlineFilesConfiguration.ts
+++ b/src/app/domain/io.cozy.files/offlineFilesConfiguration.ts
@@ -1,0 +1,55 @@
+import { CozyPersistedStorageKeys, getData, storeData } from '/libs/localStore'
+
+export interface OfflineFile {
+  id: string
+  rev: string
+  path: string
+}
+
+export type OfflineFilesConfiguration = Map<string, OfflineFile>
+export type SerializedOfflineFilesConfiguration = [string, OfflineFile][]
+
+export const getOfflineFilesConfiguration =
+  async (): Promise<OfflineFilesConfiguration> => {
+    const filesArray = await getData<OfflineFilesConfiguration>(
+      CozyPersistedStorageKeys.OfflineFiles
+    )
+
+    const files = new Map(filesArray)
+
+    return files
+  }
+
+export const addOfflineFileToConfiguration = async (file: OfflineFile) => {
+  const files = await getOfflineFilesConfiguration()
+
+  files.set(file.id, file)
+  
+  const filesArray = Array.from(files.entries())
+
+  return storeData(CozyPersistedStorageKeys.OfflineFiles, filesArray)
+}
+
+export const removeOfflineFileFromConfiguration = async (
+  fileId: string
+): Promise<void> => {
+  const files = await getOfflineFilesConfiguration()
+
+  files.delete(fileId)
+
+  const filesArray = Array.from(files.entries())
+
+  return storeData(CozyPersistedStorageKeys.OfflineFiles, filesArray)
+}
+
+export const getOfflineFileFromConfiguration = async (
+  fileId: string
+): Promise<OfflineFile | undefined> => {
+  const files = await getOfflineFilesConfiguration()
+
+  if (files.has(fileId)) {
+    return files.get(fileId)
+  }
+
+  return undefined
+}

--- a/src/app/domain/io.cozy.files/remoteFiles.ts
+++ b/src/app/domain/io.cozy.files/remoteFiles.ts
@@ -1,0 +1,31 @@
+import CozyClient, { FileCollectionGetResult, Q } from 'cozy-client'
+import { FileDocument } from 'cozy-client/types/types'
+
+export const DOCTYPE_FILES = 'io.cozy.files'
+
+export const getFileById = async (
+  client: CozyClient,
+  id: string
+): Promise<FileDocument> => {
+  const query = Q(DOCTYPE_FILES).getById(id)
+  const { data } = (await client.query(query)) as FileCollectionGetResult
+
+  return data as unknown as FileDocument
+}
+
+export const getDownloadUrlById = async (
+  client: CozyClient,
+  id: string,
+  filename: string
+): Promise<string> => {
+  const fileCollection = client.collection(
+    DOCTYPE_FILES
+  ) as unknown as FileCollection
+  const downloadURL = await fileCollection.getDownloadLinkById(id, filename)
+
+  return downloadURL
+}
+
+interface FileCollection {
+  getDownloadLinkById: (id: string, filename: string) => Promise<string>
+}

--- a/src/app/domain/io.cozy.files/remoteFiles.ts
+++ b/src/app/domain/io.cozy.files/remoteFiles.ts
@@ -3,6 +3,18 @@ import { FileDocument } from 'cozy-client/types/types'
 
 export const DOCTYPE_FILES = 'io.cozy.files'
 
+const IMPORTANT_PAPERS = [
+  'bank_details',
+  'driver_license',
+  'identity_photo',
+  'national_health_insurance_card',
+  'national_id_card',
+  'passport',
+  'residence_permit',
+  'resume',
+  'vehicle_registration'
+]
+
 export const getFileById = async (
   client: CozyClient,
   id: string
@@ -24,6 +36,31 @@ export const getDownloadUrlById = async (
   const downloadURL = await fileCollection.getDownloadLinkById(id, filename)
 
   return downloadURL
+}
+
+export const getImportantFiles = async (
+  client: CozyClient
+): Promise<FileDocument[]> => {
+  const query = Q(DOCTYPE_FILES)
+    .where({
+      created_at: {
+        $gt: null
+      },
+      'metadata.qualification.label': {
+        $in: IMPORTANT_PAPERS
+      }
+    })
+    .partialIndex({
+      type: 'file',
+      trashed: false,
+      'cozyMetadata.createdByApp': { $exists: true }
+    })
+    .indexFields(['created_at', 'metadata.qualification.label'])
+    .sortBy([{ created_at: 'desc' }])
+
+  const { data } = (await client.query(query)) as FileCollectionGetResult
+
+  return data as unknown as FileDocument[]
 }
 
 interface FileCollection {

--- a/src/app/domain/settings/services/SettingsService.spec.ts
+++ b/src/app/domain/settings/services/SettingsService.spec.ts
@@ -9,6 +9,9 @@ import { ensureAutoLockIsEnabled } from '/app/domain/settings/services/SettingsS
 jest.mock('@react-native-cookies/cookies', () => ({
   clearAll: jest.fn()
 }))
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
 
 describe('ensureAutoLockIsEnabled', () => {
   beforeEach(async () => await clearCozyData())

--- a/src/app/view/Secure/PinPrompt.spec.tsx
+++ b/src/app/view/Secure/PinPrompt.spec.tsx
@@ -22,6 +22,9 @@ jest.mock('/app/view/Lock/useLockScreenWrapper', () => ({
   hideSecurityScreen: jest.fn(),
   showSecurityScreen: jest.fn()
 }))
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
 
 // This is our main test suite for the PinPrompt component
 describe('PinPrompt', () => {

--- a/src/hooks/useGlobalAppState.spec.ts
+++ b/src/hooks/useGlobalAppState.spec.ts
@@ -2,6 +2,10 @@ import { Platform } from 'react-native'
 
 import { _shouldLockApp } from '/app/domain/authorization/services/SecurityService'
 
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
+
 afterAll(jest.resetModules)
 
 it('should always lock the application on iOS devices when running through the autolock check, ignoring timer', () => {

--- a/src/libs/intents/localMethods.spec.ts
+++ b/src/libs/intents/localMethods.spec.ts
@@ -17,6 +17,9 @@ jest.mock('../RootNavigation')
 jest.mock('@react-native-cookies/cookies', () => ({
   clearAll: jest.fn()
 }))
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
 
 describe('asyncLogout', () => {
   const client = {

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -2,6 +2,7 @@ import { Linking } from 'react-native'
 import { getDeviceName } from 'react-native-device-info'
 
 import CozyClient, { QueryDefinition } from 'cozy-client'
+import type { FileDocument } from 'cozy-client/types/types'
 import {
   FlagshipUI,
   NativeMethodsRegisterWithOptions,
@@ -60,6 +61,7 @@ import {
   sendGeolocationTrackingLogs,
   forceUploadGeolocationTrackingData
 } from '/app/domain/geolocation/services/tracking'
+import { downloadFileAndPreview } from '/app/domain/io.cozy.files/offlineFiles'
 import {
   checkPermissions,
   requestPermissions
@@ -401,6 +403,8 @@ export const localMethods = (
     ) => Promise.resolve(setColorScheme(colorScheme)),
     flagshipLinkRequest: (_options, operation) =>
       flagshipLinkRequest(operation as QueryDefinition, client),
+    downloadFile: (_options, file) =>
+      downloadFileAndPreview(file as FileDocument, client),
     ...mergedMethods
   }
 }

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -4,6 +4,7 @@ import { BiometryType } from 'react-native-biometrics'
 
 import { logger } from '/libs/functions/logger'
 import type { FirstTimeserie } from '/app/domain/geolocation/helpers/quota'
+import { SerializedOfflineFilesConfiguration } from '/app/domain/io.cozy.files/offlineFilesConfiguration'
 import type { OnboardingPartner } from '/screens/welcome/install-referrer/onboardingPartner'
 import { OauthData } from '/libs/clientHelpers/persistClient'
 
@@ -36,7 +37,8 @@ export enum CozyPersistedStorageKeys {
   ServiceWebhookURL = 'CozyGPSMemory.ServiceWebhookURL',
   Oauth = '@cozy_AmiralAppOAuthConfig',
   Cookie = '@cozy_AmiralAppCookieConfig',
-  SessionCreated = '@cozy_AmiralAppSessionCreated'
+  SessionCreated = '@cozy_AmiralAppSessionCreated',
+  OfflineFiles = '@cozy_AmiralAppOfflineFiles'
 }
 
 /*
@@ -62,6 +64,7 @@ export interface StorageItems {
   cookie: Cookies
   clouderyEnv: string
   logsEnabled: number
+  offlineFiles: SerializedOfflineFilesConfiguration
 }
 
 export const storeData = async (


### PR DESCRIPTION
When the application is offline, we want the user to be able to access their files that are accessible offline

To make this possible, we want the Flagship app to provide a new `downloadFileAndPreview()` interface that can be called from cozy-apps

Internally this method should allow to download and preview files, but also to store them in the device's storage in order to make them accessible later even when the app is offline

This method will be called from cozy-client through `file` model

For now we make files accessible only if they have already downloaded
once
___
We also want the user's important files to always be accessible offline

To make this possible, we want the app to download them in background on startup

We consider important files as files from `mespapiers` with specific qualification labels like passport, identification papers, vehicle registration, etc.
___
Finally, as we store offline accessible files in the device's storage, we want to prevent them to fill the entire device's storage

We chose to keep only files that were accessed in the previous month. All other files would be deleted

Important files are never deleted as long as they exist on the Cozy instance

___

TODO:

- [x] Upgrade cozy-intent after cozy/cozy-libs#2562 being merged