### PR TITLE
fix: Upload log files to the Cozy instance before emailing them + fix the react-native-file-logger that failed to write logs in the files

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1329,11 +1329,12 @@ PODS:
     - Firebase/Messaging (= 8.15.0)
     - React-Core
     - RNFBApp
-  - RNFileLogger (0.5.6):
-    - CocoaLumberjack
+  - RNFileLogger (0.6.0):
+    - CocoaLumberjack (~> 3.8.5)
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
+    - SSZipArchive (~> 2.4.3)
   - RNFileViewer (2.1.5):
     - React-Core
   - RNFS (2.20.0):
@@ -1375,6 +1376,7 @@ PODS:
     - React-Core
   - Sentry/HybridSDK (8.36.0)
   - SocketRocket (0.6.1)
+  - SSZipArchive (2.4.3)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -1545,6 +1547,7 @@ SPEC REPOS:
     - Protobuf
     - Sentry
     - SocketRocket
+    - SSZipArchive
 
 EXTERNAL SOURCES:
   boost:
@@ -1865,7 +1868,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
   RNFBApp: e4439717c23252458da2b41b81b4b475c86f90c4
   RNFBMessaging: 40dac204b4197a2661dec5be964780c6ec39bf65
-  RNFileLogger: 2abb4af567fc2876a9b4b8b4959d0f3ad25abd29
+  RNFileLogger: 624443561ee79bce4bdbfecf8d53d8168d434f00
   RNFileViewer: ce7ca3ac370e18554d35d6355cffd7c30437c592
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
@@ -1882,6 +1885,7 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
+  SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
   Yoga: 66a97477b94264cc4e49990c8fe6b153260d871d
 
 PODFILE CHECKSUM: ffa593b12c30a7e7caee95758144754e377e8623

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-native-config": "1.5.0",
     "react-native-device-info": "^10.3.0",
     "react-native-document-scanner-plugin": "^0.7.3",
-    "react-native-file-logger": "^0.5.6",
+    "react-native-file-logger": "^0.6.0",
     "react-native-file-viewer": "^2.1.5",
     "react-native-flipper": "^0.269.0",
     "react-native-fs": "^2.20.0",

--- a/patches/react-native-file-logger+0.6.0.patch
+++ b/patches/react-native-file-logger+0.6.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-file-logger/android/build.gradle b/node_modules/react-native-file-logger/android/build.gradle
-index fb515a6..f6d9c42 100644
+index 55f0b45..6c083ca 100644
 --- a/node_modules/react-native-file-logger/android/build.gradle
 +++ b/node_modules/react-native-file-logger/android/build.gradle
