### PR TITLE
feat: Optimize NetService related performances

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,7 @@ import { useCozyEnvironmentOverride } from '/hooks/useCozyEnvironmentOverride'
 import { useNotifications } from '/hooks/useNotifications'
 import { useSynchronizeOnInit } from '/hooks/useSynchronizeOnInit'
 import { useInitBackup } from '/app/domain/backup/hooks'
-import { useNetService } from '/libs/services/NetService'
+import { configureNetService, useNetService } from '/libs/services/NetService'
 import { withSentry } from '/libs/monitoring/Sentry'
 import { ThemeProvider } from '/app/theme/ThemeProvider'
 import { useInitI18n } from '/locales/useInitI18n'
@@ -90,6 +90,7 @@ if (__DEV__) {
 }
 
 configurePerformances()
+configureNetService()
 configureFileLogger()
 
 const markStartName = rnperformance.mark('AppStart')

--- a/src/libs/services/NetService.ts
+++ b/src/libs/services/NetService.ts
@@ -12,7 +12,7 @@ import { showSplashScreen } from '/app/theme/SplashScreenService'
 export const netLogger = Minilog('🛜 NetService')
 
 // Function to configure NetInfo service with the given client
-const configureService = (client?: CozyClient): void => {
+export const configureNetService = (client?: CozyClient): void => {
   NetInfo.configure({
     reachabilityUrl: client?.isLogged
       ? `${client.getStackClient().uri}/${strings.reachability.stack}`
@@ -24,7 +24,7 @@ const configureService = (client?: CozyClient): void => {
 export const useNetService = (client?: CozyClient): void =>
   useEffect(() => {
     const configure = (): void => {
-      configureService(client)
+      configureNetService(client)
     }
 
     client?.on('logout', configure)

--- a/src/pouchdb/platformReactNative.isOnline.ts
+++ b/src/pouchdb/platformReactNative.isOnline.ts
@@ -1,5 +1,15 @@
+import NetInfo from '@react-native-community/netinfo'
+
 import { NetService } from '/libs/services/NetService'
 
+let currentState: boolean | undefined = undefined
+
 export const isOnline = async (): Promise<boolean> => {
-  return (await NetService.isConnected()) ?? true
+  if (currentState === undefined) {
+    currentState = (await NetService.isConnected()) ?? true
+    NetInfo.addEventListener(state => {
+      currentState = state.isConnected ?? true
+    })
+  }
+  return currentState
 }


### PR DESCRIPTION
This PR add caching for the `isOnline()` method and also change the way NetService is initialized to prevent unwanted calls to google's servers

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```