### PR TITLE
fix: Correctly handle removal of unimportant cached files

### DIFF
--- a/src/app/domain/io.cozy.files/importantFiles.ts
+++ b/src/app/domain/io.cozy.files/importantFiles.ts
@@ -65,8 +65,8 @@ const cleanOldNonImportantFiles = async (
       const lastOpened = offlineFile.lastOpened
       if (
         !importantFilesIds.includes(offlineFile.id) &&
-        (differenceInMonths(lastOpened, now) > NB_OF_MONTH_BEFORE_EXPIRATION ||
-          !lastOpened)
+        (!lastOpened ||
+          differenceInMonths(now, lastOpened) > NB_OF_MONTH_BEFORE_EXPIRATION)
       ) {
         log.debug(
           `Remove old unimportant file ${


### PR DESCRIPTION
Previous implementation was incorrect because `lastOpened` prop was stored as a string in the device's storage and so it was retrieved as string

Then the date-fns `differenceInMonths` was failing comparing dates as it accepts only `Date` objects and no string

This commit fixes this by parsing the persisted date into a `Date` and by fixing related TS typings