### PR TITLE
feat: Migrate storage from AsyncStorage to MMKV

### DIFF
--- a/android/app/src/main/java/io/cozy/flagship/mobile/MainApplication.java
+++ b/android/app/src/main/java/io/cozy/flagship/mobile/MainApplication.java
@@ -80,15 +80,5 @@ public class MainApplication extends Application implements ReactApplication {
 
     WebView.setWebContentsDebuggingEnabled(true);
     OkHttpClientProvider.setOkHttpClientFactory(new UserAgentClientFactory());
-
-    try {
-      Field field = CursorWindow.class.getDeclaredField("sCursorWindowSize");
-      field.setAccessible(true);
-      field.set(null, 50 * 1024 * 1024); // 50MB
-    } catch (Exception e) {
-      if (BuildConfig.DEBUG) {
-        e.printStackTrace();
-      }
-    }
   }
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -179,6 +179,9 @@ PODS:
     - MLImage (= 1.0.0-beta2)
     - MLKitCommon (~> 5.0)
     - Protobuf (~> 3.12)
+  - MMKV (2.0.0):
+    - MMKVCore (~> 2.0.0)
+  - MMKVCore (2.0.0)
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
     - nanopb/encode (= 2.30908.0)
@@ -1091,6 +1094,11 @@ PODS:
   - react-native-mlkit-ocr (0.3.0):
     - GoogleMLKit/TextRecognition (= 2.6.0)
     - React
+  - react-native-mmkv (2.12.2):
+    - glog
+    - MMKV (>= 1.3.3)
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core
   - react-native-netinfo (9.5.0):
     - React-Core
   - react-native-performance (5.1.2):
@@ -1426,6 +1434,7 @@ DEPENDENCIES:
   - react-native-idle-timer (from `../node_modules/react-native-idle-timer`)
   - react-native-mail (from `../node_modules/react-native-mail`)
   - react-native-mlkit-ocr (from `../node_modules/react-native-mlkit-ocr`)
+  - react-native-mmkv (from `../node_modules/react-native-mmkv`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-performance (from `../node_modules/react-native-performance`)
   - react-native-print (from `../node_modules/react-native-print`)
@@ -1513,6 +1522,8 @@ SPEC REPOS:
     - MLKitTextRecognition
     - MLKitTextRecognitionCommon
     - MLKitVision
+    - MMKV
+    - MMKVCore
     - nanopb
     - NVHTarGzip
     - OpenSSL-Universal
@@ -1605,6 +1616,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-mail"
   react-native-mlkit-ocr:
     :path: "../node_modules/react-native-mlkit-ocr"
+  react-native-mmkv:
+    :path: "../node_modules/react-native-mmkv"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-performance:
@@ -1752,6 +1765,8 @@ SPEC CHECKSUMS:
   MLKitTextRecognition: 8b0e0023a4babc66ca83d8b82864e57931164445
   MLKitTextRecognitionCommon: 3e84602c928fe2b775fae81376f2136324cbd763
   MLKitVision: e87dc3f2e456a6ab32361ebd985e078dd2746143
+  MMKV: f7d1d5945c8765f97f39c3d121f353d46735d801
+  MMKVCore: c04b296010fcb1d1638f2c69405096aac12f6390
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   NVHTarGzip: 74cc227b902e5725900d37eb6d79b57e93005a73
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
@@ -1792,6 +1807,7 @@ SPEC CHECKSUMS:
   react-native-idle-timer: f1920a59fe776340d004ff9de13c4a6eedcc8807
   react-native-mail: 8fdcd3aef007c33a6877a18eb4cf7447a1d4ce4a
   react-native-mlkit-ocr: 72cdbde86f8d29cba26cf9fa0a1865fe45c8f8d6
+  react-native-mmkv: 1fdc81aa70c1aba09370718e6a63a09cbbbac8d2
   react-native-netinfo: 48c5f79a84fbc3ba1d28a8b0d04adeda72885fa8
   react-native-performance: ff93f8af3b2ee9519fd7879896aa9b8b8272691d
   react-native-print: f704aef52d931bfce6d1d84351dbb5232d7ecb89

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "react-native-mail": "^6.1.1",
     "react-native-mask-input": "1.2.1",
     "react-native-mlkit-ocr": "^0.3.0",
+    "react-native-mmkv": "2.12.2",
+    "react-native-mmkv-flipper-plugin": "^1.0.0",
     "react-native-performance": "^5.1.2",
     "react-native-performance-flipper-reporter": "^5.0.0",
     "react-native-permissions": "^3.9.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,13 @@
 import { NavigationContainer } from '@react-navigation/native'
 import { decode, encode } from 'base-64'
 import React, { useEffect, useState } from 'react'
-import { StatusBar, StyleSheet, View } from 'react-native'
-
+import {
+  StatusBar,
+  StyleSheet,
+  View,
+  ActivityIndicator,
+  InteractionManager
+} from 'react-native'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
@@ -71,9 +76,17 @@ import { ClouderyOffer } from '/app/view/IAP/ClouderyOffer'
 import { useDimensions } from '/libs/dimensions'
 import { configureFileLogger } from '/app/domain/logger/fileLogger'
 import { useColorScheme } from '/app/theme/colorScheme'
+import {
+  hasMigratedFromAsyncStorage,
+  migrateFromAsyncStorage,
+  storage
+} from '/libs/localStore/storage'
 
 if (__DEV__) {
   require('react-native-performance-flipper-reporter').setupDefaultFlipperReporter()
+  require('react-native-mmkv-flipper-plugin').initializeMMKVFlipper({
+    default: storage
+  })
 }
 
 configurePerformances()
@@ -316,6 +329,30 @@ const Wrapper = () => {
     initFlagshipUIService()
     setTimeoutForSplashScreen()
   }, [markNameWrapper])