-@@ -73,8 +73,8 @@ repositories {
+@@ -97,8 +97,8 @@ repositories {
  dependencies {
      //noinspection GradleDynamicVersion
      implementation "com.facebook.react:react-native:+"

--- a/src/app/domain/performances/sendPerformancesByEmail.ts
+++ b/src/app/domain/performances/sendPerformancesByEmail.ts
@@ -1,22 +1,14 @@
 import { format } from 'date-fns'
-import { Alert, PermissionsAndroid } from 'react-native'
-import Mailer from 'react-native-mail'
+import { PermissionsAndroid } from 'react-native'
 import RNFS from 'react-native-fs'
 import DeviceInfo from 'react-native-device-info'
 
 import type CozyClient from 'cozy-client'
-// @ts-expect-error Not typed
-import { makeSharingLink } from 'cozy-client/dist/models/sharing'
 import Minilog from 'cozy-minilog'
 
-import { fetchSupportMail } from '/app/domain/logger/supportEmail'
 import { getPerformancesLogs } from '/app/domain/performances/measure'
-import { uploadFileWithConflictStrategy } from '/app/domain/upload/services'
-import {
-  hideSplashScreen,
-  showSplashScreen,
-  splashScreens
-} from '/app/theme/SplashScreenService'
+import { sendEmailToSupport } from '/app/domain/supportEmailer/sendEmail'
+import { uploadFilesToSupportFolder } from '/app/domain/supportEmailer/uploadFiles'
 import { getInstanceAndFqdnFromClient } from '/libs/client'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
 import { normalizeFqdn } from '/libs/functions/stringHelpers'
@@ -38,24 +30,9 @@ export const sendPerformancesByEmail = async (
     const permission = PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
     await PermissionsAndroid.request(permission)
 
-    const supportEmail = await fetchSupportMail(client)
-
     const { fqdn } = getInstanceAndFqdnFromClient(client)
 
-    const instance = client.getStackClient().uri ?? 'not logged app'
-
-    const subject = `Performance files for ${instance}`
-
-    const token = client.getStackClient().token.accessToken
-
-    if (!token) {
-      throw new Error('No token found')
-    }
-
     const date = format(new Date(), 'yyyyMMdd_HHmmss_SSS')
-    const existingLogsFolderId = await client
-      .collection('io.cozy.files')
-      .ensureDirectoryExists(`/Settings/AALogs/${date}`)
 
     const normalizedFqdn = normalizeFqdn(fqdn)
 
@@ -69,108 +46,18 @@ export const sendPerformancesByEmail = async (
 
     await RNFS.writeFile(performanceFilePath, getPerformancesLogs())
 
-    const url = getUrl(client, existingLogsFolderId, performanceFileName)
+    const subject = 'Performance files'
 
-    log.info('Send file', performanceFileName)
-    await uploadFileWithConflictStrategy({
-      url,
-      token,
-      filename: performanceFileName,
-      filepath: performanceFilePath,
+    const performanceFile = {
+      name: performanceFileName,
+      path: performanceFilePath,
       mimetype: '.json'
-    })
+    }
+    const link = await uploadFilesToSupportFolder([performanceFile], client)
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    const link: string = await makeSharingLink(client, [existingLogsFolderId])
-
-    await showSplashScreen(splashScreens.SEND_LOG_EMAIL)
-    log.info('Start email intent')
-    await sendMailPromise(subject, supportEmail, link).catch(
-      (errorData: sendMailError) => {
-        const { error, event } = errorData
-        Alert.alert(
-          error,
-          event,
-          [
-            {
-              text: 'Ok',
-              onPress: (): void => log.debug('OK: Email Error Response')
-            },
-            {
-              text: 'Cancel',
-              onPress: (): void => log.debug('CANCEL: Email Error Response')
-            }
-          ],
-          { cancelable: true }
-        )
-      }
-    )
-    log.info('Did finish email intent')
-    await hideSplashScreen(splashScreens.SEND_LOG_EMAIL)
+    await sendEmailToSupport(subject, link, client)
   } catch (error) {
     const errorMessage = getErrorMessage(error)
     log.error('Error while trying to send performances email', errorMessage)
   }
-}
-
-const sendMailPromise = (
-  subject: string,
-  email: string,
-  link: string
-): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    Mailer.mail(
-      {
-        subject: subject,
-        recipients: [email],
-        body: buildMessageBody(link),
-        isHTML: true
-      },
-      (error, event) => {
-        if (error) {
-          reject({ error, event })
-        } else {
-          resolve()
-        }
-      }
-    )
-  })
-}
-
-const buildMessageBody = (link: string): string => {
-  const appVersion = DeviceInfo.getVersion()
-  const appBuild = DeviceInfo.getBuildNumber()
-  const bundle = DeviceInfo.getBundleId()
-  const deviceBrand = DeviceInfo.getBrand()
-  const deviceModel = DeviceInfo.getModel()
-  const os = DeviceInfo.getSystemName()
-  const version = DeviceInfo.getSystemVersion()
-
-  const linkText = `Link: ${link}`
-  const appInfo = `App info: ${appVersion} (${appBuild})`
-  const bundleInfo = `App bundle: ${bundle}`
-  const deviceInfo = `Device info: ${deviceBrand} ${deviceModel} ${os} ${version}`
-
-  return `${linkText}${appInfo}\n${bundleInfo}\n${deviceInfo}`
-}
-
-const getUrl = (client: CozyClient, dirId: string, name: string): string => {
-  const createdAt = new Date().toISOString()
-  const modifiedAt = new Date().toISOString()
-
-  const toURL = new URL(client.getStackClient().uri)
-  toURL.pathname = `/files/${dirId}`
-  toURL.searchParams.append('Name', name)
-  toURL.searchParams.append('Type', 'file')
-  toURL.searchParams.append('Tags', 'library')
-  toURL.searchParams.append('Executable', 'false')
-  toURL.searchParams.append('CreatedAt', createdAt)
-  toURL.searchParams.append('UpdatedAt', modifiedAt)
-
-  return toURL.toString()
-}
-
-interface sendMailError {
-  error: string
-  event?: string
 }

