### PR TITLE
feat: Prevent local PouchDB modification to be replicated to remote DB

### DIFF
--- a/__tests__/jestSetupFile.js
+++ b/__tests__/jestSetupFile.js
@@ -140,3 +140,11 @@ jest.mock('cozy-pouch-link', () => {
     return new mockPouchLink()
   })
 })
+
+jest.mock('react-native-mail', () => ({
+  mail: jest.fn()
+}))
+
+jest.mock('rn-fetch-blob', () => ({
+  mail: jest.fn()
+}))

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -509,6 +509,8 @@ PODS:
     - React
   - react-native-idle-timer (2.2.1):
     - React-Core
+  - react-native-mail (6.1.1):
+    - React-Core
   - react-native-mlkit-ocr (0.3.0):
     - GoogleMLKit/TextRecognition (= 2.6.0)
     - React
@@ -648,6 +650,8 @@ PODS:
     - React-jsi (= 0.72.12)
     - React-logger (= 0.72.12)
     - React-perflogger (= 0.72.12)
+  - rn-fetch-blob (0.12.0):
+    - React-Core
   - RNBackgroundFetch (4.2.5):
     - React-Core
   - RNBackgroundGeolocation (4.16.4):
@@ -776,6 +780,7 @@ DEPENDENCIES:
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - "react-native-gzip (from `../node_modules/@fengweichong/react-native-gzip`)"
   - react-native-idle-timer (from `../node_modules/react-native-idle-timer`)
