### PR TITLE
feat: Allow the user to choose to save debug traces on error (SCR-872)

### DIFF
--- a/src/constants/strings.json
+++ b/src/constants/strings.json
@@ -17,7 +17,9 @@
   "authLogin": "/auth/login?redirect=",
   "konnectors": {
     "worker": {
-      "backButton": "RETOUR À MON COZY"
+      "backButton": "RETOUR À MON COZY",
+      "sendTraces": "Envoyer les traces"
+              
     }
   },
   "cloudery": {


### PR DESCRIPTION
This feature is still behind the `clisk.automatic.html-on-error` flag
because it still needs some UI work.

When an unexpected error is raised from a clisk konnector, the current
page in the worker is displayed to user and a button to send traces is
proposed which does exactly the same as the `clisk.html-on-error` flag.

```
### ✨ Features

* Offers the possibility to save html traces on clisk konnector error
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

