### PR TITLE
fix: Build broken by androidx.annotation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,13 @@ allprojects {
         }
     }
 
-
+    // androidx.annotation:annotation:1.9.1 breaks our build, maybe because of kotlin version
+    // https://developer.android.com/jetpack/androidx/releases/annotation#1.9.1
+    configurations.all {
+        resolutionStrategy {
+            force 'androidx.annotation:annotation:1.9.0'  // Replace with the desired version
+        }
+    }
     // For unknown reasons at this time, the build fails with Javadoc tasks on JDK11
     // A temporary workaround for that is to disable Javadoc generation for all modules
     // tasks.withType(Javadoc).all { enabled = false }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1026,7 +1026,7 @@ SPEC CHECKSUMS:
   boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: 6a459bc897d6d80bd1b8c78482ec7ad05dffc3f0
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: a31ac2336aea59512b5b982f8e231f65d7d148e1
   FBReactNativeSpec: 0976da6bc1ebd3ea9b3a65d04be2c0117d304c4c
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
@@ -1044,7 +1044,7 @@ SPEC CHECKSUMS:
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
   GoogleMLKit: 755661c46990a85e42278015f26400286d98ad95
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34


### PR DESCRIPTION
androidx.annotation:annotation:1.9.1 breaks our build, maybe because of kotlin version

See https://developer.android.com/jetpack/androidx/releases/annotation#1.9.1

Leading to errors like this :

```
Execution failed for task ':app:mergeExtDexDevDebug'.
> Could not resolve all files for configuration
':app:devDebugRuntimeClasspath'.
> Failed to transform annotation-jvm-1.9.1.jar
```

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

