### PR TITLE
fix: Inject `{}` instead of `null` as second parameter of RealtimePlugin

### DIFF
--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -78,7 +78,7 @@ export const getClient = async () => {
     token
   })
 
-  await client.registerPlugin(RealtimePlugin)
+  await client.registerPlugin(RealtimePlugin, {})
   await client.registerPlugin(flag.plugin)
   await client.plugins.flags.initializing
 

--- a/src/libs/clientHelpers/createClient.ts
+++ b/src/libs/clientHelpers/createClient.ts
@@ -71,7 +71,7 @@ export const finalizeClientCreation = async (
 
 const registerPlugins = async (client: CozyClient): Promise<void> => {
   await client.registerPlugin(flag.plugin, null)
-  await client.registerPlugin(RealtimePlugin, null)
+  await client.registerPlugin(RealtimePlugin, {})
 }
 
 const initializePlugins = async (client: CozyClient): Promise<void> => {


### PR DESCRIPTION
CozyClient.registerPlugin typing requires an `option` parameter to be defined

But the RealtimePlugin expect this parameter to be optional or to be an object

If `null` is given, then the application would crash. We injected `null` in #1279 because the CI did reject the initial attempt with no parameter, but this was not the correct solution, the correct one would be to inject an empty object

In the future we may want to make this parameter optional in the `registerPlugin` definition

### Related PRs

- cozy/cozy-libs#2703 (this is a beginning but this don't fix the declaration on cozy-client's side)