### PR TITLE
feat: Allow clisk konnectors to run server job (SCR-845)

### DIFF
--- a/src/libs/Launcher.js
+++ b/src/libs/Launcher.js
@@ -472,6 +472,32 @@ export default class Launcher {
   }
 
   /**
+   * Save data in the current account's data attribute
+   *
+   * @param {Object} data - any object serializable with JSON.stringify
+   * @returns <Promise<import('cozy-client/types/types').IOCozyAccount>>
+   */
+  async saveAccountData(data) {
+    const { launcherClient: client, account } = this.getStartContext() || {}
+
+    if (!account._id) {
+      throw new Error('Launcher: No associated account. Cannot save account data yet')
+    }
+
+    const { data: currentAccount } = await client.query(
+      Q('io.cozy.accounts').getById(account._id)
+    )
+    currentAccount.data = data
+    const { data: newAccount } = await client.save(currentAccount)
+
+    this.setStartContext({
+      ...this.getStartContext(),
+      account: newAccount
+    })
+    return newAccount
+  }
+
+  /**
    * Calls cozy-konnector-libs' saveFiles function
    *
    * @param {Array<FileDocument>} entries - list of file entries to save

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -157,7 +157,8 @@ class ReactNativeLauncher extends Launcher {
           'saveCookieToKeychain',
           'getCookieByDomainAndName',
           'getCookieFromKeychainByName',
-          'saveAccountData'
+          'saveAccountData',
+          'runServerJob'
         ],
         listenedEventsNames: ['log']
       }),

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -156,7 +156,8 @@ class ReactNativeLauncher extends Launcher {
           'getCookiesByDomain',
           'saveCookieToKeychain',
           'getCookieByDomainAndName',
-          'getCookieFromKeychainByName'
+          'getCookieFromKeychainByName',
+          'saveAccountData'
         ],
         listenedEventsNames: ['log']
       }),

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -151,6 +151,7 @@ class ReactNativeLauncher extends Launcher {
           'saveIdentity',
           'queryAll',
           'setUserAgent',
+          'setIncognito',
           'getCredentials',
           'saveCredentials',
           'getCookiesByDomain',
@@ -581,6 +582,15 @@ class ReactNativeLauncher extends Launcher {
    */
   async setUserAgent(userAgent) {
     this.emit('SET_USER_AGENT', userAgent)
+  }
+
+  /**
+   * Set incognito mode for worker webview
+   *
+   * @param {Boolean} incognito
+   */
+  async setIncognito(incognito) {
+    this.emit('SET_INCOGNITO', incognito)
   }
 
   /**

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -57,6 +57,7 @@ export class LauncherView extends Component {
     this.workerWebview = null
     this.state = {
       userAgent: undefined,
+      incognito: false,
       konnector: null,
       workerInnerUrl: null,
       worker: {},
@@ -220,6 +221,9 @@ export class LauncherView extends Component {
     this.launcher.on('SET_USER_AGENT', userAgent => {
       this.setState({ userAgent })
     })
+    this.launcher.on('SET_INCOGNITO', incognito => {
+      this.setState({ incognito })
+    })
     this.launcher.on('CREATED_ACCOUNT', this.onCreatedAccount)
     this.launcher.on('CREATED_JOB', this.onCreatedJob)
     this.launcher.on('STOPPED_JOB', this.onStoppedJob)
@@ -304,6 +308,7 @@ export class LauncherView extends Component {
                 javaScriptEnabled={true}
                 onContentProcessDidTerminate={this.onWorkerWebviewKilled}
                 onRenderProcessGone={this.onWorkerWebviewKilled}
+                incognito={this.state.incognito}
                 userAgent={this.state.userAgent}
                 source={{
                   uri: this.state.worker.url


### PR DESCRIPTION
Clisk konnectors can now run themselves as server jobs. The result of    the execution is given back to the clisk konnector.
    
This is just a first step. Later, it will be possible to let hybrid
konnector be run only in server mode when the context is relevant.

```
### ✨ Features

* Allow clisk konnectors to save data in their own account
* Allow clisk konnectors to run server job
* Allow clisk konnectors to have incognito mode
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Test coverage
* [ ] README and documentation



