### PR TITLE
feat: Improve log interception

### DIFF
--- a/src/components/webviews/jsInteractions/jsLogInterception.ts
+++ b/src/components/webviews/jsInteractions/jsLogInterception.ts
@@ -20,6 +20,13 @@ export const jsLogInterception = `
     info: (...log) => consoleLog('info', log),
     warn: (...log) => consoleLog('log', ['warn:', ...log]),
     error: (...log) => consoleLog('error', log),
+    group: (...log) => consoleLog('group', log),
+    groupEnd: (...log) => consoleLog('groupEnd', log),
+    count: () => consoleLog('log', ['console.count is not supported in the flagship app']),
+    countReset: () => consoleLog('log', ['console.countReset is not supported in the flagship app']),
+    table: () => consoleLog('log', ['console.table is not supported in the flagship app']),
+    time: () => consoleLog('log', ['console.time is not supported in the flagship app']),
+    timeEnd: () => consoleLog('log', ['console.timeEnd is not supported in the flagship app']),
   }
 `
 


### PR DESCRIPTION
- Support console.group and console.groupEnd
- Log an message instead of throwing for console.count, console.countReset, console.table, console.time and console.timeEnd which are unsupported by cozy-minilog and/or react-native

group/groupEnd example on React Native metro
![Capture d’écran 2024-10-28 à 17 08 31](https://github.com/user-attachments/assets/5ae883ed-5238-4cf8-bb71-7e9fb1364f28)

group/groupEnd example on the webview
![Capture d’écran 2024-10-28 à 17 08 48](https://github.com/user-attachments/assets/f8c7080f-d939-4839-a958-c9cf6d395cf6)

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Improve log interception
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