--- a/src/app/domain/supportEmailer/sendEmail.ts
+++ b/src/app/domain/supportEmailer/sendEmail.ts
@@ -1,0 +1,99 @@
+import { Alert } from 'react-native'
+import Mailer from 'react-native-mail'
+import DeviceInfo from 'react-native-device-info'
+
+import type CozyClient from 'cozy-client'
+import Minilog from 'cozy-minilog'
+
+import { fetchSupportMail } from '/app/domain/logger/supportEmail'
+import {
+  hideSplashScreen,
+  showSplashScreen,
+  splashScreens
+} from '/app/theme/SplashScreenService'
+
+const log = Minilog('🗒️ Support Mailer')
+
+interface sendMailError {
+  error: string
+  event?: string
+}
+
+export const sendEmailToSupport = async (
+  subject: string,
+  link: string,
+  client: CozyClient
+): Promise<void> => {
+  const supportEmail = await fetchSupportMail(client)
+
+  const instance = client.getStackClient().uri ?? 'not logged app'
+
+  const fullSubject = `${subject} for ${instance}`
+
+  await showSplashScreen(splashScreens.SEND_LOG_EMAIL)
+  log.info('Start email intent')
+
+  await sendMailPromise(fullSubject, supportEmail, link).catch(
+    (errorData: sendMailError) => {
+      const { error, event } = errorData
+      Alert.alert(
+        error,
+        event,
+        [
+          {
+            text: 'Ok',
+            onPress: (): void => log.debug('OK: Email Error Response')
+          },
+          {
+            text: 'Cancel',
+            onPress: (): void => log.debug('CANCEL: Email Error Response')
+          }
+        ],
+        { cancelable: true }
+      )
+    }
+  )
+  log.info('Did finish email intent')
+  await hideSplashScreen(splashScreens.SEND_LOG_EMAIL)
+}
+
+const sendMailPromise = (
+  subject: string,
+  email: string,
+  link: string
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    Mailer.mail(
+      {
+        subject: subject,
+        recipients: [email],
+        body: buildMessageBody(link),
+        isHTML: true
+      },
+      (error, event) => {
+        if (error) {
+          reject({ error, event })
+        } else {
+          resolve()
+        }
+      }
+    )
+  })
+}
+
+const buildMessageBody = (link: string): string => {
+  const appVersion = DeviceInfo.getVersion()
+  const appBuild = DeviceInfo.getBuildNumber()
+  const bundle = DeviceInfo.getBundleId()
+  const deviceBrand = DeviceInfo.getBrand()
+  const deviceModel = DeviceInfo.getModel()
+  const os = DeviceInfo.getSystemName()
+  const version = DeviceInfo.getSystemVersion()
+
+  const linkText = `Link: ${link}`
+  const appInfo = `App info: ${appVersion} (${appBuild})`
+  const bundleInfo = `App bundle: ${bundle}`
+  const deviceInfo = `Device info: ${deviceBrand} ${deviceModel} ${os} ${version}`
+
+  return `${linkText}${appInfo}\n${bundleInfo}\n${deviceInfo}`
+}

