### PR TITLE
chore: Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-android-dev.yml
+++ b/.github/workflows/build-android-dev.yml
@@ -113,7 +113,7 @@ jobs:
           BUILD_TOOLS_VERSION: "33.0.0"
 
       - name: Upload Dev artifact to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Signed Android Package Dev Env ${{ inputs.brand }}
           path: |
@@ -132,7 +132,7 @@ jobs:
           BUILD_TOOLS_VERSION: "33.0.0"
 
       - name: Upload Prod artifact to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Signed Android Package Prod Env ${{ inputs.brand }}
           path: |

--- a/.github/workflows/build-android-prod.yml
+++ b/.github/workflows/build-android-prod.yml
@@ -99,7 +99,7 @@ jobs:
           BUILD_TOOLS_VERSION: "33.0.0"
 
       - name: Upload AAB artifact to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: AAB
           path: android/app/build/outputs/bundle/prodRelease/*.aab
@@ -154,7 +154,7 @@ jobs:
         id: artifact_info
 
       - name: Upload APK artifact to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact_info.outputs.artifact_name }}
           path: ./extracted-apks/cozy_flagship_universal.apk

--- a/.github/workflows/build-ios-dev.yml
+++ b/.github/workflows/build-ios-dev.yml
@@ -96,15 +96,14 @@ jobs:
           export-method: ad-hoc
 
       - name: Upload artifact to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: iOS App Store Package
           path: 'output.ipa'
 
       - name: Upload XCode error logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.ios_build.outcome == 'failure'
         with:
           name: XCode Build Logs
           path: '/Users/runner/Library/Logs/gym/CozyReactNative-CozyReactNative.log'
-          

--- a/.github/workflows/build-ios-prod.yml
+++ b/.github/workflows/build-ios-prod.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Select Xcode 15.3
         run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
-  
+
       - name: Check out Git repository
         uses: actions/checkout@v3
 
@@ -103,7 +103,7 @@ jobs:
           api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
 
       - name: Upload XCode error logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.ios_build.outcome == 'failure'
         with:
           name: XCode Build Logs


### PR DESCRIPTION
We are not concerned by breaking changes. See https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

It seems we need https://github.com/cozy/cozy-flagship-app/pull/1253/commits/3eff0bd3182cab350ca12d88647db6103cb1679b.

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Update actions/upload-artifact to v4
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

