### PR TITLE
feat: Correctly handle error screens when the app is offline and allow to open cozy-apps when offline in iOS

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -225,7 +225,13 @@ const WrappedApp = () => {
     [client]
   )
 
-  if (client === null) return <Nav client={client} setClient={setClient} />
+  if (client === null) {
+    return (
+      <NetStatusBoundary>
+        <Nav client={client} setClient={setClient} />
+      </NetStatusBoundary>
+    )
+  }
 
   if (client)
     return (
@@ -259,13 +265,11 @@ const Wrapper = () => {
                 <HomeStateProvider>
                   <SplashScreenProvider>
                     <SecureBackgroundSplashScreenWrapper>
-                      <NetStatusBoundary>
-                        <ThemeProvider>
-                          <PermissionsChecker>
-                            <WrappedApp />
-                          </PermissionsChecker>
-                        </ThemeProvider>
-                      </NetStatusBoundary>
+                      <ThemeProvider>
+                        <PermissionsChecker>
+                          <WrappedApp />
+                        </PermissionsChecker>
+                      </ThemeProvider>
                     </SecureBackgroundSplashScreenWrapper>
                   </SplashScreenProvider>
                 </HomeStateProvider>

--- a/src/components/webviews/CozyProxyWebView.js
+++ b/src/components/webviews/CozyProxyWebView.js
@@ -1,4 +1,4 @@
-import { useFocusEffect } from '@react-navigation/native'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import React, { useCallback, useState, useEffect } from 'react'
 import { AppState, KeyboardAvoidingView, Platform, View } from 'react-native'
 
@@ -9,6 +9,7 @@ import { RemountProgress } from '/app/view/Loading/RemountProgress'
 import { initHtmlContent } from '/components/webviews/CozyProxyWebView.functions'
 import { CozyWebView } from '/components/webviews/CozyWebView'
 import { useHttpServerContext } from '/libs/httpserver/httpServerProvider'
+import { useI18n } from '/locales/i18n'
 
 import { styles } from '/components/webviews/CozyProxyWebView.styles'
 
@@ -23,6 +24,7 @@ export const CozyProxyWebView = ({
   wrapperStyle,
   ...props
 }) => {
+  const { t } = useI18n()
   const client = useClient()
   const httpServerContext = useHttpServerContext()
   const [state, dispatch] = useState({
@@ -34,6 +36,7 @@ export const CozyProxyWebView = ({
   const [htmlContentCreationDate, setHtmlContentCreationDate] = useState(
     Date.now()
   )
+  const navigation = useNavigation()
 
   const reload = useCallback(() => {
     log.debug('Reloading CozyProxyWebView')
@@ -73,7 +76,9 @@ export const CozyProxyWebView = ({
             href,
             client,
             dispatch,
-            setHtmlContentCreationDate
+            setHtmlContentCreationDate,
+            navigation,
+            t
           })
         } else {
           dispatch({
@@ -86,7 +91,7 @@ export const CozyProxyWebView = ({
     }
 
     void init()
-  }, [client, httpServerContext, slug, href])
+  }, [client, httpServerContext, navigation, slug, href])
 
   useFocusEffect(
     useCallback(() => {

--- a/src/libs/httpserver/httpServerProvider.tsx
+++ b/src/libs/httpserver/httpServerProvider.tsx
@@ -139,6 +139,15 @@ export const HttpServerProvider = (
         client
       )
 
+      if (source === 'cache') {
+        if (slug !== 'home' && slug !== 'mespapiers') {
+          return {
+            html: false,
+            source: 'offline'
+          }
+        }
+      }
+
       await setCookie(cookie, client)
       const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug)
 

--- a/src/libs/httpserver/httpServerProvider.tsx
+++ b/src/libs/httpserver/httpServerProvider.tsx
@@ -149,7 +149,7 @@ export const HttpServerProvider = (
       }
 
       await setCookie(cookie, client)
-      const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug)
+      const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug, source)
 
       if (!rawHtml) {
         return {

--- a/src/libs/httpserver/httpServerProvider.tsx
+++ b/src/libs/httpserver/httpServerProvider.tsx
@@ -16,6 +16,7 @@ import { fetchAppDataForSlug } from '/libs/httpserver/indexDataFetcher'
 import { getServerBaseFolder } from '/libs/httpserver/httpPaths'
 import { queryResultToCrypto } from '/components/webviews/CryptoWebView/cryptoObservable/cryptoObservable'
 import { setCookie } from '/libs/httpserver/httpCookieManager'
+import { HtmlSource } from '/libs/httpserver/models'
 
 import {
   addBodyClasses,
@@ -36,8 +37,8 @@ const DEFAULT_PORT = Config.HTTP_SERVER_DEFAULT_PORT
   : 5759
 
 interface IndexHtmlForSlug {
-  source: 'stack' | 'cache'
-  html: string
+  source: HtmlSource
+  html: string | false
 }
 
 interface HttpServerState {
@@ -123,7 +124,7 @@ export const HttpServerProvider = (
   const getIndexHtmlForSlug = async (
     slug: string,
     client: CozyClient
-  ): Promise<IndexHtmlForSlug | false> => {
+  ): Promise<IndexHtmlForSlug> => {
     try {
       if (!serverInstance) {
         throw new Error('ServerInstance is null, should not happen')
@@ -142,7 +143,10 @@ export const HttpServerProvider = (
       const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug)
 
       if (!rawHtml) {
-        return false
+        return {
+          html: false,
+          source: 'none'
+        }
       }
 
       const computedHtml = await fillIndexWithData({
@@ -185,7 +189,10 @@ export const HttpServerProvider = (
         `Error while generating Index.html for ${slug}. Cozy-stack version will be used instead. Error was: ${errorMessage}`
       )
 
-      return false
+      return {
+        html: false,
+        source: 'offline'
+      }
     }
   }
 

--- a/src/libs/httpserver/indexGenerator.ts
+++ b/src/libs/httpserver/indexGenerator.ts
@@ -13,6 +13,7 @@ import {
   prepareAssets
 } from '/libs/httpserver/copyAllFilesFromBundleAssets'
 import { TemplateValues } from '/libs/httpserver/indexDataFetcher'
+import { HtmlSource } from '/libs/httpserver/models'
 import {
   getCurrentAppConfigurationForFqdnAndSlug,
   setCurrentAppVersionForFqdnAndSlug
@@ -87,11 +88,17 @@ const isSlugInBlocklist = (currentSlug: string): boolean =>
 
 export const getIndexForFqdnAndSlug = async (
   fqdn: string,
-  slug: string
+  slug: string,
+  source: HtmlSource
 ): Promise<string | false> => {
   if (shouldDisableGetIndex()) return false // Make cozy-app hosted by webpack-dev-server work with HTTPServer
 
-  if (!isSlugInAllowlist(slug) || isSlugInBlocklist(slug)) return false
+  if (
+    (!isSlugInAllowlist(slug) || isSlugInBlocklist(slug)) &&
+    source !== 'cache'
+  ) {
+    return false
+  }
 
   await initLocalBundleIfNotExist(fqdn, slug)
 

--- a/src/libs/httpserver/models.ts
+++ b/src/libs/httpserver/models.ts
@@ -45,3 +45,5 @@ export interface CozyData {
   token?: string
   tracking?: string
 }
+
+export type HtmlSource = 'stack' | 'cache' | 'offline' | 'none'

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,6 +13,8 @@
     "badUnlockPassword": "The credentials you entered are incorrect, please try again.",
     "badUnlockPin": "The PIN you entered is incorrect, please try again",
     "contactUs": "A problem, a suggestion? Contact us at",
+    "offline_unsupported_title": "Unable to load",
+    "offline_unsupported_message": "This application is not available offline",
     "unknown_error": "An unexpected error occurred, please try again.",
     "reset": "Return to home",
     "showDetails": "Show error details",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -13,6 +13,8 @@
     "badUnlockPassword": "Las credenciales que has introducido son incorrectas, por favor inténtalo de nuevo.",
     "badUnlockPin": "El PIN que has introducido es incorrecto, por favor inténtalo de nuevo",
     "contactUs": "¿Un problema, una sugerencia? Contáctanos en",
+    "offline_unsupported_title": "No se puede cargar",
+    "offline_unsupported_message": "Esta aplicación no está disponible sin conexión",
     "unknown_error": "Ha ocurrido un error inesperado, por favor inténtalo de nuevo.",
     "reset": "Volver al inicio",
     "showDetails": "Ver detalles del error",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -13,6 +13,8 @@
     "badUnlockPassword": "Les identifiants que vous avez saisis sont incorrects, veuillez ré-essayer.",
     "badUnlockPin": "Le code PIN que vous avez saisi est incorrect, veuillez ré-essayer",
     "contactUs": "Un problème, une suggestion ? Contactez-nous à",
+    "offline_unsupported_title": "Chargement impossible",
+    "offline_unsupported_message": "Cette application n'est pas disponible hors connexion",
     "unknown_error": "Une erreur inattendue s'est produite, veuillez ré-essayer.",
     "reset": "Revenir à l'accueil",
     "showDetails": "Voir les détails de l'erreur",


### PR DESCRIPTION
`NetStatusBoundary` is used to display an `offline` error screen when
the app is offline

Now that we implemented offline mode, we now want to disable the
`NetStatusBoundary` for cozy-apps as they should now be accessible when
offline

`NetStatusBoundary` is kept only on onboarding screens

__


In iOS, we disabled HttpServer for all cozy-apps as the WebView API may
behave differently

The side effect is that we cannot open those app when offline as we
cannot inject minimal code to make them work without network access

So we want to enable HttpServer on those apps when we detect the app to
be offline

Related PR: #486