### PR TITLE
fix: Redirection is not properly working in offline

### DIFF
--- a/src/libs/defaultRedirection/defaultRedirection.spec.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.spec.ts
@@ -48,9 +48,7 @@ describe('fetchDefaultRedirectionUrl', () => {
     client.query = async (): Promise<InstanceSettings> => {
       return Promise.resolve({
         data: {
-          attributes: {
-            default_redirection: 'drive/#/folder'
-          }
+          default_redirection: 'drive/#/folder'
         }
       })
     }
@@ -66,7 +64,7 @@ describe('fetchDefaultRedirectionUrl', () => {
   it('should return null if request was bad', async () => {
     client.query = async (): Promise<object> => {
       return Promise.resolve({
-        data: {}
+        data: null
       })
     }
 

--- a/src/libs/defaultRedirection/defaultRedirection.ts
+++ b/src/libs/defaultRedirection/defaultRedirection.ts
@@ -19,9 +19,7 @@ export const DEFAULT_REDIRECTION_DELAY_IN_MS = 3000
 
 export interface InstanceSettings {
   data: {
-    attributes: {
-      default_redirection: string
-    }
+    default_redirection: string
   }
 }
 
@@ -40,7 +38,7 @@ export const fetchDefaultRedirectionUrl = async (
       }
     )) as InstanceSettings
 
-    const defaultRedirection = data.attributes.default_redirection
+    const defaultRedirection = data.default_redirection
 
     defaultRedirectionUrl = formatRedirectLink(defaultRedirection, client)
   } catch {


### PR DESCRIPTION
To compute the home redirection link at startup, we query the instance settings doc to extract the `default_redirection` attribute. However, we were using the `data.attributes` object to access it, which cannot work in offline, because there is no JSON-API formatting coming from PouchDB. And it is not required with online, because cozy-client does the JSON-API normalization.

```
### ✨ Features

*

### 🐛 Bug Fixes

* Get correct redirect link with offline 

### 🔧 Tech

*
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

