### PR TITLE
feat: Allow clisk konnectors to have more context

### DIFF
--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -292,7 +292,12 @@ class ReactNativeLauncher extends Launcher {
   }
 
   async _start({ initKonnectorError } = {}) {
-    const { account: prevAccount, konnector, client } = this.getStartContext()
+    const {
+      account: prevAccount,
+      konnector,
+      client,
+      trigger: contextTrigger
+    } = this.getStartContext()
     await initialize(client)
     if (flag('clisk.html-on-error')) {
       Minilog.pipe(Minilog.backends.array)
@@ -324,13 +329,19 @@ class ReactNativeLauncher extends Launcher {
 
       try {
         this.setUserData(
-          await this.initAndCheckSourceAccountIdentifier(prevAccount)
+          await this.initAndCheckSourceAccountIdentifier({
+            account: prevAccount,
+            trigger: contextTrigger
+          })
         )
       } catch (err) {
         if (err.message === 'WRONG_ACCOUNT_IDENTIFIER') {
           await this.pilot.call('ensureNotAuthenticated')
           this.setUserData(
-            await this.initAndCheckSourceAccountIdentifier(prevAccount)
+            await this.initAndCheckSourceAccountIdentifier({
+              account: prevAccount,
+              trigger: contextTrigger
+            })
           )
         } else {
           throw err
@@ -397,14 +408,14 @@ class ReactNativeLauncher extends Launcher {
    * @returns {Object}
    * @throws 'WRONG_ACCOUNT_IDENTIFIER'
    */
-  async initAndCheckSourceAccountIdentifier(account) {
+  async initAndCheckSourceAccountIdentifier({ account, trigger }) {
     this.log({
       namespace: 'ReactNativeLauncher',
       label: 'initAndCheckSourceAccountIdentifier',
       level: 'debug',
       msg: 'start'
     })
-    await this.pilot.call('ensureAuthenticated', { account })
+    await this.pilot.call('ensureAuthenticated', { account, trigger })
 
     const userDataResult = await this.pilot.call('getUserDataFromWebsite')
 

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -285,7 +285,7 @@ describe('ReactNativeLauncher', () => {
       expect(launcher.pilot.call).toHaveBeenNthCalledWith(
         2,
         'ensureAuthenticated',
-        { account: fixtures.account }
+        { account: fixtures.account, trigger: fixtures.trigger }
       )
       expect(launcher.pilot.call).toHaveBeenNthCalledWith(
         3,
@@ -522,7 +522,7 @@ describe('ReactNativeLauncher', () => {
       expect(launcher.pilot.call).toHaveBeenNthCalledWith(
         4,
         'ensureAuthenticated',
-        { account: fixtures.account }
+        { account: fixtures.account, trigger: fixtures.trigger }
       )
     })
     it('should not fail when clisk version is less than 0.10.0', async () => {
@@ -560,7 +560,7 @@ describe('ReactNativeLauncher', () => {
       expect(launcher.pilot.call).toHaveBeenNthCalledWith(
         3,
         'ensureAuthenticated',
-        { account: fixtures.account }
+        { account: fixtures.account, trigger: fixtures.trigger }
       )
     })
     it('should raise WRONG_ACCOUNT_IDENTIFIER when the user authenticates with the wrong identifiers twice', async () => {


### PR DESCRIPTION
In ensureAuthenticated method, clisk konnectors now also get current
trigger when available.

```
### ✨ Features

* clisk: ensureAuthenticated get trigger when available
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [X] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

