### PR TITLE
fix: Allow Unlock by Password feature when offline

### DIFF
--- a/src/app/domain/authorization/services/LockScreenService.spec.ts
+++ b/src/app/domain/authorization/services/LockScreenService.spec.ts
@@ -17,6 +17,9 @@ jest.mock('/libs/client', () => ({
   __esModule: true,
   getInstanceAndFqdnFromClient: jest.fn().mockReturnValue({
     fqdn: 'http://test.fqdn'
+  }),
+  fetchCozyPreloginData: jest.fn().mockReturnValue({
+    KdfIterations: 1337
   })
 }))
 
@@ -57,9 +60,6 @@ describe('validatePassword', () => {
   })
 
   it('should succeed when cached password is correct and input is correct', async () => {
-    // Mock the server response for the KdfIterations
-    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
-
     // Mock the local password cache hash value
     mockGetVaultInformation.mockResolvedValue('1337')
 
@@ -86,9 +86,6 @@ describe('validatePassword', () => {
   })
 
   it('should fail when cached password is correct but user input is not correct', async () => {
-    // Mock the server response for the KdfIterations
-    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
-
     // Mock the local password cache hash value
     mockGetVaultInformation.mockResolvedValue('1337')
 
@@ -115,9 +112,6 @@ describe('validatePassword', () => {
   })
 
   it('should succeed when cached password is correct but user input is not correct', async () => {
-    // Mock the server response for the KdfIterations
-    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
-
     // Mock the local password cache hash value
     mockGetVaultInformation.mockResolvedValue('1337')
 
@@ -150,9 +144,6 @@ describe('validatePassword', () => {
   })
 
   it('should fail when both cached and user input passwords are not correct', async () => {
-    // Mock the server response for the KdfIterations
-    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
-
     // Mock the local password cache hash value
     mockGetVaultInformation.mockResolvedValue('1337')
 
@@ -182,9 +173,6 @@ describe('validatePassword', () => {
   })
 
   it('should handle unexpected server error during cached password check', async () => {
-    // Mock the server response for the KdfIterations
-    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
-
     // Mock the local password cache hash value
     mockGetVaultInformation.mockResolvedValue('1337')
 
@@ -211,9 +199,6 @@ describe('validatePassword', () => {
   })
 
   it('should handle unexpected server error during input password check', async () => {
-    // Mock the server response for the KdfIterations
-    mockFetchJSON.mockResolvedValueOnce({ KdfIterations: 1337 })
-
     // Mock the local password cache hash value
     mockGetVaultInformation.mockResolvedValue('1337')
 

--- a/src/app/domain/authorization/services/LockScreenService.ts
+++ b/src/app/domain/authorization/services/LockScreenService.ts
@@ -6,7 +6,10 @@ import { FaceId } from '/ui/Icons/FaceId'
 import { Fingerprint } from '/ui/Icons/Fingerprint'
 import { asyncLogout } from '/libs/intents/localMethods'
 import { doHashPassword } from '/libs/functions/passwordHelpers'
-import { getInstanceAndFqdnFromClient } from '/libs/client'
+import {
+  fetchCozyPreloginData,
+  getInstanceAndFqdnFromClient
+} from '/libs/client'
 import {
   getVaultInformation,
   removeVaultInformation,
@@ -28,9 +31,8 @@ const hashInputPassword = async (
   input: string
 ): Promise<LoginData> => {
   const { fqdn } = getInstanceAndFqdnFromClient(client)
-  const { KdfIterations } = await client
-    .getStackClient()
-    .fetchJSON<{ KdfIterations: number }>('GET', '/public/prelogin')
+
+  const { KdfIterations } = await fetchCozyPreloginData(client)
   return doHashPassword({ password: input }, fqdn, KdfIterations)
 }
 

--- a/src/libs/client.js
+++ b/src/libs/client.js
@@ -176,6 +176,41 @@ export const fetchCozyDataForSlug = async (slug, client, cookie) => {
 }
 
 /**
+ * @typedef {object} CozyPreloginData
+ * @property {number} KdfIterations - The appliation data
+ */
+
+/**
+ * Call /public/prelogin and return result from web or from cache if offline
+ *
+ * @param {object} client - A CozyClient instance
+ * @returns {Promise<CozyPreloginData>} - The cozy's prelogin data
+ */
+export const fetchCozyPreloginData = async client => {
+  const cacheKey = `CozyPreloginData`
+
+  try {
+    const preloginData = await client
+      .getStackClient()
+      .fetchJSON('GET', '/public/prelogin')
+
+    storeClientCachedData(client, cacheKey, preloginData)
+
+    return preloginData
+  } catch (err) {
+    if (err.message === 'Network request failed') {
+      const cachedResult = await getClientCachedData(client, cacheKey)
+
+      if (cachedResult) {
+        return cachedResult
+      }
+    }
+
+    throw err
+  }
+}
+
+/**
  * @typedef {Object} getInstanceAndFqdnFromClient
  * @property {string} fqdn - The fqdn is the raw host of the cozy instance (usually you don't want to use it)
  * @property {string} normalizedFqdn - The normalizedFqdn is the fqdn with special characters replaced by underscores


### PR DESCRIPTION
When implementing the offline support, we did test the unlock screen using the PIN code

But we found that the Unlock by Password mode would require internet access in order to retrieve the number of KDF iterations for hashing the password

By caching this method's result, we allow this method to retrieve the number of KDF iteration even when offline

We also found that the Unlock by Password mode would require internet access in order to verify the password on the cozy-stack side

By nature this is impossible to do when offline, and we already check the entered password against the one stored in the phone's keychain

So we want to make this method resilient to connectivity issues

When disconnected, the app will now only checks the password agains the hash stored in the local keychain
