### PR TITLE
Support RAW file for iPhone photo backup

### DIFF
--- a/src/app/domain/backup/services/getMedias.ts
+++ b/src/app/domain/backup/services/getMedias.ts
@@ -3,7 +3,6 @@ import {
   PhotoIdentifiersPage,
   PhotoIdentifier
 } from '@react-native-camera-roll/camera-roll'
-import mime from 'mime/lite'
 import { Platform } from 'react-native'
 import RNFS from 'react-native-fs'
 
@@ -24,6 +23,7 @@ import {
 } from '/app/domain/backup/helpers'
 import { getBackupInfo } from '/app/domain/backup/services/manageBackup'
 import { t } from '/locales/i18n'
+import { getMime } from '/utils/mime'
 
 const MEDIAS_BY_PAGE = 500
 
@@ -51,7 +51,7 @@ export const getMimeType = (media: Media): string => {
     return media.mimeType
   }
 
-  const guessedMimeType = mime.getType(media.name)
+  const guessedMimeType = getMime(media.name)
 
   if (guessedMimeType === null) {
     throw new Error(t('services.backup.errors.fileNotSupported'))

--- a/src/app/domain/osReceive/services/OsReceiveCandidateApps.ts
+++ b/src/app/domain/osReceive/services/OsReceiveCandidateApps.ts
@@ -1,4 +1,3 @@
-import mime from 'mime/lite'
 import RNFS from 'react-native-fs'
 
 import {
@@ -9,6 +8,7 @@ import {
 } from '/app/domain/osReceive/models/OsReceiveCozyApp'
 import { OsReceiveFile } from '/app/domain/osReceive/models/OsReceiveState'
 import { t } from '/locales/i18n'
+import { getMime } from '/utils/mime'
 
 export const getAppsForUpload = async (
   filesToUpload: OsReceiveFile[],
@@ -81,7 +81,7 @@ const checkFileMimes =
       acceptedMime.includes('*/*') ||
       filesToUpload.every(file => {
         const guessedMimeType =
-          mime.getType(file.file.mimeType) ?? file.file.mimeType
+          getMime(file.file.mimeType) ?? file.file.mimeType
 
         return app.accept_documents_from_flagship.accepted_mime_types.includes(
           guessedMimeType

--- a/src/utils/mime.spec.ts
+++ b/src/utils/mime.spec.ts
@@ -1,0 +1,9 @@
+import { getMime } from './mime'
+
+describe('getMime', () => {
+  it('should return correct mime', () => {
+    expect(getMime('file.txt')).toEqual('text/plain')
+    expect(getMime('txt')).toEqual('text/plain')
+    expect(getMime('fkjqhdsfnvbqs')).toEqual(null)
+  })
+})

--- a/src/utils/mime.spec.ts
+++ b/src/utils/mime.spec.ts
@@ -5,5 +5,6 @@ describe('getMime', () => {
     expect(getMime('file.txt')).toEqual('text/plain')
     expect(getMime('txt')).toEqual('text/plain')
     expect(getMime('fkjqhdsfnvbqs')).toEqual(null)
+    expect(getMime('picture.dng')).toEqual('image/x-adobe-dng')
   })
 })

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,5 +1,8 @@
 import mime from 'mime/lite'
 
+// For RAW pictures created on modern iPhones
+mime.define({ 'image/x-adobe-dng': ['dng'] })
+
 export const getMime = (path: string): string | null => {
   return mime.getType(path)
 }

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,0 +1,5 @@
+import mime from 'mime/lite'
+
+export const getMime = (path: string): string | null => {
+  return mime.getType(path)
+}


### PR DESCRIPTION
```
### ✨ Features

* Support RAW file for iPhone photo backup

### 🐛 Bug Fixes

* 

### 🔧 Tech

*
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

