### PR TITLE
fix: Improve error message when query fail in  backup

### DIFF
--- a/src/app/domain/backup/services/manageLocalBackupConfig.ts
+++ b/src/app/domain/backup/services/manageLocalBackupConfig.ts
@@ -214,10 +214,14 @@ export const fixLocalBackupConfigIfNecessary = async (
     remoteBackupFolderUpdated = data
   } catch (e) {
     if (e instanceof Error) {
-      const { errors } = JSON.parse(e.message) as StackErrors
+      try {
+        const { errors } = JSON.parse(e.message) as StackErrors
 
-      if (errors.find(e => e.status === '404')) {
-        throw new Error('Remote backup folder has been deleted.')
+        if (errors.find(e => e.status === '404')) {
+          throw new Error('Remote backup folder has been deleted.')
+        }
+      } catch {
+        throw e
       }
     }
 

--- a/src/app/domain/backup/services/manageRemoteBackupConfig.ts
+++ b/src/app/domain/backup/services/manageRemoteBackupConfig.ts
@@ -123,18 +123,22 @@ const createRemoteBackupFolderWithConflictStrategy = async (
     )) as FileCollectionGetResult
   } catch (e) {
     if (e instanceof Error) {
-      const { errors } = JSON.parse(e.message) as StackErrors
+      try {
+        const { errors } = JSON.parse(e.message) as StackErrors
 
-      if (errors.find(e => e.status === '409')) {
-        const { filename } = models.file.splitFilename({
-          type: 'file',
-          name: backupFolderAttributes.name
-        } as IOCozyFile) as SplitFilenameResult
+        if (errors.find(e => e.status === '409')) {
+          const { filename } = models.file.splitFilename({
+            type: 'file',
+            name: backupFolderAttributes.name
+          } as IOCozyFile) as SplitFilenameResult
 
-        return await createRemoteBackupFolderWithConflictStrategy(client, {
-          ...backupFolderAttributes,
-          name: models.file.generateNewFileNameOnConflict(filename)
-        })
+          return await createRemoteBackupFolderWithConflictStrategy(client, {
+            ...backupFolderAttributes,
+            name: models.file.generateNewFileNameOnConflict(filename)
+          })
+        }
+      } catch {
+        throw e
       }
     }
 


### PR DESCRIPTION
Due to the way we manage errors, we sometimes try to JSON.parse string that were not JSON leading to errors like "[SyntaxError: JSON Parse error: Unexpected character: N]" displayed to the user.

Now we use the try/parse pattern to return the most appropriate message to the user.

```
### ✨ Features

*

### 🐛 Bug Fixes

* Improve error message when query fail in  backup

### 🔧 Tech

*
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