--- a/src/app/domain/supportEmailer/temporaryFile.ts
+++ b/src/app/domain/supportEmailer/temporaryFile.ts
@@ -1,0 +1,46 @@
+import { format } from 'date-fns'
+import RNFS from 'react-native-fs'
+
+import CozyClient from 'cozy-client'
+
+import { getInstanceAndFqdnFromClient } from '/libs/client'
+import { normalizeFqdn } from '/libs/functions/stringHelpers'
+
+export const saveToTempDir = async (
+  client: CozyClient,
+  filePath: string,
+  fileName: string
+): Promise<string> => {
+  const tempFolderPath = getTempFolderPath(client)
+
+  await RNFS.mkdir(tempFolderPath)
+
+  const date = format(new Date(), 'yyyyMMdd_HHmmss_SSS')
+  const destFolderPath = `${tempFolderPath}/${date}`
+
+  await RNFS.mkdir(destFolderPath)
+
+  const destPath = `${destFolderPath}/${fileName}`
+
+  await RNFS.copyFile(filePath, destPath)
+
+  return destPath
+}
+
+export const cleanTempDir = async (client: CozyClient): Promise<void> => {
+  const tempFolderPath = getTempFolderPath(client)
+
+  if (await RNFS.exists(tempFolderPath)) {
+    await RNFS.unlink(tempFolderPath)
+  }
+}
+
+const getTempFolderPath = (client: CozyClient): string => {
+  const { fqdn } = getInstanceAndFqdnFromClient(client)
+
+  const normalizedFqdn = normalizeFqdn(fqdn)
+
+  const tempFolderPath = `${RNFS.DocumentDirectoryPath}/${normalizedFqdn}/SupportTemp`
+
+  return tempFolderPath
+}

