### PR TITLE
feat: Add Twake apps queries schemes

### DIFF
--- a/ios/CozyReactNative/Info.plist
+++ b/ios/CozyReactNative/Info.plist
@@ -96,6 +96,8 @@
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
+		<string>twakemail.mobile</string>
+		<string>twake.chat</string>
 		<string>cozydrive</string>
 		<string>cozybanks</string>
 		<string>cozypass</string>


### PR DESCRIPTION
To be able to open these apps from flagship app in iOS. Goal is to have the same behavior as Cozy Pass for Cozy Twake Chat and Cozy Twake Mail : 
- they will be displayed on the Home
- on browser we can open them as Cozy apps
- on mobile it redirects to native apps

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Add Twake apps queries schemes
```

#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [x] Tested on iOS
* [ ] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