+
+  const [hasMigrated, setHasMigrated] = useState(hasMigratedFromAsyncStorage)
+
+  useEffect(() => {
+    if (!hasMigratedFromAsyncStorage) {
+      InteractionManager.runAfterInteractions(async () => {
+        try {
+          await migrateFromAsyncStorage()
+          setHasMigrated(true)
+        } catch (e) {
+          // TODO: fall back to AsyncStorage? Wipe storage clean and use MMKV? Crash app?
+        }
+      })
+    }
+  }, [])
+
+  if (!hasMigrated) {
+    // show loading indicator while app is migrating storage...
+    return (
+      <View style={{ justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator color="black" />
+      </View>
+    )
+  }
 
   return (
     <>

--- a/src/app/domain/logger/fileLogger.spec.ts
+++ b/src/app/domain/logger/fileLogger.spec.ts
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { FileLogger } from 'react-native-file-logger'
 import { Alert } from 'react-native'
 
@@ -15,7 +14,8 @@ import * as SplashScreenService from '/app/theme/SplashScreenService'
 import {
   DevicePersistedStorageKeys,
   getData,
-  storeData
+  storeData,
+  storage
 } from '/libs/localStore'
 
 jest.mock('react-native-file-logger')
@@ -149,7 +149,7 @@ describe('fileLogger', () => {
     })
 
     it('should configure FileLogger with ConsoleCapture disabled if logs are not configured in AsyncStorage', async () => {
-      await AsyncStorage.clear()
+      storage.clearAll()
 
       await configureFileLogger()
 

--- a/src/libs/localStore/clientCachedStorage.spec.ts
+++ b/src/libs/localStore/clientCachedStorage.spec.ts
@@ -1,5 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
-
 import CozyClient from 'cozy-client'
 
 import {
@@ -7,14 +5,13 @@ import {
   getClientCachedData,
   storeClientCachedData
 } from '/libs/localStore/clientCachedStorage'
+import { storage } from '/libs/localStore/storage'
 import { AppData } from '/libs/httpserver/models'
 import {
   clearAllData,
   CozyPersistedStorageKeys,
   storeData
 } from '/libs/localStore/storage'
-
-const { getAllKeys } = AsyncStorage
 
 describe('clientCachedStorage', () => {
   beforeEach(async () => {
@@ -26,7 +23,7 @@ describe('clientCachedStorage', () => {
       const request = 'SomeRequestName'
 
       await storeClientCachedData(aliceClient, request, getFakeAppData())
-      const keys = await getAllKeys()
+      const keys = storage.getAllKeys()
 
       expect(keys).toStrictEqual([
         '@ccCache_alice.mycozy.cloud_SomeRequestName'
@@ -42,7 +39,7 @@ describe('clientCachedStorage', () => {
       }
 
       await storeClientCachedData(aliceClient, request, getFakeAppData())
-      const keys = await getAllKeys()
+      const keys = storage.getAllKeys()
 
       expect(keys).toStrictEqual([
         '@ccCache_alice.mycozy.cloud_eyJtZXRob2QiOiJHRVQiLCJwYXRoIjoiL3NvbWUvcGF0aCIsImJvZHkiOnt9LCJvcHRpb25zIjp7fX0='
@@ -112,7 +109,7 @@ describe('clientCachedStorage', () => {
       await storeData(CozyPersistedStorageKeys.Activities, 'SomeValue')
       await storeData(CozyPersistedStorageKeys.AutoLockEnabled, 'SomeValue')
 
-      const keys = await getAllKeys()
+      const keys = storage.getAllKeys()
       expect(keys).toStrictEqual([
         '@ccCache_alice.mycozy.cloud_SomeRequestName',
         '@ccCache_alice.mycozy.cloud_eyJtZXRob2QiOiJHRVQiLCJwYXRoIjoiL3NvbWUvcGF0aCIsImJvZHkiOnt9LCJvcHRpb25zIjp7fX0=',
@@ -122,7 +119,7 @@ describe('clientCachedStorage', () => {
 
       await clearClientCachedData(aliceClient)
 
-      const keys2 = await getAllKeys()
+      const keys2 = storage.getAllKeys()
       expect(keys2).toStrictEqual([
         CozyPersistedStorageKeys.Activities,
         CozyPersistedStorageKeys.AutoLockEnabled
@@ -146,7 +143,7 @@ describe('clientCachedStorage', () => {
         'SomeValue'
       )
 
-      const keys = await getAllKeys()
+      const keys = storage.getAllKeys()
       expect(keys).toStrictEqual([
         '@ccCache_alice.mycozy.cloud_SomeRequestName',
         '@ccCache_alice.mycozy.cloud_eyJtZXRob2QiOiJHRVQiLCJwYXRoIjoiL3NvbWUvcGF0aCIsImJvZHkiOnt9LCJvcHRpb25zIjp7fX0=',
@@ -155,7 +152,7 @@ describe('clientCachedStorage', () => {
 
       await clearClientCachedData(aliceClient)
 
-      const keys2 = await getAllKeys()
+      const keys2 = storage.getAllKeys()
       expect(keys2).toStrictEqual(['@ccCache_bob.mycozy.cloud_SomeRequestName'])
     })
   })

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -161,8 +161,7 @@ export const hasMigratedFromAsyncStorage = storage.getBoolean(
 // TODO: Remove `hasMigratedFromAsyncStorage` after a while (when everyone has migrated)
 export async function migrateFromAsyncStorage(): Promise<void> {
   log.info('Migrating from AsyncStorage -> MMKV...')
-  const markName = `migrateFromAsyncStorage`
-  rnperformance.mark(markName)
+  const markName = rnperformance.mark('migrateFromAsyncStorage')
 
   const keys = await AsyncStorage.getAllKeys()
 
@@ -184,6 +183,9 @@ export async function migrateFromAsyncStorage(): Promise<void> {
 
   storage.set('hasMigratedFromAsyncStorage', true)
 
-  rnperformance.measure(markName, markName, 'AsyncStorageMigration')
+  rnperformance.measure({
+    markName: markName,
+    category: 'AsyncStorageMigration'
+  })
   log.info(`Migrated from AsyncStorage -> MMKV!`)
 }

--- a/src/pouchdb/platformReactNative.storage.ts
+++ b/src/pouchdb/platformReactNative.storage.ts
@@ -1,14 +1,14 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
+import { storage as mmkvStorage } from '/libs/localStore'
 
 export const storage = {
   getItem: async (key: string): Promise<string | null> => {
-    return AsyncStorage.getItem(key)
+    return Promise.resolve(mmkvStorage.getString(key) ?? null)
   },
   setItem: async (key: string, value: string | undefined): Promise<void> => {
     if (value === undefined) return
-    return AsyncStorage.setItem(key, value)
+    return Promise.resolve(mmkvStorage.set(key, value))
   },
   removeItem: async (key: string): Promise<void> => {
-    return AsyncStorage.removeItem(key)
+    return Promise.resolve(mmkvStorage.delete(key))
   }
 }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -9,16 +9,29 @@ import {
   persistReducer,
   persistStore
 } from 'redux-persist'
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import logger from 'redux-logger'
 
 import konnectorLogsSlice from '/redux/KonnectorState/KonnectorLogsSlice'
 import currentKonnectorSlice from '/redux/KonnectorState/CurrentKonnectorSlice'
 import { shouldEnableReduxLogger } from '/core/tools/env'
+import { storage as mmkvStorage } from '/libs/localStore'
 
 const persistConfig = {
   key: 'root',
-  storage: AsyncStorage
+  storage: {
+    getItem: (key: string): unknown => {
+      const value = mmkvStorage.getString(key)
+      return Promise.resolve(value)
+    },
+    setItem: (key: string, value: string): unknown => {
+      mmkvStorage.set(key, value)
+      return Promise.resolve(true)
+    },
+    removeItem: (key: string): unknown => {
+      mmkvStorage.delete(key)
+      return Promise.resolve()
+    }
+  }
 }
 
 const rootReducter = combineReducers({

--- a/yarn.lock
+++ b/yarn.lock
@@ -17698,6 +17698,16 @@ react-native-mlkit-ocr@^0.3.0:
   resolved "https://registry.yarnpkg.com/react-native-mlkit-ocr/-/react-native-mlkit-ocr-0.3.0.tgz#b5b65dbe1fffdca0ca2012b1cab56cca6ea1bf58"
   integrity sha512-8oNJwNMGsUup41nWlKA01iW6xiNkCcXM3ANDsOKKijvsrd3eWNs7kL0Yhpt3Cq64zSyjoeqkdTdOCDiI6Pv6KA==
 
+react-native-mmkv-flipper-plugin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-mmkv-flipper-plugin/-/react-native-mmkv-flipper-plugin-1.0.0.tgz#f87f747d8cea51d2b12a1e711287feff5f212788"
+  integrity sha512-e3owMIBzXez45Wz8Ac84Vf1FmfwMXFVUpf/gCDWDLq19w7iCipVezQjlZo8ISVza8aQf1G4ggaK/r+qqtGmRlg==
+
+react-native-mmkv@2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.12.2.tgz#4bba0f5f04e2cf222494cce3a9794ba6a4894dee"
+  integrity sha512-6058Aq0p57chPrUutLGe9fYoiDVDNMU2PKV+lLFUJ3GhoHvUrLdsS1PDSCLr00yqzL4WJQ7TTzH+V8cpyrNcfg==
+
 react-native-modal-datetime-picker@^14.0.0:
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-14.0.1.tgz#d9c6df4ff85bf1cfbe108c756dc26dcca4cc5f2f"


### PR DESCRIPTION
Since we migrated the project to RN73 we can now use MMKV instead of AsyncStorage

This migration is done in order to improve performances. MMKV being faster by multiple order of magnitude than AsyncStorage

This PR replaces #1097

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Migrate storage management from AsyncStorage to MMKV
```