### PR TITLE
feat: Open cozy-app when offline only if it supports Offline mode

### DIFF
--- a/src/app/domain/offline/isOfflineCompatible.ts
+++ b/src/app/domain/offline/isOfflineCompatible.ts
@@ -1,0 +1,48 @@
+import RNFS from 'react-native-fs'
+
+import { getErrorMessage } from 'cozy-intent'
+import Minilog from 'cozy-minilog'
+
+import { getCurrentAppConfigurationForFqdnAndSlug } from '/libs/cozyAppBundle/cozyAppBundleConfiguration'
+import { getBaseFolderForFqdnAndSlugAndCurrentVersion } from '/libs/httpserver/httpPaths'
+
+export const log = Minilog('IsOfflineCompatible')
+
+export const isOfflineCompatible = async (
+  fqdn: string,
+  slug: string
+): Promise<boolean> => {
+  try {
+    const appConfiguration = await getCurrentAppConfigurationForFqdnAndSlug(
+      fqdn,
+      slug
+    )
+
+    if (!appConfiguration) {
+      return false
+    }
+
+    const basePath = await getBaseFolderForFqdnAndSlugAndCurrentVersion(
+      fqdn,
+      slug
+    )
+
+    const manifestPath = basePath + '/manifest.webapp'
+
+    if (!(await RNFS.exists(manifestPath))) {
+      return false
+    }
+
+    const fileContent = await RNFS.readFile(manifestPath)
+
+    const manifest = JSON.parse(fileContent) as Record<string, unknown>
+
+    return manifest.offline_support === true
+  } catch (error) {
+    log.error(
+      `Could not read manifest for app "${slug}": ${getErrorMessage(error)}.`
+    )
+
+    return false
+  }
+}

--- a/src/libs/httpserver/httpServerProvider.tsx
+++ b/src/libs/httpserver/httpServerProvider.tsx
@@ -10,6 +10,7 @@ import Config from 'react-native-config'
 import type CozyClient from 'cozy-client'
 import Minilog from 'cozy-minilog'
 
+import { isOfflineCompatible } from '/app/domain/offline/isOfflineCompatible'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
 import HttpServer from '/libs/httpserver/HttpServer'
 import { fetchAppDataForSlug } from '/libs/httpserver/indexDataFetcher'
@@ -140,12 +141,23 @@ export const HttpServerProvider = (
       )
 
       if (source === 'cache') {
-        if (slug !== 'home' && slug !== 'mespapiers') {
+        log.debug(
+          'App from cache detected, cheking if the app is compatible with offline mode'
+        )
+        const isOffflineCompatitble = await isOfflineCompatible(fqdn, slug)
+
+        if (!isOffflineCompatitble) {
+          log.debug(
+            `App ${slug}' is NOT compatible with offline, abort index generation`
+          )
           return {
             html: false,
             source: 'offline'
           }
         }
+        log.debug(
+          `App ${slug}' is compatible with offline, continue index generation`
+        )
       }
 
       await setCookie(cookie, client)


### PR DESCRIPTION
When offline, we want to open coz-apps only when they declare to be compatible with Offline mode

Cozy-app can declare this by setting `offline_support: true` in their manifest.webapp file

Non compatible cozy-app won't be opened when the Flagship app is offline, and instead an error message will be displayed

