### PR TITLE
feat: Record clisk konnectors execution in io.cozy.clisk.records

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "redux-logger": "3.0.6",
     "redux-persist": "^6.0.0",
     "rn-flipper-async-storage-advanced": "^1.0.4",
-    "semver": "^7.3.2"
+    "semver": "^7.3.2",
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@babel/core": "7.14.8",

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -309,7 +309,10 @@ class ReactNativeLauncher extends Launcher {
         throw initKonnectorError
       }
       await this.pilot.call('setContentScriptType', 'pilot')
-      await this.worker.call('setContentScriptType', 'worker')
+      const workerOptions = {
+        shouldRecord: flag('clisk.record')
+      }
+      await this.worker.call('setContentScriptType', 'worker', workerOptions)
       const shouldLogout = await this.cleanCredentialsAccounts(konnector.slug)
       if (shouldLogout) {
         log(
@@ -689,7 +692,10 @@ class ReactNativeLauncher extends Launcher {
         listenedEventsNames: this.workerListenedEventsNames,
         label: 'launcher => worker'
       })
-      await this.worker.call('setContentScriptType', 'worker')
+      const workerOptions = {
+        shouldRecord: flag('clisk.record')
+      }
+      await this.worker.call('setContentScriptType', 'worker', workerOptions)
     } catch (err) {
       throw new Error(`worker bridge restart init error: ${err.message}`)
     }

--- a/src/libs/ReactNativeLauncher.js
+++ b/src/libs/ReactNativeLauncher.js
@@ -25,6 +25,10 @@ import {
 } from '/app/domain/sleep/services/sleep'
 import { hasPermission } from '/app/domain/manifest/permissions'
 
+import { v4 as uuidv4 } from 'uuid'
+
+import CliskRecorder from '/screens/konnectors/core/record'
+
 const log = Minilog('ReactNativeLauncher')
 
 const SET_WORKER_STATE_TIMEOUT_MS = 30 * 1000
@@ -55,11 +59,13 @@ class ReactNativeLauncher extends Launcher {
       'sendToPilot',
       'getCookiesByDomain',
       'getCookieByDomainAndName',
-      'getCookieFromKeychainByName'
+      'getCookieFromKeychainByName',
+      'saveCookieToKeychain'
     ]
     this.workerListenedEventsNames = ['log', 'workerEvent']
 
     this.controller = new AbortController()