+  - react-native-mail (from `../node_modules/react-native-mail`)
   - react-native-mlkit-ocr (from `../node_modules/react-native-mlkit-ocr`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-print (from `../node_modules/react-native-print`)
@@ -803,6 +808,7 @@ DEPENDENCIES:
   - React-runtimescheduler (from `../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
   - RNBackgroundFetch (from `../node_modules/react-native-background-fetch`)
   - RNBackgroundGeolocation (from `../node_modules/react-native-background-geolocation`)
   - RNBootSplash (from `../node_modules/react-native-bootsplash`)
@@ -937,6 +943,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@fengweichong/react-native-gzip"
   react-native-idle-timer:
     :path: "../node_modules/react-native-idle-timer"
+  react-native-mail:
+    :path: "../node_modules/react-native-mail"
   react-native-mlkit-ocr:
     :path: "../node_modules/react-native-mlkit-ocr"
   react-native-netinfo:
@@ -991,6 +999,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/utils"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  rn-fetch-blob:
+    :path: "../node_modules/rn-fetch-blob"
   RNBackgroundFetch:
     :path: "../node_modules/react-native-background-fetch"
   RNBackgroundGeolocation:
@@ -1110,6 +1120,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
   react-native-gzip: 5ffb84bf191c7cd135338eca748317bc466d41a1
   react-native-idle-timer: f1920a59fe776340d004ff9de13c4a6eedcc8807
+  react-native-mail: 8fdcd3aef007c33a6877a18eb4cf7447a1d4ce4a
   react-native-mlkit-ocr: 72cdbde86f8d29cba26cf9fa0a1865fe45c8f8d6
   react-native-netinfo: 48c5f79a84fbc3ba1d28a8b0d04adeda72885fa8
   react-native-print: f704aef52d931bfce6d1d84351dbb5232d7ecb89
@@ -1137,6 +1148,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 8aea338c561b2175f47018124c076d89d3808d30
   React-utils: 9a24cb88f950d1020ee55bddacbc8c16a611e2dc
   ReactCommon: 76843a9bb140596351ac2786257ac9fe60cafabb
+  rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNBackgroundFetch: 2f800a04434620db15ede2e8f21886608a2d1743
   RNBackgroundGeolocation: 7df16548756b443aac809663cba8a4e03f0b8732
   RNBootSplash: 4844706cbb56a3270556c9b94e59dedadccd47e4

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "react-native-ios11-devicecheck": "https://github.com/cozy/react-native-devicecheck#app-attest-v0.1",
     "react-native-keychain": "^8.0.0",
     "react-native-localize": "2.2.6",
+    "react-native-mail": "^6.1.1",
     "react-native-mask-input": "1.2.1",
     "react-native-mlkit-ocr": "^0.3.0",
     "react-native-permissions": "^3.9.3",
@@ -128,6 +129,7 @@
     "react-scripts": "4.0.3",
     "redux-logger": "3.0.6",
     "redux-persist": "^6.0.0",
+    "rn-fetch-blob": "^0.12.0",
     "rn-flipper-async-storage-advanced": "^1.0.4",
     "semver": "^7.3.2"
   },

--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -111,6 +111,7 @@ declare module 'cozy-client' {
   export interface FileCollectionGetResult {
     data: {
       _id: string
+      _rev: string
       name: string
       path: string
       metadata?: {

--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import 'cozy-client'
-import { FileDocument, CozyClientDocument } from 'cozy-client/types/types'
+import { QueryDefinition } from 'cozy-client'
+import {
+  FileDocument,
+  CozyClientDocument,
+  QueryOptions,
+  QueryResult
+} from 'cozy-client/types/types'
 
 declare module 'cozy-client' {
   interface ClientOptions {
@@ -157,6 +163,10 @@ declare module 'cozy-client' {
     on: (event: string, callback: () => void) => void
     removeListener: (event: string, callback: () => void) => void
     logout: () => Promise<void>
+    query: (
+      queryDefinition: QueryDefinition,
+      options?: QueryOptions
+    ) => Promise<QueryResult>
   }
 
   export const createMockClient = (options?: ClientOptions): CozyClient =>

--- a/src/App.js
+++ b/src/App.js
@@ -59,6 +59,7 @@ import {
   LauncherContextProvider
 } from '/screens/home/hooks/useLauncherContext'
 import LauncherView from '/screens/konnectors/LauncherView'
+import { makeImportantFilesAvailableOfflineInBackground } from '/app/domain/io.cozy.files/importantFiles'
 import { useShareFiles } from '/app/domain/osReceive/services/shareFilesService'
 import { ClouderyOffer } from '/app/view/IAP/ClouderyOffer'
 import { useDimensions } from '/libs/dimensions'
@@ -111,6 +112,13 @@ const App = ({ setClient }) => {
     resetLauncherContext,
     setLauncherContext
   } = useLauncherContext()
+
+  useEffect(() => {
+    if (!client) {
+      return
+    }
+    makeImportantFilesAvailableOfflineInBackground(client)
+  }, [client])
 
   if (isLoading) {
     return null

--- a/src/App.js
+++ b/src/App.js
@@ -225,7 +225,11 @@ const WrappedApp = () => {
     [client]
   )
 
-  if (client === null) return <Nav client={client} setClient={setClient} />
+  if (client === null) return (
+    <NetStatusBoundary>
+      <Nav client={client} setClient={setClient} />
+    </NetStatusBoundary>
+  )
 
   if (client)
     return (
@@ -259,13 +263,11 @@ const Wrapper = () => {
                 <HomeStateProvider>
                   <SplashScreenProvider>
                     <SecureBackgroundSplashScreenWrapper>
-                      <NetStatusBoundary>
                         <ThemeProvider>
                           <PermissionsChecker>
                             <WrappedApp />
                           </PermissionsChecker>
                         </ThemeProvider>
-                      </NetStatusBoundary>
                     </SecureBackgroundSplashScreenWrapper>
                   </SplashScreenProvider>
                 </HomeStateProvider>

--- a/src/app/domain/authentication/services/BiometryService.spec.ts
+++ b/src/app/domain/authentication/services/BiometryService.spec.ts
@@ -28,6 +28,10 @@ jest.mock('react-native-keychain')
 
 jest.mock('@react-native-cookies/cookies', () => ({}))
 
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
+
 it('should not throw with a null hasBiometry', async () => {
   const result = await makeFlagshipMetadataInjection()
   expect(result).toStrictEqual(

--- a/src/app/domain/authorization/services/LockScreenService.spec.ts
+++ b/src/app/domain/authorization/services/LockScreenService.spec.ts
@@ -40,6 +40,10 @@ jest.mock('cozy-client', () => ({
   }))
 }))
 
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
+
 describe('validatePassword', () => {
   // Mocks and common setup
   let client: CozyClient

--- a/src/app/domain/io.cozy.files/importantFiles.ts
+++ b/src/app/domain/io.cozy.files/importantFiles.ts
@@ -1,0 +1,44 @@
+import CozyClient from 'cozy-client'
+import Minilog from 'cozy-minilog'
+
+import { downloadFile } from '/app/domain/io.cozy.files/offlineFiles'
+import {
+  getOfflineFilesConfiguration,
+  removeOfflineFileFromConfiguration
+} from '/app/domain/io.cozy.files/offlineFilesConfiguration'
+import { getImportantFiles } from '/app/domain/io.cozy.files/remoteFiles'
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+const log = Minilog('📁 Offline Files')
+
+const IMPORTANT_FILES_DOWNLOAD_DELAY_IN_MS = 100
+
+export const makeImportantFilesAvailableOfflineInBackground = (
+  client: CozyClient
+): Promise<void> => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      makeImportantFilesAvailableOffline(client)
+        .then(resolve)
+        .catch(error => {
+          const errorMessage = getErrorMessage(error)
+          log.error(
+            `Something went wrong while making important files available offline: ${errorMessage}`,
+            resolve()
+          )
+        })
+    }, IMPORTANT_FILES_DOWNLOAD_DELAY_IN_MS)
+  })
+}
+
+const makeImportantFilesAvailableOffline = async (
+  client: CozyClient
+): Promise<void> => {
+  log.debug('Start downloading important files for offline support')
+  const importantFiles = await getImportantFiles(client)
+
+  for (const importantFile of importantFiles) {
+    log.debug(`Start downloading file ${importantFile._id}`)
+    await downloadFile(importantFile, client)
+  }
+}

--- a/src/app/domain/io.cozy.files/importantFiles.ts
+++ b/src/app/domain/io.cozy.files/importantFiles.ts
@@ -1,4 +1,8 @@
+import { differenceInMonths } from 'date-fns'
+import RNFS from 'react-native-fs'
+
 import CozyClient from 'cozy-client'
+import type { FileDocument } from 'cozy-client/types/types'
 import Minilog from 'cozy-minilog'
 
 import { downloadFile } from '/app/domain/io.cozy.files/offlineFiles'
@@ -12,6 +16,7 @@ import { getErrorMessage } from '/libs/functions/getErrorMessage'
 const log = Minilog('📁 Offline Files')
 
 const IMPORTANT_FILES_DOWNLOAD_DELAY_IN_MS = 100
+const NB_OF_MONTH_BEFORE_EXPIRATION = 1
 
 export const makeImportantFilesAvailableOfflineInBackground = (
   client: CozyClient
@@ -37,8 +42,47 @@ const makeImportantFilesAvailableOffline = async (
   log.debug('Start downloading important files for offline support')
   const importantFiles = await getImportantFiles(client)
 
+  await cleanOldNonImportantFiles(importantFiles)
+
   for (const importantFile of importantFiles) {
     log.debug(`Start downloading file ${importantFile._id}`)
     await downloadFile(importantFile, client)
+  }
+}
+
+const cleanOldNonImportantFiles = async (
+  importantFiles: FileDocument[]
+): Promise<void> => {
+  try {
+    const offlineFiles = await getOfflineFilesConfiguration()
+    const offlineFilesMap = Array.from(offlineFiles)
+
+    const importantFilesIds = importantFiles.map(file => file._id)
+
+    const now = new Date()
+
+    for (const [, offlineFile] of offlineFilesMap) {
+      const lastOpened = offlineFile.lastOpened
+      if (
+        !importantFilesIds.includes(offlineFile.id) &&
+        (differenceInMonths(lastOpened, now) > NB_OF_MONTH_BEFORE_EXPIRATION ||
+          !lastOpened)
+      ) {
+        log.debug(
+          `Remove old unimportant file ${
+            offlineFile.id
+          } (last opened on ${lastOpened.toString()})`
+        )
+        if (await RNFS.exists(offlineFile.path)) {
+          await RNFS.unlink(offlineFile.path)
+        }
+        await removeOfflineFileFromConfiguration(offlineFile.id)
+      }
+    }
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error(
+      `Something went wrong while cleaning non-important files: ${errorMessage}`
+    )
   }
 }

--- a/src/app/domain/io.cozy.files/offlineFiles.spec.ts
+++ b/src/app/domain/io.cozy.files/offlineFiles.spec.ts
@@ -1,0 +1,244 @@
+import RNFS from 'react-native-fs'
+
+import CozyClient, { createMockClient } from 'cozy-client'
+import { FileDocument } from 'cozy-client/types/types'
+
+import {
+  downloadFile,
+  getFilesFolder
+} from '/app/domain/io.cozy.files/offlineFiles'
+import {
+  addOfflineFileToConfiguration,
+  getOfflineFileFromConfiguration,
+  OfflineFile
+} from '/app/domain/io.cozy.files/offlineFilesConfiguration'
+import {
+  getDownloadUrlById,
+  getFileById
+} from '/app/domain/io.cozy.files/remoteFiles'
+
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
+jest.mock('/app/domain/io.cozy.files/offlineFilesConfiguration', () => ({
+  addOfflineFileToConfiguration: jest.fn(),
+  getOfflineFileFromConfiguration: jest.fn()
+}))
+jest.mock('/app/domain/io.cozy.files/remoteFiles', () => ({
+  getFileById: jest.fn(),
+  getDownloadUrlById: jest.fn()
+}))
+
+jest.mock('react-native-fs', () => {
+  return {
+    DocumentDirectoryPath: '/mockedDocumentDirectoryPath',
+    downloadFile: jest.fn().mockImplementation(() => ({
+      promise: Promise.resolve({
+        jobId: 1,
+        statusCode: 200,
+        bytesWritten: 100,
+        path: () => 'mocked-file-path'
+      })
+    })),
+    mkdir: jest.fn(),
+    unlink: jest.fn()
+  }
+})
+
+const mockGetOfflineFileFromConfiguration =
+  getOfflineFileFromConfiguration as jest.MockedFunction<typeof getOfflineFileFromConfiguration>
+const mockGetFileById =
+  getFileById as jest.MockedFunction<typeof getFileById>
+const mockGetDownloadUrlById =
+  getDownloadUrlById as jest.MockedFunction<typeof getDownloadUrlById>
+
+describe('offlineFiles', () => {
+  let mockClient: jest.Mocked<CozyClient>
+
+  beforeEach(() => {
+    const options = {
+      clientOptions: {
+        uri: 'http://claude.mycozy.cloud'
+      }
+    } as object
+    mockClient = createMockClient(
+      options
+    ) as Partial<CozyClient> as jest.Mocked<CozyClient>
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getFilesFolder', () => {
+    it('should return File path relative to instance url', () => {
+      const result = getFilesFolder(mockClient)
+
+      expect(result).toBe(
+        '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files'
+      )
+    })
+  })
+
+  describe('downloadFile', () => {
+    it('should download file if not existing', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_REV',
+        name: 'SOME_FILE_NAME'
+      })
+      mockDownloadUrl('SOME_FILE_DOWNLOAD_URL')
+      mockFileFromConfiguration(undefined)
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      const result = await downloadFile(file, mockClient)
+
+      expect(RNFS.downloadFile).toHaveBeenCalledWith({
+        fromUrl: 'SOME_FILE_DOWNLOAD_URL',
+        toFile:
+          '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        begin: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progress: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progressInterval: expect.anything()
+      })
+      expect(result).toBe(
+        '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME'
+      )
+      expect(addOfflineFileToConfiguration).toHaveBeenCalledWith({
+        id: 'SOME_FILE_ID',
+        path: '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME',
+        rev: 'SOME_REV'
+      })
+    })
+
+    it('should not download file if existing', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_REV',
+        name: 'SOME_FILE_NAME'
+      })
+      mockFileFromConfiguration({
+        id: 'SOME_FILE_ID',
+        rev: 'SOME_REV',
+        path: 'SOME_EXISTING_PATH_FROM_CACHE',
+        lastOpened: new Date()
+      })
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      const result = await downloadFile(file, mockClient)
+
+      expect(RNFS.downloadFile).not.toHaveBeenCalled()
+      expect(result).toBe('SOME_EXISTING_PATH_FROM_CACHE')
+      expect(addOfflineFileToConfiguration).not.toHaveBeenCalled()
+    })
+
+    it('should download file if existing but with different rev', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_NEW_REV',
+        name: 'SOME_FILE_NAME'
+      })
+      mockDownloadUrl('SOME_NEW_FILE_DOWNLOAD_URL')
+      mockFileFromConfiguration({
+        id: 'SOME_FILE_ID',
+        rev: 'SOME_REV',
+        path: 'SOME_EXISTING_PATH_FROM_CACHE',
+        lastOpened: new Date()
+      })
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      const result = await downloadFile(file, mockClient)
+
+      expect(RNFS.downloadFile).toHaveBeenCalledWith({
+        fromUrl: 'SOME_NEW_FILE_DOWNLOAD_URL',
+        toFile:
+          '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        begin: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progress: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progressInterval: expect.anything()
+      })
+      expect(result).toBe(
+        '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME'
+      )
+      expect(addOfflineFileToConfiguration).toHaveBeenCalledWith({
+        id: 'SOME_FILE_ID',
+        path: '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_FILE_NAME',
+        rev: 'SOME_NEW_REV'
+      })
+    })
+
+    it('should use new file name new rev with different name', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_NEW_REV',
+        name: 'SOME_NEW_FILE_NAME'
+      })
+      mockDownloadUrl('SOME_NEW_FILE_DOWNLOAD_URL')
+      mockFileFromConfiguration({
+        id: 'SOME_FILE_ID',
+        rev: 'SOME_REV',
+        path: 'SOME_EXISTING_PATH_FROM_CACHE',
+        lastOpened: new Date()
+      })
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      const result = await downloadFile(file, mockClient)
+
+      expect(RNFS.downloadFile).toHaveBeenCalledWith({
+        fromUrl: 'SOME_NEW_FILE_DOWNLOAD_URL',
+        toFile:
+          '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_NEW_FILE_NAME',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        begin: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progress: expect.anything(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        progressInterval: expect.anything()
+      })
+      expect(RNFS.unlink).toHaveBeenCalledWith('SOME_EXISTING_PATH_FROM_CACHE')
+      expect(result).toBe(
+        '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_NEW_FILE_NAME'
+      )
+      expect(addOfflineFileToConfiguration).toHaveBeenCalledWith({
+        id: 'SOME_FILE_ID',
+        path: '/mockedDocumentDirectoryPath/claude.mycozy.cloud/Files/SOME_NEW_FILE_NAME',
+        rev: 'SOME_NEW_REV'
+      })
+    })
+  })
+})
+
+const mockFileFromConfiguration = (file: OfflineFile | undefined): void => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  mockGetOfflineFileFromConfiguration.mockResolvedValue(file)
+}
+
+const mockRemoteFile = (file: RemoteFile): void => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  mockGetFileById.mockResolvedValue(file as unknown as FileDocument)
+}
+
+const mockDownloadUrl = (url: string): void => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  mockGetDownloadUrlById.mockResolvedValue(url)
+}
+
+interface RemoteFile {
+  _id: string
+  _rev: string
+  name: string
+}

--- a/src/app/domain/io.cozy.files/offlineFiles.spec.ts
+++ b/src/app/domain/io.cozy.files/offlineFiles.spec.ts
@@ -10,7 +10,8 @@ import {
 import {
   addOfflineFileToConfiguration,
   getOfflineFileFromConfiguration,
-  OfflineFile
+  OfflineFile,
+  updateLastOpened
 } from '/app/domain/io.cozy.files/offlineFilesConfiguration'
 import {
   getDownloadUrlById,
@@ -22,7 +23,8 @@ jest.mock('react-native-file-viewer', () => ({
 }))
 jest.mock('/app/domain/io.cozy.files/offlineFilesConfiguration', () => ({
   addOfflineFileToConfiguration: jest.fn(),
-  getOfflineFileFromConfiguration: jest.fn()
+  getOfflineFileFromConfiguration: jest.fn(),
+  updateLastOpened: jest.fn()
 }))
 jest.mock('/app/domain/io.cozy.files/remoteFiles', () => ({
   getFileById: jest.fn(),
@@ -137,6 +139,27 @@ describe('offlineFiles', () => {
       expect(RNFS.downloadFile).not.toHaveBeenCalled()
       expect(result).toBe('SOME_EXISTING_PATH_FROM_CACHE')
       expect(addOfflineFileToConfiguration).not.toHaveBeenCalled()
+    })
+
+    it('should update lastOpened attribute if file exists', async () => {
+      mockRemoteFile({
+        _id: 'SOME_FILE_ID',
+        _rev: 'SOME_REV',
+        name: 'SOME_FILE_NAME'
+      })
+      mockFileFromConfiguration({
+        id: 'SOME_FILE_ID',
+        rev: 'SOME_REV',
+        path: 'SOME_EXISTING_PATH_FROM_CACHE',
+        lastOpened: new Date()
+      })
+      const file = {
+        _id: 'SOME_FILE_ID',
+        name: 'SOME_FILE_NAME'
+      } as unknown as FileDocument
+      await downloadFile(file, mockClient)
+
+      expect(updateLastOpened).toHaveBeenCalledWith('SOME_FILE_ID')
     })
 
     it('should download file if existing but with different rev', async () => {

--- a/src/app/domain/io.cozy.files/offlineFiles.ts
+++ b/src/app/domain/io.cozy.files/offlineFiles.ts
@@ -7,7 +7,8 @@ import Minilog from 'cozy-minilog'
 
 import {
   addOfflineFileToConfiguration,
-  getOfflineFileFromConfiguration
+  getOfflineFileFromConfiguration,
+  updateLastOpened
 } from '/app/domain/io.cozy.files/offlineFilesConfiguration'
 import {
   getDownloadUrlById,
@@ -50,6 +51,7 @@ export const downloadFile = async (
 
     if (existingFile && existingFile.rev === remoteFile._rev) {
       log.debug(`File ${file._id} already exist, returning existing one`)
+      await updateLastOpened(file._id)
       return existingFile.path
     }
 

--- a/src/app/domain/io.cozy.files/offlineFiles.ts
+++ b/src/app/domain/io.cozy.files/offlineFiles.ts
@@ -1,0 +1,115 @@
+import FileViewer from 'react-native-file-viewer'
+import RNFS from 'react-native-fs'
+
+import CozyClient from 'cozy-client'
+import type { FileDocument } from 'cozy-client/types/types'
+import Minilog from 'cozy-minilog'
+
+import {
+  addOfflineFileToConfiguration,
+  getOfflineFileFromConfiguration
+} from '/app/domain/io.cozy.files/offlineFilesConfiguration'
+import {
+  getDownloadUrlById,
+  getFileById
+} from '/app/domain/io.cozy.files/remoteFiles'
+import { getInstanceAndFqdnFromClient } from '/libs/client'
+import { normalizeFqdn } from '/libs/functions/stringHelpers'
+
+const log = Minilog('📁 Offline Files')
+
+export const getFilesFolder = (client: CozyClient): string => {
+  const { fqdn } = getInstanceAndFqdnFromClient(client)
+
+  const normalizedFqdn = normalizeFqdn(fqdn)
+
+  const destinationPath = `${RNFS.DocumentDirectoryPath}/${normalizedFqdn}/Files`
+
+  return destinationPath
+}
+
+const ensureFilesFolder = async (client: CozyClient): Promise<void> => {
+  await RNFS.mkdir(getFilesFolder(client))
+}
+
+export const downloadFile = async (
+  file: FileDocument,
+  client: CozyClient,
+  setDownloadProgress?: (progress: number) => void
+): Promise<string> => {
+  try {
+    log.debug('Download file', file._id)
+
+    await ensureFilesFolder(client)
+
+    const filesFolder = getFilesFolder(client)
+
+    const existingFile = await getOfflineFileFromConfiguration(file._id)
+
+    const remoteFile = await getFileById(client, file._id)
+
+    if (existingFile && existingFile.rev === remoteFile._rev) {
+      log.debug(`File ${file._id} already exist, returning existing one`)
+      return existingFile.path
+    }
+
+    const filename = remoteFile.name
+
+    const downloadURL = await getDownloadUrlById(client, file._id, filename)
+
+    const destinationPath = `${filesFolder}/${filename}`
+
+    const result = await RNFS.downloadFile({
+      fromUrl: downloadURL,
+      toFile: `${filesFolder}/${filename}`,
+      begin: () => undefined,
+      progress: res => {
+        const progressPercent = res.bytesWritten / res.contentLength
+        setDownloadProgress?.(progressPercent)
+      },
+      progressInterval: 100
+    }).promise
+
+    log.debug(`Donload result is ${JSON.stringify(result)}`)
+
+    const { statusCode } = result
+
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`Status code: ${statusCode}`)
+    }
+
+    setDownloadProgress?.(0)
+
+    await addOfflineFileToConfiguration({
+      id: file._id,
+      rev: remoteFile._rev,
+      path: destinationPath
+    })
+
+    // If the file's new Rev has a new name, we should delete old file version as file path also changed
+    if (existingFile && existingFile.path !== destinationPath) {
+      await RNFS.unlink(existingFile.path)
+    }
+
+    return destinationPath
+    // return destinationPath
+  } catch (error) {
+    log.error('Something went wrong while downloading file', error)
+    throw error
+  }
+}
+
+export const downloadFileAndPreview = async (
+  file: FileDocument,
+  client: CozyClient | undefined
+): Promise<null> => {
+  if (!client) {
+    throw new Error('You must be logged in to use backup feature')
+  }
+
+  const filePath = await downloadFile(file, client)
+
+  await FileViewer.open(filePath)
+
+  return null
+}

--- a/src/app/domain/io.cozy.files/offlineFilesConfiguration.ts
+++ b/src/app/domain/io.cozy.files/offlineFilesConfiguration.ts
@@ -1,0 +1,55 @@
+import { CozyPersistedStorageKeys, getData, storeData } from '/libs/localStore'
+
+export interface OfflineFile {
+  id: string
+  rev: string
+  path: string
+}
+
+export type OfflineFilesConfiguration = Map<string, OfflineFile>
+export type SerializedOfflineFilesConfiguration = [string, OfflineFile][]
+
+export const getOfflineFilesConfiguration =
+  async (): Promise<OfflineFilesConfiguration> => {
+    const filesArray = await getData<OfflineFilesConfiguration>(
+      CozyPersistedStorageKeys.OfflineFiles
+    )
+
+    const files = new Map(filesArray)
+
+    return files
+  }
+
+export const addOfflineFileToConfiguration = async (file: OfflineFile) => {
+  const files = await getOfflineFilesConfiguration()
+
+  files.set(file.id, file)
+  
+  const filesArray = Array.from(files.entries())
+
+  return storeData(CozyPersistedStorageKeys.OfflineFiles, filesArray)
+}
+
+export const removeOfflineFileFromConfiguration = async (
+  fileId: string
+): Promise<void> => {
+  const files = await getOfflineFilesConfiguration()
+
+  files.delete(fileId)
+
+  const filesArray = Array.from(files.entries())
+
+  return storeData(CozyPersistedStorageKeys.OfflineFiles, filesArray)
+}
+
+export const getOfflineFileFromConfiguration = async (
+  fileId: string
+): Promise<OfflineFile | undefined> => {
+  const files = await getOfflineFilesConfiguration()
+
+  if (files.has(fileId)) {
+    return files.get(fileId)
+  }
+
+  return undefined
+}

--- a/src/app/domain/io.cozy.files/remoteFiles.ts
+++ b/src/app/domain/io.cozy.files/remoteFiles.ts
@@ -1,0 +1,31 @@
+import CozyClient, { FileCollectionGetResult, Q } from 'cozy-client'
+import { FileDocument } from 'cozy-client/types/types'
+
+export const DOCTYPE_FILES = 'io.cozy.files'
+
+export const getFileById = async (
+  client: CozyClient,
+  id: string
+): Promise<FileDocument> => {
+  const query = Q(DOCTYPE_FILES).getById(id)
+  const { data } = (await client.query(query)) as FileCollectionGetResult
+
+  return data as unknown as FileDocument
+}
+
+export const getDownloadUrlById = async (
+  client: CozyClient,
+  id: string,
+  filename: string
+): Promise<string> => {
+  const fileCollection = client.collection(
+    DOCTYPE_FILES
+  ) as unknown as FileCollection
+  const downloadURL = await fileCollection.getDownloadLinkById(id, filename)
+
+  return downloadURL
+}
+
+interface FileCollection {
+  getDownloadLinkById: (id: string, filename: string) => Promise<string>
+}

--- a/src/app/domain/settings/services/SettingsService.spec.ts
+++ b/src/app/domain/settings/services/SettingsService.spec.ts
@@ -9,6 +9,9 @@ import { ensureAutoLockIsEnabled } from '/app/domain/settings/services/SettingsS
 jest.mock('@react-native-cookies/cookies', () => ({
   clearAll: jest.fn()
 }))
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
 
 describe('ensureAutoLockIsEnabled', () => {
   beforeEach(async () => await clearCozyData())

--- a/src/app/view/Secure/PinPrompt.spec.tsx
+++ b/src/app/view/Secure/PinPrompt.spec.tsx
@@ -22,6 +22,9 @@ jest.mock('/app/view/Lock/useLockScreenWrapper', () => ({
   hideSecurityScreen: jest.fn(),
   showSecurityScreen: jest.fn()
 }))
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
 
 // This is our main test suite for the PinPrompt component
 describe('PinPrompt', () => {

--- a/src/components/webviews/CozyProxyWebView.functions.js
+++ b/src/components/webviews/CozyProxyWebView.functions.js
@@ -31,7 +31,8 @@ export const initHtmlContent = async ({
     return
   }
 
-  const htmlContent = await httpServerContext.getIndexHtmlForSlug(slug, client)
+  const { html: htmlContent, source: htmlSource } =
+    await httpServerContext.getIndexHtmlForSlug(slug, client)
 
   if (
     !cookieAlreadyExists &&
@@ -47,6 +48,7 @@ export const initHtmlContent = async ({
   setHtmlContentCreationDate(Date.now())
   dispatch(oldState => ({
     ...oldState,
+    activateCache: htmlSource === 'cache' && Platform.OS === 'android',
     html: htmlContent,
     nativeConfig: nativeConfigActual,
     source: sourceActual

--- a/src/components/webviews/CozyProxyWebView.js
+++ b/src/components/webviews/CozyProxyWebView.js
@@ -1,4 +1,4 @@
-import { useFocusEffect } from '@react-navigation/native'
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import React, { useCallback, useState, useEffect } from 'react'
 import { AppState, KeyboardAvoidingView, Platform, View } from 'react-native'
 
@@ -9,6 +9,7 @@ import { RemountProgress } from '/app/view/Loading/RemountProgress'
 import { initHtmlContent } from '/components/webviews/CozyProxyWebView.functions'
 import { CozyWebView } from '/components/webviews/CozyWebView'
 import { useHttpServerContext } from '/libs/httpserver/httpServerProvider'
+import { useI18n } from '/locales/i18n'
 
 import { styles } from '/components/webviews/CozyProxyWebView.styles'
 
@@ -23,6 +24,7 @@ export const CozyProxyWebView = ({
   wrapperStyle,
   ...props
 }) => {
+  const { t } = useI18n()
   const client = useClient()
   const httpServerContext = useHttpServerContext()
   const [state, dispatch] = useState({
@@ -34,6 +36,7 @@ export const CozyProxyWebView = ({
   const [htmlContentCreationDate, setHtmlContentCreationDate] = useState(
     Date.now()
   )
+  const navigation = useNavigation()
 
   const reload = useCallback(() => {
     log.debug('Reloading CozyProxyWebView')
@@ -73,7 +76,9 @@ export const CozyProxyWebView = ({
             href,
             client,
             dispatch,
-            setHtmlContentCreationDate
+            setHtmlContentCreationDate,
+            navigation,
+            t
           })
         } else {
           dispatch({
@@ -86,7 +91,7 @@ export const CozyProxyWebView = ({
     }
 
     void init()
-  }, [client, httpServerContext, slug, href])
+  }, [client, httpServerContext, navigation, slug, href])
 
   useFocusEffect(
     useCallback(() => {

--- a/src/components/webviews/CozyProxyWebView.js
+++ b/src/components/webviews/CozyProxyWebView.js
@@ -124,6 +124,9 @@ export const CozyProxyWebView = ({
             dispatch(oldState => ({ ...oldState, isLoading: false }))
             onLoad?.(syntheticEvent)
           }}
+          cacheMode={
+            state.activateCache ? 'LOAD_CACHE_ELSE_NETWORK' : 'LOAD_DEFAULT'
+          }
           {...props}
         />
       ) : null}

--- a/src/components/webviews/CozyProxyWebView.spec.js
+++ b/src/components/webviews/CozyProxyWebView.spec.js
@@ -24,7 +24,10 @@ describe('CozyWebview', () => {
 
   describe('OAuth Client Limit', () => {
     const httpServerContext = {
-      getIndexHtmlForSlug: jest.fn()
+      getIndexHtmlForSlug: jest.fn().mockResolvedValue({
+        source: 'stack',
+        html: 'SOME_HTML'
+      })
     }
     const href = 'https://claude-home.mycozy.cloud'
     const client = {}

--- a/src/components/webviews/CozyWebview.spec.js
+++ b/src/components/webviews/CozyWebview.spec.js
@@ -63,6 +63,7 @@ jest.mock('cozy-intent', () => ({
 }))
 
 jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
   useClient: jest.fn().mockReturnValue({}),
   useInstanceInfo: jest.fn().mockReturnValue({})
 }))

--- a/src/components/webviews/jsInteractions/jsCozyInjection.ts
+++ b/src/components/webviews/jsInteractions/jsCozyInjection.ts
@@ -17,6 +17,7 @@ const makeMetadata = (routeName?: string): string => {
   return JSON.stringify({
     immersive: routeName ? immersiveRoutes.includes(routeName) : false,
     navbarHeight,
+    offline_available: true,
     platform: Platform,
     routeName,
     statusBarHeight,

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { deconstructCozyWebLinkWithSlug } from 'cozy-client'
 
 import { handleLogsDeepLink } from '/app/domain/logger/deeplinkHandler'
+import { handleDbDeepLink } from '/pouchdb/deeplinkHandler'
 import { SentryCustomTags, setSentryTag } from '/libs/monitoring/Sentry'
 import { manageIconCache } from '/libs/functions/iconTable'
 import { getDefaultIconParams } from '/libs/functions/openApp'
@@ -157,6 +158,10 @@ export const useAppBootstrap = client => {
       log.debug(`🔗 Linking URL is ${url}`)
 
       if (handleLogsDeepLink(url, client)) {
+        return
+      }
+
+      if (handleDbDeepLink(url, client)) {
         return
       }
 

--- a/src/hooks/useAppBootstrap.spec.js
+++ b/src/hooks/useAppBootstrap.spec.js
@@ -50,6 +50,7 @@ jest.mock('/libs/RootNavigation', () => ({
 jest.mock('./useSplashScreen', () => ({
   useSplashScreen: () => ({ hideSplashScreen: mockHideSplashScreen })
 }))
+jest.mock('/app/theme/SplashScreenService', () => ({}))
 
 jest.mock('/libs/functions/openApp', () => ({
   getDefaultIconParams: jest.fn().mockReturnValue({})

--- a/src/hooks/useGlobalAppState.spec.ts
+++ b/src/hooks/useGlobalAppState.spec.ts
@@ -2,6 +2,10 @@ import { Platform } from 'react-native'
 
 import { _shouldLockApp } from '/app/domain/authorization/services/SecurityService'
 
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
+
 afterAll(jest.resetModules)
 
 it('should always lock the application on iOS devices when running through the autolock check, ignoring timer', () => {

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -104,13 +104,20 @@ export const fetchPublicData = async client => {
 }
 
 /**
+ * @template T
+ * @typedef {object} CozyDataStackOrCache
+ * @property {'stack'|'cache'} source - Source of the retrieved data
+ * @property {T} data - The appliation data
+ */
+
+/**
  * Fetches the data that is used to display a cozy application.
  *
  * @template T - The type of the application data
  * @param {string} slug - The application slug
  * @param {object} client - A CozyClient instance
  * @param {object} [cookie] - An object containing a name and value property
- * @returns {Promise<T>} - The application data
+ * @returns {Promise<CozyDataStackOrCache<T>>} - The application data
  */
 
 export const fetchCozyDataForSlug = async (slug, client, cookie) => {
@@ -138,13 +145,19 @@ export const fetchCozyDataForSlug = async (slug, client, cookie) => {
 
     storeClientCachedData(client, cacheKey, result)
 
-    return result
+    return {
+      source: 'stack',
+      data: result.data
+    }
   } catch (err) {
     if (err.message === 'Network request failed') {
       const cachedResult = await getClientCachedData(client, cacheKey)
 
       if (cachedResult) {
-        return cachedResult
+        return {
+          source: 'cache',
+          data: cachedResult.data
+        }
       }
     }
 

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -35,6 +35,7 @@ import {
 } from '/libs/localStore/clientCachedStorage'
 import { CozyPersistedStorageKeys, getData } from '/libs/localStore/storage'
 import { getLinks } from '/pouchdb/getLinks'
+import schema from '/pouchdb/schema'
 
 const log = Minilog('LoginScreen')
 
@@ -58,7 +59,8 @@ export const getClient = async () => {
       slug: 'flagship',
       version: packageJSON.version
     },
-    links
+    links,
+    schema
   })
   listenTokenRefresh(client)
   client.getStackClient().setOAuthOptions(oauthOptions)

--- a/src/libs/client.spec.js
+++ b/src/libs/client.spec.js
@@ -63,7 +63,8 @@ describe('client', () => {
           slug: 'flagship',
           version: packageJSON.version
         },
-        links: expect.anything()
+        links: expect.anything(),
+        schema: expect.anything()
       })
     })
 

--- a/src/libs/clientHelpers/createClient.ts
+++ b/src/libs/clientHelpers/createClient.ts
@@ -14,6 +14,7 @@ import packageJSON from '../../../package.json'
 
 import { startListening } from '/app/domain/authentication/services/AuthService'
 import { getLinks } from '/pouchdb/getLinks'
+import schema from '/pouchdb/schema'
 
 /**
  * Create a CozyClient for the given Cozy instance and register it
@@ -41,7 +42,8 @@ export const createClient = async (instance: string): Promise<CozyClient> => {
       slug: 'flagship',
       version: packageJSON.version
     },
-    links
+    links,
+    schema
   }
 
   const client = new CozyClient(options)

--- a/src/libs/httpserver/httpServerProvider.tsx
+++ b/src/libs/httpserver/httpServerProvider.tsx
@@ -139,6 +139,15 @@ export const HttpServerProvider = (
         client
       )
 
+      if (source === 'cache') {
+        if (slug !== 'home' && slug !== 'mespapiers') {
+          return {
+            html: false,
+            source: 'offline'
+          }
+        }
+      }
+
       await setCookie(cookie, client)
       const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug)
 

--- a/src/libs/httpserver/httpServerProvider.tsx
+++ b/src/libs/httpserver/httpServerProvider.tsx
@@ -149,7 +149,7 @@ export const HttpServerProvider = (
       }
 
       await setCookie(cookie, client)
-      const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug)
+      const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug, source)
 
       if (!rawHtml) {
         return {

--- a/src/libs/httpserver/httpServerProvider.tsx
+++ b/src/libs/httpserver/httpServerProvider.tsx
@@ -16,6 +16,7 @@ import { fetchAppDataForSlug } from '/libs/httpserver/indexDataFetcher'
 import { getServerBaseFolder } from '/libs/httpserver/httpPaths'
 import { queryResultToCrypto } from '/components/webviews/CryptoWebView/cryptoObservable/cryptoObservable'
 import { setCookie } from '/libs/httpserver/httpCookieManager'
+import { HtmlSource } from '/libs/httpserver/models'
 
 import {
   addBodyClasses,
@@ -36,8 +37,8 @@ const DEFAULT_PORT = Config.HTTP_SERVER_DEFAULT_PORT
   : 5759
 
 interface IndexHtmlForSlug {
-  source: 'stack' | 'cache'
-  html: string
+  source: HtmlSource
+  html: string | false
 }
 
 interface HttpServerState {
@@ -123,7 +124,7 @@ export const HttpServerProvider = (
   const getIndexHtmlForSlug = async (
     slug: string,
     client: CozyClient
-  ): Promise<IndexHtmlForSlug | false> => {
+  ): Promise<IndexHtmlForSlug> => {
     try {
       if (!serverInstance) {
         throw new Error('ServerInstance is null, should not happen')
@@ -142,7 +143,10 @@ export const HttpServerProvider = (
       const rawHtml = await getIndexForFqdnAndSlug(fqdn, slug)
 
       if (!rawHtml) {
-        return false
+        return {
+          html: false,
+          source: 'none'
+        }
       }
 
       const computedHtml = await fillIndexWithData({
@@ -185,7 +189,10 @@ export const HttpServerProvider = (
         `Error while generating Index.html for ${slug}. Cozy-stack version will be used instead. Error was: ${errorMessage}`
       )
 
-      return false
+      return {
+        html: false,
+        source: 'offline'
+      }
     }
   }
 

--- a/src/libs/httpserver/indexDataFetcher.spec.ts
+++ b/src/libs/httpserver/indexDataFetcher.spec.ts
@@ -12,7 +12,7 @@ jest.mock('@react-native-cookies/cookies', () => ({
 }))
 
 const mockedFetchCozyDataForSlug = fetchCozyDataForSlug as jest.MockedFunction<
-  typeof fetchCozyDataForSlug
+  typeof fetchCozyDataForSlug<StackResultData>
 >
 
 describe('indexDataFetcher', () => {
@@ -37,7 +37,23 @@ describe('indexDataFetcher', () => {
   })
 })
 
-const mockStackResult = {
+interface StackResultData {
+  type: string
+  id: string
+  attributes: Record<string, string>
+  meta: unknown
+  links: {
+    self: string
+  }
+}
+
+interface StackResult {
+  source: 'stack'
+  data: StackResultData
+}
+
+const mockStackResult: StackResult = {
+  source: 'stack',
   data: {
     type: 'io.cozy.apps.open',
     id: 'home',
@@ -72,6 +88,7 @@ const mockStackResult = {
 
 const expectedResult = {
   cookie: 'SOME_COOKIE',
+  source: 'stack',
   templateValues: {
     AppEditor: 'Cozy',
     AppName: 'Home',

--- a/src/libs/httpserver/indexDataFetcher.ts
+++ b/src/libs/httpserver/indexDataFetcher.ts
@@ -11,6 +11,7 @@ export type TemplateValues = Omit<AppAttributes, 'Cookie'> & {
 }
 
 interface FetchAppDataForSlugResult {
+  source: 'stack' | 'cache'
   cookie: AppAttributes['Cookie']
   templateValues: TemplateValues
 }
@@ -23,7 +24,7 @@ export const fetchAppDataForSlug = async (
 ): Promise<FetchAppDataForSlugResult> => {
   try {
     const storedCookie = await getCookie(client)
-    const cozyDataResult = await fetchCozyDataForSlug<{ data: AppData }>(
+    const cozyDataResult = await fetchCozyDataForSlug<AppData>(
       slug,
       client,
       storedCookie
@@ -57,6 +58,7 @@ export const fetchAppDataForSlug = async (
 
     return {
       cookie,
+      source: cozyDataResult.source,
       templateValues: {
         ...cozyDataAttributes,
         // The following attributes have to be sanitized to avoid semantic quotes.

--- a/src/libs/httpserver/indexGenerator.ts
+++ b/src/libs/httpserver/indexGenerator.ts
@@ -13,6 +13,7 @@ import {
   prepareAssets
 } from '/libs/httpserver/copyAllFilesFromBundleAssets'
 import { TemplateValues } from '/libs/httpserver/indexDataFetcher'
+import { HtmlSource } from '/libs/httpserver/models'
 import {
   getCurrentAppConfigurationForFqdnAndSlug,
   setCurrentAppVersionForFqdnAndSlug
@@ -87,11 +88,17 @@ const isSlugInBlocklist = (currentSlug: string): boolean =>
 
 export const getIndexForFqdnAndSlug = async (
   fqdn: string,
-  slug: string
+  slug: string,
+  source: HtmlSource
 ): Promise<string | false> => {
   if (shouldDisableGetIndex()) return false // Make cozy-app hosted by webpack-dev-server work with HTTPServer
 
-  if (!isSlugInAllowlist(slug) || isSlugInBlocklist(slug)) return false
+  if (
+    (!isSlugInAllowlist(slug) || isSlugInBlocklist(slug)) &&
+    source !== 'cache'
+  ) {
+    return false
+  }
 
   await initLocalBundleIfNotExist(fqdn, slug)
 

--- a/src/libs/httpserver/models.ts
+++ b/src/libs/httpserver/models.ts
@@ -45,3 +45,5 @@ export interface CozyData {
   token?: string
   tracking?: string
 }
+
+export type HtmlSource = 'stack' | 'cache' | 'offline' | 'none'

--- a/src/libs/intents/flagshipLink.ts
+++ b/src/libs/intents/flagshipLink.ts
@@ -1,0 +1,31 @@
+import CozyClient, { QueryDefinition } from 'cozy-client'
+import type { QueryResult } from 'cozy-client/types/types'
+import Minilog from 'cozy-minilog'
+
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+const log = Minilog('⛳🔗 flagshipLink')
+
+export const flagshipLinkRequest = async (
+  operation: QueryDefinition,
+  client: CozyClient | undefined
+): Promise<QueryResult> => {
+  try {
+    if (!client) {
+      throw new Error(
+        'FlagshipLinkRequest should not be called with undefined client'
+      )
+    }
+
+    const result = await client.query(operation)
+
+    return result
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error(
+      `Something when wrong while processing FlagshipLinkRequest: ${errorMessage}`,
+      operation
+    )
+    throw error
+  }
+}

--- a/src/libs/intents/localMethods.spec.ts
+++ b/src/libs/intents/localMethods.spec.ts
@@ -17,6 +17,9 @@ jest.mock('../RootNavigation')
 jest.mock('@react-native-cookies/cookies', () => ({
   clearAll: jest.fn()
 }))
+jest.mock('react-native-file-viewer', () => ({
+  open: jest.fn()
+}))
 
 describe('asyncLogout', () => {
   const client = {

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -1,7 +1,7 @@
 import { Linking } from 'react-native'
 import { getDeviceName } from 'react-native-device-info'
 
-import CozyClient from 'cozy-client'
+import CozyClient, { QueryDefinition } from 'cozy-client'
 import {
   FlagshipUI,
   NativeMethodsRegisterWithOptions,
@@ -36,6 +36,7 @@ import { openApp } from '/libs/functions/openApp'
 import { routes } from '/constants/routes'
 import { sendKonnectorsLogs } from '/libs/konnectors/sendKonnectorsLogs'
 import { setDefaultRedirection } from '/libs/defaultRedirection/defaultRedirection'
+import { flagshipLinkRequest } from '/libs/intents/flagshipLink'
 import { setFlagshipUI } from '/libs/intents/setFlagshipUI'
 import { showInAppBrowser, closeInAppBrowser } from '/libs/intents/InAppBrowser'
 import { isBiometryDenied } from '/app/domain/authentication/services/BiometryService'
@@ -398,6 +399,8 @@ export const localMethods = (
       _options: PostMeMessageOptions,
       colorScheme: string | undefined
     ) => Promise.resolve(setColorScheme(colorScheme)),
+    flagshipLinkRequest: (_options, operation) =>
+      flagshipLinkRequest(operation as QueryDefinition, client),
     ...mergedMethods
   }
 }

--- a/src/libs/intents/localMethods.ts
+++ b/src/libs/intents/localMethods.ts
@@ -2,6 +2,7 @@ import { Linking } from 'react-native'
 import { getDeviceName } from 'react-native-device-info'
 
 import CozyClient, { QueryDefinition } from 'cozy-client'
+import type { FileDocument } from 'cozy-client/types/types'
 import {
   FlagshipUI,
   NativeMethodsRegisterWithOptions,
@@ -60,6 +61,7 @@ import {
   sendGeolocationTrackingLogs,
   forceUploadGeolocationTrackingData
 } from '/app/domain/geolocation/services/tracking'
+import { downloadFileAndPreview } from '/app/domain/io.cozy.files/offlineFiles'
 import {
   checkPermissions,
   requestPermissions
@@ -401,6 +403,8 @@ export const localMethods = (
     ) => Promise.resolve(setColorScheme(colorScheme)),
     flagshipLinkRequest: (_options, operation) =>
       flagshipLinkRequest(operation as QueryDefinition, client),
+    downloadFile: (_options, file) =>
+      downloadFileAndPreview(file as FileDocument, client),
     ...mergedMethods
   }
 }

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -4,6 +4,7 @@ import { BiometryType } from 'react-native-biometrics'
 
 import { logger } from '/libs/functions/logger'
 import type { FirstTimeserie } from '/app/domain/geolocation/helpers/quota'
+import { SerializedOfflineFilesConfiguration } from '/app/domain/io.cozy.files/offlineFilesConfiguration'
 import type { OnboardingPartner } from '/screens/welcome/install-referrer/onboardingPartner'
 import { OauthData } from '/libs/clientHelpers/persistClient'
 
@@ -36,7 +37,8 @@ export enum CozyPersistedStorageKeys {
   ServiceWebhookURL = 'CozyGPSMemory.ServiceWebhookURL',
   Oauth = '@cozy_AmiralAppOAuthConfig',
   Cookie = '@cozy_AmiralAppCookieConfig',
-  SessionCreated = '@cozy_AmiralAppSessionCreated'
+  SessionCreated = '@cozy_AmiralAppSessionCreated',
+  OfflineFiles = '@cozy_AmiralAppOfflineFiles'
 }
 
 /*
@@ -62,6 +64,7 @@ export interface StorageItems {
   cookie: Cookies
   clouderyEnv: string
   logsEnabled: number
+  offlineFiles: SerializedOfflineFilesConfiguration
 }
 
 export const storeData = async (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,6 +13,8 @@
     "badUnlockPassword": "The credentials you entered are incorrect, please try again.",
     "badUnlockPin": "The PIN you entered is incorrect, please try again",
     "contactUs": "A problem, a suggestion? Contact us at",
+    "offline_unsupported_title": "Unable to load",
+    "offline_unsupported_message": "This application is not available offline",
     "unknown_error": "An unexpected error occurred, please try again.",
     "reset": "Return to home",
     "showDetails": "Show error details",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -13,6 +13,8 @@
     "badUnlockPassword": "Les identifiants que vous avez saisis sont incorrects, veuillez ré-essayer.",
     "badUnlockPin": "Le code PIN que vous avez saisi est incorrect, veuillez ré-essayer",
     "contactUs": "Un problème, une suggestion ? Contactez-nous à",
+    "offline_unsupported_title": "Chargement impossible",
+    "offline_unsupported_message": "Cette application n'est pas disponible hors connexion",
     "unknown_error": "Une erreur inattendue s'est produite, veuillez ré-essayer.",
     "reset": "Revenir à l'accueil",
     "showDetails": "Voir les détails de l'erreur",

--- a/src/pouchdb/deeplinkHandler.ts
+++ b/src/pouchdb/deeplinkHandler.ts
@@ -1,0 +1,23 @@
+import CozyClient from 'cozy-client'
+
+import strings from '/constants/strings.json'
+import { sendDbByEmail } from '/pouchdb/sendDbByEmail'
+
+export const handleDbDeepLink = (url: string, client?: CozyClient): boolean => {
+  if (isSendDbDeepLink(url)) {
+    void sendDbByEmail(client)
+
+    return true
+  }
+
+  return false
+}
+
+const isSendDbDeepLink = (url: string): boolean => {
+  const deepLinks = [
+    `${strings.COZY_SCHEME}senddb`,
+    `${strings.UNIVERSAL_LINK_BASE}/senddb`
+  ]
+
+  return deepLinks.includes(url.toLowerCase())
+}

--- a/src/pouchdb/getLinks.ts
+++ b/src/pouchdb/getLinks.ts
@@ -30,7 +30,17 @@ export const getLinks = (): CozyLink[] => {
     doctypes: offlineDoctypes,
     initialSync: true,
     platform: platformReactNative,
-    ignoreWarmup: true
+    ignoreWarmup: true,
+    doctypesReplicationOptions: Object.fromEntries(
+      offlineDoctypes.map(doctype => {
+        return [
+          doctype,
+          {
+            strategy: 'fromRemote'
+          }
+        ]
+      })
+    )
   }
 
   const stackLink = new StackLink({

--- a/src/pouchdb/getLinks.ts
+++ b/src/pouchdb/getLinks.ts
@@ -29,7 +29,8 @@ export const getLinks = (): CozyLink[] => {
   const pouchLinkOptions = {
     doctypes: offlineDoctypes,
     initialSync: true,
-    platform: platformReactNative
+    platform: platformReactNative,
+    ignoreWarmup: true
   }
 
   const stackLink = new StackLink({

--- a/src/pouchdb/schema.js
+++ b/src/pouchdb/schema.js
@@ -1,0 +1,56 @@
+import { QueryDefinition, HasMany } from 'cozy-client'
+
+const CONTACTS_DOCTYPE = 'io.cozy.contacts'
+const FILES_DOCTYPE = 'io.cozy.files'
+const BILLS_DOCTYPE = 'io.cozy.bills'
+
+class HasManyBills extends HasMany {
+  get data() {
+    const refs = this.target.relationships.referenced_by.data
+    return refs
+      ? refs
+          .map(ref => {
+            if (ref.type === BILLS_DOCTYPE) {
+              return this.get(ref.type, ref.id)
+            }
+          })
+          .filter(Boolean)
+      : []
+  }
+
+  static query(doc, client, assoc) {
+    if (
+      !doc.relationships ||
+      !doc.relationships.referenced_by ||
+      !doc.relationships.referenced_by.data
+    ) {
+      return null
+    }
+
+    const included = doc.relationships.referenced_by.data
+    const ids = included
+      .filter(inc => inc.type === assoc.doctype)
+      .map(inc => inc.id)
+
+    return new QueryDefinition({ doctype: assoc.doctype, ids })
+  }
+}
+
+// the documents schema, necessary for CozyClient
+export default {
+  contacts: {
+    doctype: CONTACTS_DOCTYPE,
+    attributes: {},
+    relationships: {}
+  },
+  files: {
+    doctype: FILES_DOCTYPE,
+    attributes: {},
+    relationships: {
+      bills: {
+        type: HasManyBills,
+        doctype: BILLS_DOCTYPE
+      }
+    }
+  }
+}

--- a/src/pouchdb/sendDbByEmail.ts
+++ b/src/pouchdb/sendDbByEmail.ts
@@ -1,0 +1,146 @@
+import { Alert, PermissionsAndroid, Platform } from 'react-native'
+import Mailer from 'react-native-mail'
+import RNFS from 'react-native-fs'
+import RNFetchBlob from 'rn-fetch-blob'
+import DeviceInfo from 'react-native-device-info'
+
+import type CozyClient from 'cozy-client'
+import Minilog from 'cozy-minilog'
+
+import { fetchSupportMail } from '/app/domain/logger/supportEmail'
+import {
+  hideSplashScreen,
+  showSplashScreen,
+  splashScreens
+} from '/app/theme/SplashScreenService'
+import { getInstanceAndFqdnFromClient } from '/libs/client'
+import { getErrorMessage } from '/libs/functions/getErrorMessage'
+
+const log = Minilog('🗒️ DB Mailer')
+
+export const sendDbByEmail = async (client?: CozyClient): Promise<void> => {
+  log.info('Send DB by email')
+
+  if (!client) {
+    log.info('SendDbByEmail called with no client, return')
+    return
+  }
+
+  try {
+    const permission = PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
+    await PermissionsAndroid.request(permission)
+
+    const supportEmail = await fetchSupportMail(client)
+
+    const { fqdn } = getInstanceAndFqdnFromClient(client)
+
+    const instance = client.getStackClient().uri ?? 'not logged app'
+
+    const subject = `DB files for ${instance}`
+
+    const files = await RNFS.readDir(RNFS.DocumentDirectoryPath)
+
+    const dbFiles = files.filter(f => f.name.startsWith(`${fqdn}_`))
+
+    const externalFiles = []
+    for (const dbFile of dbFiles) {
+      const dirs = RNFetchBlob.fs.dirs
+
+      const internalPath = dbFile.path
+
+      if (Platform.OS === 'android') {
+        const date = Number(new Date())
+        const externalPath = `${dirs.DCIMDir}/DbFile_${dbFile.name}${date}.sqlite`
+
+        await RNFS.copyFile(internalPath, externalPath)
+
+        externalFiles.push({
+          path: externalPath
+        })
+      } else {
+        externalFiles.push({
+          path: dbFile.path,
+          type: 'pdf' // there is no compatible MIME type, so we use PDF one as replacement, this should change nothing expect the email aspect
+        })
+      }
+    }
+
+    await showSplashScreen(splashScreens.SEND_LOG_EMAIL)
+    log.info('Start email intent', externalFiles)
+    await sendMailPromise(subject, supportEmail, externalFiles).catch(
+      (errorData: sendMailError) => {
+        const { error, event } = errorData
+        Alert.alert(
+          error,
+          event,
+          [
+            {
+              text: 'Ok',
+              onPress: (): void => log.debug('OK: Email Error Response')
+            },
+            {
+              text: 'Cancel',
+              onPress: (): void => log.debug('CANCEL: Email Error Response')
+            }
+          ],
+          { cancelable: true }
+        )
+      }
+    )
+    log.info('Did finish email intent')
+    await hideSplashScreen(splashScreens.SEND_LOG_EMAIL)
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    log.error('Error while trying to send DB email', errorMessage)
+  }
+}
+
+const sendMailPromise = (
+  subject: string,
+  email: string,
+  attachments: Attachment[]
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    Mailer.mail(
+      {
+        subject: subject,
+        recipients: ['yannick.chiron@gmail.com'],//email],
+        body: buildMessageBody(),
+        isHTML: true,
+        attachments: attachments
+      },
+      (error, event) => {
+        if (error) {
+          reject({ error, event })
+        } else {
+          resolve()
+        }
+      }
+    )
+  })
+}
+
+const buildMessageBody = (): string => {
+  const appVersion = DeviceInfo.getVersion()
+  const appBuild = DeviceInfo.getBuildNumber()
+  const bundle = DeviceInfo.getBundleId()
+  const deviceBrand = DeviceInfo.getBrand()
+  const deviceModel = DeviceInfo.getModel()
+  const os = DeviceInfo.getSystemName()
+  const version = DeviceInfo.getSystemVersion()
+
+  const appInfo = `App info: ${appVersion} (${appBuild})`
+  const bundleInfo = `App bundle: ${bundle}`
+  const deviceInfo = `Device info: ${deviceBrand} ${deviceModel} ${os} ${version}`
+
+  return `${appInfo}\n${bundleInfo}\n${deviceInfo}`
+}
+
+interface sendMailError {
+  error: string
+  event?: string
+}
+
+interface Attachment {
+  path: string
+}

--- a/src/screens/konnectors/LauncherView.spec.jsx
+++ b/src/screens/konnectors/LauncherView.spec.jsx
@@ -10,6 +10,7 @@ jest.mock('@fengweichong/react-native-gzip', () => {
 })
 
 jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
   withClient: jest.fn().mockReturnValue({})
 }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7167,7 +7167,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-64@^0.1.0:
+base-64@0.1.0, base-64@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
@@ -11041,6 +11041,18 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
+glob@7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
+  integrity sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@7.1.6:
   version "7.1.6"
@@ -17361,6 +17373,11 @@ react-native-localize@2.2.6:
   resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-2.2.6.tgz#484f8c700bc629f230066e819265f80f6dd3ef58"
   integrity sha512-EZETlC1ZlW/4g6xfsNCwAkAw5BDL2A6zk/08JjFR/GRGxYuKRD7iP1hHn1+h6DEu+xROjPpoNeXfMER2vkTVIQ==
 
+react-native-mail@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-mail/-/react-native-mail-6.1.1.tgz#f1b1f8034c84d2510a93e4a2a795f0db5a13595e"
+  integrity sha512-pTs180wwyh7hN/iyTC9SfOX579U4YhDlHOLxi47IGvhPJENqO/QFdBq+wWKxyhNqdQuVSy+LoeIxLreWnIeYmg==
+
 react-native-mask-input@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-mask-input/-/react-native-mask-input-1.2.1.tgz#2f01683844ded3693d0d845bd1beeb2b8367f2e2"
@@ -18152,6 +18169,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rn-fetch-blob@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/rn-fetch-blob/-/rn-fetch-blob-0.12.0.tgz#ec610d2f9b3f1065556b58ab9c106eeb256f3cba"
+  integrity sha512-+QnR7AsJ14zqpVVUbzbtAjq0iI8c9tCg49tIoKO2ezjzRunN7YL6zFSFSWZm6d+mE/l9r+OeDM3jmb2tBb2WbA==
+  dependencies:
+    base-64 "0.1.0"
+    glob "7.0.6"
 
 rn-flipper-async-storage-advanced@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
For now we don't want to replicate local changes into remote PouchDB as we first want to ensure everything works as expected locally before activating two-way replication in the future
