### PR TITLE
feat: Optimize startup timings by delaying heavy tasts

### DIFF
--- a/src/app/domain/authentication/services/AuthService.ts
+++ b/src/app/domain/authentication/services/AuthService.ts
@@ -2,6 +2,7 @@ import { Linking } from 'react-native'
 
 import type CozyClient from 'cozy-client'
 import Minilog from 'cozy-minilog'
+import PouchLink from 'cozy-pouch-link'
 
 import { asyncLogoutNoClient } from '/app/domain/authentication/utils/asyncLogoutNoClient'
 
@@ -28,8 +29,29 @@ export const handleSupportEmail = (): void => {
   }
 }
 
+const handleLogin = (): void => {
+  try {
+    authLogger.info('Debounce replication')
+    if (clientInstance === null) throw new Error('No client instance set')
+
+    const pouchLink = getPouchLink(clientInstance)
+    pouchLink?.startReplicationWithDebounce()
+  } catch (error) {
+    authLogger.error('Error while handling login', error)
+  }
+}
+
 export const startListening = (client: CozyClient): void => {
   authLogger.info('Start listening to cozy-client events')
   clientInstance = client
   clientInstance.on('revoked', handleTokenError)
+  clientInstance.on('login', handleLogin)
+}
+
+const getPouchLink = (client?: CozyClient): PouchLink | null => {
+  if (!client) {
+    return null
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return client.links.find(link => link instanceof PouchLink) || null
 }

--- a/src/app/domain/authentication/services/SynchronizeService.spec.ts
+++ b/src/app/domain/authentication/services/SynchronizeService.spec.ts
@@ -11,6 +11,9 @@ const {
   synchronizeOnInit
 } = SynchronizeService
 
+// @ts-expect-error TS see this as a const but we can edit it on tests runtime
+SynchronizeService.SYNCHRONIZE_DELAY_IN_MS = 0
+
 jest.mock('cozy-client')
 
 describe('SynchronizeService', () => {

--- a/src/app/domain/authentication/services/SynchronizeService.ts
+++ b/src/app/domain/authentication/services/SynchronizeService.ts
@@ -9,6 +9,8 @@ import { saveClient } from '/libs/clientHelpers/persistClient'
 
 export const syncLog = Minilog('📱 SynchronizeService')
 
+export const SYNCHRONIZE_DELAY_IN_MS = 10 * 1000
+
 export const synchronizeDevice = async (client: CozyClient): Promise<void> => {
   try {
     await client.getStackClient().fetchJSON('POST', '/settings/synchronized')
@@ -50,6 +52,12 @@ export const checkClientName = async (client: CozyClient): Promise<void> => {
 }
 
 export const synchronizeOnInit = async (client: CozyClient): Promise<void> => {
-  await checkClientName(client)
-  await synchronizeDevice(client)
+  return new Promise(resolve => {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    setTimeout(async (): Promise<void> => {
+      await checkClientName(client)
+      await synchronizeDevice(client)
+      resolve()
+    }, SYNCHRONIZE_DELAY_IN_MS)
+  })
 }

--- a/src/app/domain/io.cozy.files/importantFiles.ts
+++ b/src/app/domain/io.cozy.files/importantFiles.ts
@@ -15,7 +15,7 @@ import { getErrorMessage } from '/libs/functions/getErrorMessage'
 
 const log = Minilog('📁 Offline Files')
 
-const IMPORTANT_FILES_DOWNLOAD_DELAY_IN_MS = 100
+const IMPORTANT_FILES_DOWNLOAD_DELAY_IN_MS = 30 * 1000
 const NB_OF_MONTH_BEFORE_EXPIRATION = 1
 
 export const makeImportantFilesAvailableOfflineInBackground = (

--- a/src/hooks/useAppBootstrap.js
+++ b/src/hooks/useAppBootstrap.js
@@ -25,6 +25,8 @@ import { useHomeStateContext } from '/screens/home/HomeStateProvider'
 
 const log = Minilog('useAppBootstrap')
 
+const MANAGE_ICON_CACHE_DELAY_IN_MS = 30 * 1000
+
 export const useAppBootstrap = client => {
   const [markName] = useState(() => rnperformance.mark('useAppBootstrap'))
   const [initialRoute, setInitialRoute] = useState('fetching')
@@ -176,7 +178,8 @@ export const useAppBootstrap = client => {
       return
     }
 
-    client && manageIconCache(client)
+    client &&
+      setTimeout(() => manageIconCache(client), MANAGE_ICON_CACHE_DELAY_IN_MS)
     client && setSentryTag(SentryCustomTags.Instance, client.stackClient?.uri)
 
     const subscription = Linking.addEventListener('url', ({ url }) => {

--- a/src/pouchdb/getLinks.ts
+++ b/src/pouchdb/getLinks.ts
@@ -12,6 +12,9 @@ import { default as PouchLink } from 'cozy-pouch-link'
 
 const log = Minilog('🔗 GetLinks')
 
+export const REPLICATION_DEBOUNCE = 30 * 1000 // 30s
+export const REPLICATION_DEBOUNCE_MAX_DELAY = 600 * 1000 // 10min
+
 export const offlineDoctypes = [
   // cozy-home
   'io.cozy.accounts',
@@ -37,8 +40,10 @@ export const offlineDoctypes = [
 export const getLinks = (): CozyLink[] => {
   const pouchLinkOptions = {
     doctypes: offlineDoctypes,
-    initialSync: true,
-    periodicSync: true,
+    initialSync: false,
+    periodicSync: false,
+    syncDebounceDelayInMs: REPLICATION_DEBOUNCE,
+    syncDebounceMaxDelayInMs: REPLICATION_DEBOUNCE_MAX_DELAY,
     platform: platformReactNative,
     ignoreWarmup: true,
     doctypesReplicationOptions: Object.fromEntries(


### PR DESCRIPTION
This PR's goal is to improve startup timings by delaying heavy tasks after the startup is complete.

What have been delayed:
- PouchDB replication
- Important files downloading (for offline access)
- Call to Oauth client's `synchronize()` api
- Downloading of cozy-app icons for opening animations

For now those delay have been hardcoded, but in the future we may want to implement some "orchestrator" mechanism that would be responsible to call those tasks when the application is IDLE

```
### ✨ Features

* Improve startup timings

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```