+    this.sessionId = uuidv4() // Génération du sessionId unique pour cette instance
 
     const wrapTimer = wrapTimerFactory({
       logFn: (/** @type {String} */ msg) =>
@@ -91,6 +97,7 @@ class ReactNativeLauncher extends Launcher {
       'ensureAccountTriggerAndLaunch'
     )
     this.onWorkerWillReload = debounce(this.onWorkerWillReload.bind(this))
+    this.cliskRecorder = new CliskRecorder(this)
   }
 
   /**
@@ -121,6 +128,21 @@ class ReactNativeLauncher extends Launcher {
     if (context.job) {
       jobId = context.job.id
     }
+
+    this.cliskRecorder.handleRecorderEvent({
+      type: 5,
+      data: {
+        tag: 'log',
+        payload: {
+          ...logContent,
+          level: newLevel
+        }
+      },
+      timestamp: Date.now(),
+      konnectorSlug: slug,
+      jobId
+    })
+
     this.logger({
       ...logContent,
       slug,
@@ -448,6 +470,7 @@ class ReactNativeLauncher extends Launcher {
 
   async fetchAndSaveDebugData(force) {
     const flagvalue = flag('clisk.html-on-error')
+    await this.cliskRecorder.flush()
     if (!flagvalue && !force) {
       return true
     }
@@ -501,12 +524,6 @@ class ReactNativeLauncher extends Launcher {
         data: traceFileContent,
         dirId: existingLogsFolderId,
         name
-      })
-      this.log({
-        namespace: 'ReactNativeLauncher',
-        label: 'fetchAndSaveDebugData',
-        level: 'debug',
-        msg: `Saved debug data in /Settings/Logs/${name}`
       })
     } catch (err) {
       const message = err instanceof Error ? err.message : err

--- a/src/libs/ReactNativeLauncher.spec.js
+++ b/src/libs/ReactNativeLauncher.spec.js
@@ -988,4 +988,36 @@ describe('ReactNativeLauncher', () => {
       expect(result).toEqual({ data: { id: 'testjobid' } })
     })
   })
+  describe('CliskRecorder integration', () => {
+    it('should handle clisk events correctly', async () => {
+      const { launcher } = setup()
+      const mockHandleRecorderEvent = jest.spyOn(
+        launcher.cliskRecorder,
+        'handleRecorderEvent'
+      )
+
+      launcher.setStartContext({
+        konnector: { slug: 'testslug' },
+        job: { id: 'testjobid' }
+      })
+
+      const logContent = { message: 'Test log message' }
+      launcher.log({ level: 'info', ...logContent })
+
+      expect(mockHandleRecorderEvent).toHaveBeenCalledWith({
+        type: 5,
+        data: {
+          tag: 'log',
+          payload: {
+            ...logContent,
+            level: 'info'
+          }
+        },
+        timestamp: expect.any(Number),
+        konnectorSlug: 'testslug',
+        jobId: 'testjobid',
+        sessionId: expect.any(String)
+      })
+    })
+  })
 })

--- a/src/screens/konnectors/LauncherView.js
+++ b/src/screens/konnectors/LauncherView.js
@@ -421,6 +421,7 @@ export class LauncherView extends Component {
    */
   onWorkerMessage(event) {
     tryConsole(event, log, 'CONSOLE_WORKER')
+    this.launcher.cliskRecorder.tryCliskRecord(this.launcher, event)
     if (event.nativeEvent && event.nativeEvent.data) {
       const msg = JSON.parse(event.nativeEvent.data)
       if (msg.message === 'NEW_WORKER_INITIALIZING') {

--- a/src/screens/konnectors/core/record.js
+++ b/src/screens/konnectors/core/record.js
@@ -1,0 +1,108 @@
+import debounce from 'lodash/debounce'
+
+/**
+ * Constants for clisk recording
+ */
+export const CLISK_EVENTS_SAVE_DELAY = 1000
+export const CLISK_BATCH_SIZE = 50
+
+/**
+ * Class for recording and managing clisk events during konnector execution.
+ * Handles buffering and saving events to avoid overwhelming storage.
+ */
+class CliskRecorder {
+  constructor(launcher) {
+    this.launcher = launcher
+    this.cliskPendingEvents = []
+    this.saveCliskEvents = debounce(
+      this.saveCliskEvents,
+      CLISK_EVENTS_SAVE_DELAY
+    )
+  }
+
+  /**
+   * Flushes any pending clisk events by forcing an immediate save
+   * and waiting for the debounced save to complete
+   * @returns {Promise<void>}
+   */
+  async flush() {
+    if (this.cliskPendingEvents.length > 0) {
+      await this.saveCliskEvents()
+      await this.saveCliskEvents.flush()
+    }
+  }
+
+  /**
+   * Save clisk events incrementally
+   * @returns {Promise<void>}
+   */
+  async saveCliskEvents() {
+    try {
+      if (this.cliskPendingEvents.length === 0) return
+
+      const { client } = this.launcher.getStartContext()
+      if (!client) return
+
+      await client.saveAll(this.cliskPendingEvents)
+
+      this.cliskPendingEvents = []
+    } catch (err) {
+      const message = err instanceof Error ? err.message : err
+      this.launcher.log({
+        namespace: 'ReactNativeLauncher',
+        label: 'saveCliskEvents',
+        level: 'warn',
+        msg: 'Error while saving clisk events: ' + message
+      })
+    }
+  }
+
+  /**
+   * Handle clisk event received from LauncherView
+   * @param {Object} event - The clisk event object
+   * @returns {Promise<void>}
+   */
+  async handleRecorderEvent(event) {
+    if (!event) return
+
+    event.timestamp = Date.now()
+    event.sessionId = this.launcher.sessionId
+
+    this.cliskPendingEvents.push({ ...event, _type: 'io.cozy.clisk.record' })
+
+    // If we've accumulated enough events, trigger the save
+    if (this.cliskPendingEvents.length >= CLISK_BATCH_SIZE) {
+      this.saveCliskEvents()
+    }
+  }
+
+  /**
+   * Attempts to record clisk events from a webview message event
+   *
+   * @param {Object} launcher - The launcher instance that will handle the clisk event
+   * @param {Object} event - The webview message event containing clisk data
+   */
+  async tryCliskRecord(launcher, event) {
+    try {
+      if (!event || !launcher) return console.error('no event or launcher')
+
+      const { data: rawData } = event.nativeEvent
+
+      const { konnector, job } = launcher.getStartContext()
+      const konnectorSlug = konnector?.slug
+      const jobId = job?.id
+
+      const dataPayload = { ...JSON.parse(rawData), konnectorSlug, jobId }
+
+      if (!dataPayload.data || dataPayload.messageType !== 'clisk') return
+
+      delete dataPayload.messageType
+
+      await this.handleRecorderEvent(dataPayload)
+    } catch (e) {
+      console.error('clisk recorder error', e)
+    }
+  }
+}
+
+export default CliskRecorder

--- a/src/screens/konnectors/core/record.spec.js
+++ b/src/screens/konnectors/core/record.spec.js
@@ -1,0 +1,59 @@
+import CliskRecorder from './record'
+
+// Mock dependencies
+const mockClient = {
+  saveAll: jest.fn()
+}
+
+const mockLauncher = {
+  getStartContext: jest.fn(() => ({ client: mockClient })),
+  log: jest.fn(),
+  sessionId: 'test-session-id'
+}
+
+describe('CliskRecorder', () => {
+  let recorder
+
+  beforeEach(() => {
+    recorder = new CliskRecorder(mockLauncher)
+    jest.clearAllMocks()
+  })
+
+  it('should handle clisk event and save when batch size is reached', async () => {
+    const event = { type: 'test-event', data: {} }
+    for (let i = 0; i < 50; i++) {
+      await recorder.handleRecorderEvent(event)
+    }
+    await recorder.saveCliskEvents.flush() // flush the debounced function
+    expect(mockClient.saveAll).toHaveBeenCalledTimes(1)
+    expect(recorder.cliskPendingEvents.length).toBe(0)
+  })
+
+  it('should not save if no events are pending', async () => {
+    await recorder.saveCliskEvents()
+    expect(mockClient.saveAll).not.toHaveBeenCalled()
+  })
+
+  it('should flush pending events', async () => {
+    const event = { type: 'test-event', data: {} }
+    await recorder.handleRecorderEvent(event)
+    await recorder.flush()
+    expect(mockClient.saveAll).toHaveBeenCalledTimes(1)
+    expect(recorder.cliskPendingEvents.length).toBe(0)
+  })
+
+  it('should log error if saving events fails', async () => {
+    mockClient.saveAll.mockImplementationOnce(() => {
+      throw new Error('Save failed')
+    })
+    const event = { type: 'test-event', data: {} }
+    await recorder.handleRecorderEvent(event)
+    await recorder.flush()
+    expect(mockLauncher.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warn',
+        msg: expect.stringContaining('Error while saving clisk events')
+      })
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -19500,6 +19500,11 @@ uuid-browser@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid-browser/-/uuid-browser-3.1.0.tgz#0f05a40aef74f9e5951e20efbf44b11871e56410"
   integrity sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==
 
+uuid@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
+  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
+
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"


### PR DESCRIPTION
This is based on [rrweb](https://www.rrweb.io/)
 
   - only with the flag `clisk.record` enabled
    - each record have a unique sessionId
    - job id in the records when available
    - records saved by batches of 50 and debounced by 1 second, to avoid excessive memory usage

Needs https://github.com/konnectors/libs/pull/1022 in the konnector

The content is a suit of event object in io.cozy.clisk.records doctype. A new implementation in conrad will be needed
to view this content

```
### ✨ Features

* Record clisk konnectors execution in io.cozy.clisk.records

```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [X] Tested on Android
* [X] Test coverage
* [ ] README and documentation