--- a/src/app/domain/supportEmailer/uploadFiles.ts
+++ b/src/app/domain/supportEmailer/uploadFiles.ts
@@ -1,0 +1,72 @@
+import { format } from 'date-fns'
+
+import CozyClient from 'cozy-client'
+// @ts-expect-error Not typed
+import { makeSharingLink } from 'cozy-client/dist/models/sharing'
+import Minilog from 'cozy-minilog'
+
+import { uploadFileWithConflictStrategy } from '/app/domain/upload/services'
+
+const log = Minilog('🗒️ Support Uploader')
+
+export interface File {
+  name: string
+  path: string
+  mimetype: string
+}
+
+export const uploadFilesToSupportFolder = async (
+  files: File[],
+  client: CozyClient
+): Promise<string> => {
+  const token = client.getStackClient().token.accessToken
+
+  if (!token) {
+    throw new Error('No token found')
+  }
+
+  const logsFolderId = await createLogsFolder(client)
+
+  for (const file of files) {
+    const url = getUrl(client, logsFolderId, file.name)
+
+    log.info('Send file', file.name)
+    await uploadFileWithConflictStrategy({
+      url,
+      token,
+      filename: file.name,
+      filepath: file.path,
+      mimetype: file.mimetype
+    })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+  const link: string = await makeSharingLink(client, [logsFolderId])
+
+  return link
+}
+
+const createLogsFolder = async (client: CozyClient): Promise<string> => {
+  const date = format(new Date(), 'yyyyMMdd_HHmmss_SSS')
+  const existingLogsFolderId = await client
+    .collection('io.cozy.files')
+    .ensureDirectoryExists(`/Settings/AALogs/${date}`)
+
+  return existingLogsFolderId
+}
+
+const getUrl = (client: CozyClient, dirId: string, name: string): string => {
+  const createdAt = new Date().toISOString()
+  const modifiedAt = new Date().toISOString()
+
+  const toURL = new URL(client.getStackClient().uri)
+  toURL.pathname = `/files/${dirId}`
+  toURL.searchParams.append('Name', name)
+  toURL.searchParams.append('Type', 'file')
+  toURL.searchParams.append('Tags', 'library')
+  toURL.searchParams.append('Executable', 'false')
+  toURL.searchParams.append('CreatedAt', createdAt)
+  toURL.searchParams.append('UpdatedAt', modifiedAt)
+
+  return toURL.toString()
+}

--- a/src/pouchdb/sendDbByEmail.ts
+++ b/src/pouchdb/sendDbByEmail.ts
@@ -1,21 +1,11 @@
-import { format } from 'date-fns'
-import { Alert, PermissionsAndroid } from 'react-native'
-import Mailer from 'react-native-mail'
+import { PermissionsAndroid } from 'react-native'
 import RNFS from 'react-native-fs'
-import DeviceInfo from 'react-native-device-info'
 
 import type CozyClient from 'cozy-client'
-// @ts-expect-error Not typed
-import { makeSharingLink } from 'cozy-client/dist/models/sharing'
 import Minilog from 'cozy-minilog'
 
-import { fetchSupportMail } from '/app/domain/logger/supportEmail'
-import { uploadFileWithConflictStrategy } from '/app/domain/upload/services'
-import {
-  hideSplashScreen,
-  showSplashScreen,
-  splashScreens
-} from '/app/theme/SplashScreenService'
+import { sendEmailToSupport } from '/app/domain/supportEmailer/sendEmail'
+import { uploadFilesToSupportFolder } from '/app/domain/supportEmailer/uploadFiles'
 import { getInstanceAndFqdnFromClient } from '/libs/client'
 import { getErrorMessage } from '/libs/functions/getErrorMessage'
 
@@ -33,133 +23,25 @@ export const sendDbByEmail = async (client?: CozyClient): Promise<void> => {
     const permission = PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
     await PermissionsAndroid.request(permission)
 
-    const supportEmail = await fetchSupportMail(client)
-
     const { fqdn } = getInstanceAndFqdnFromClient(client)
-
-    const instance = client.getStackClient().uri ?? 'not logged app'
-
-    const subject = `DB files for ${instance}`
 
     const files = await RNFS.readDir(RNFS.DocumentDirectoryPath)
 
     const dbFiles = files.filter(f => f.name.startsWith(`${fqdn}_`))
 
-    const token = client.getStackClient().token.accessToken
+    const subject = 'DB files'
 
-    if (!token) {
-      throw new Error('No token found')
-    }
-
-    const date = format(new Date(), 'yyyyMMdd_HHmmss_SSS')
-    const existingLogsFolderId = await client
-      .collection('io.cozy.files')
-      .ensureDirectoryExists(`/Settings/AALogs/${date}`)
-
-    for (const dbFile of dbFiles) {
-      const url = getUrl(client, existingLogsFolderId, dbFile.name)
-
-      log.info('Send file', dbFile.name)
-      await uploadFileWithConflictStrategy({
-        url,
-        token,
-        filename: dbFile.name,
-        filepath: dbFile.path,
+    const emailedFiles = dbFiles.map(dbFile => {
+      return {
+        name: dbFile.name,
+        path: dbFile.path,
         mimetype: '.sqlite'
-      })
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    const link: string = await makeSharingLink(client, [existingLogsFolderId])
-
-    await showSplashScreen(splashScreens.SEND_LOG_EMAIL)
-    log.info('Start email intent')
-    await sendMailPromise(subject, supportEmail, link).catch(
-      (errorData: sendMailError) => {
-        const { error, event } = errorData
-        Alert.alert(
-          error,
-          event,
-          [
-            {
-              text: 'Ok',
-              onPress: (): void => log.debug('OK: Email Error Response')
-            },
-            {
-              text: 'Cancel',
-              onPress: (): void => log.debug('CANCEL: Email Error Response')
-            }
-          ],
-          { cancelable: true }
-        )
       }
-    )
-    log.info('Did finish email intent')
-    await hideSplashScreen(splashScreens.SEND_LOG_EMAIL)
+    })
+    const link = await uploadFilesToSupportFolder(emailedFiles, client)
+    await sendEmailToSupport(subject, link, client)
   } catch (error) {
     const errorMessage = getErrorMessage(error)
     log.error('Error while trying to send DB email', errorMessage)
   }
-}
-
-const sendMailPromise = (
-  subject: string,
-  email: string,
-  link: string
-): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    Mailer.mail(
-      {
-        subject: subject,
-        recipients: [email],
-        body: buildMessageBody(link),
-        isHTML: true
-      },
-      (error, event) => {
-        if (error) {
-          reject({ error, event })
-        } else {
-          resolve()
-        }
-      }
-    )
-  })
-}
-
-const buildMessageBody = (link: string): string => {
-  const appVersion = DeviceInfo.getVersion()
-  const appBuild = DeviceInfo.getBuildNumber()
-  const bundle = DeviceInfo.getBundleId()
-  const deviceBrand = DeviceInfo.getBrand()
-  const deviceModel = DeviceInfo.getModel()
-  const os = DeviceInfo.getSystemName()
-  const version = DeviceInfo.getSystemVersion()
-
-  const linkText = `Link: ${link}`
-  const appInfo = `App info: ${appVersion} (${appBuild})`
-  const bundleInfo = `App bundle: ${bundle}`
-  const deviceInfo = `Device info: ${deviceBrand} ${deviceModel} ${os} ${version}`
-
-  return `${linkText}${appInfo}\n${bundleInfo}\n${deviceInfo}`
-}
-
-const getUrl = (client: CozyClient, dirId: string, name: string): string => {
-  const createdAt = new Date().toISOString()
-  const modifiedAt = new Date().toISOString()
-
-  const toURL = new URL(client.getStackClient().uri)
-  toURL.pathname = `/files/${dirId}`
-  toURL.searchParams.append('Name', name)
-  toURL.searchParams.append('Type', 'file')
-  toURL.searchParams.append('Tags', 'library')
-  toURL.searchParams.append('Executable', 'false')
-  toURL.searchParams.append('CreatedAt', createdAt)
-  toURL.searchParams.append('UpdatedAt', modifiedAt)
-
-  return toURL.toString()
-}
-
-interface sendMailError {
-  error: string
-  event?: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17644,10 +17644,12 @@ react-native-document-scanner-plugin@^0.7.3:
   resolved "https://registry.yarnpkg.com/react-native-document-scanner-plugin/-/react-native-document-scanner-plugin-0.7.3.tgz#a0212e687681e3b1ed9b4aebcb1e7fc20d52ab50"
   integrity sha512-cddhp1rDK3nwCyi3qhbDsuWzC2svBgoGhHNQRgxJvrgfM4uoQKAGSU3XYY3VXjAZCzlqVZz9PYziYDD6fdEIcw==
 
-react-native-file-logger@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/react-native-file-logger/-/react-native-file-logger-0.5.6.tgz#b6439717a943b4677b99a6c43ffba43991ea08e9"
-  integrity sha512-npp0IB94QDhy6JjsA9jipuNmbHwcFGGSf8xPXquVbU7z2zM9GQk/JTtXm4IVidQxbDiy0Mzk48eUGkxhry0Ofg==
+react-native-file-logger@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-file-logger/-/react-native-file-logger-0.6.0.tgz#3e0f9b6bad877c7a70153d0254c0cafa5c82981d"
+  integrity sha512-JbP4jx024thxbiqfKSTzkeQcwcF2qYHa+BpFpEJdpVQrsF6ATL01obmmp99EaArfoy/xdmUcHlG8A8nvrfHKGQ==
+  dependencies:
+    util "^0.12.5"
 
 react-native-file-viewer@^2.1.5:
   version "2.1.5"


### PR DESCRIPTION
The goal of this PR is to fix a bug that prevented to correctly write logs into the log files on Android (see https://github.com/BeTomorrow/react-native-file-logger/issues/68).

Also we improved the log sending process in order to upload the file on the Cozy instance before sending them by email. This would allow to retrieve the files even when the email intent fails to open.

However, when no Cozy is logged-in, then we still use the old "email only" scenario.