### PR TITLE
fix: Upgrade @react-native-community/blur to `4.4.1`

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1078,7 +1078,9 @@ PODS:
     - React
   - react-native-biometrics (3.0.1):
     - React-Core
-  - react-native-blur (4.3.2):
+  - react-native-blur (4.4.1):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - react-native-cameraroll (7.2.0):
     - React-Core
@@ -1823,7 +1825,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 758750eb32350b01dd9c350010aecc46842047bd
   react-native-background-upload: 7c608537f87106c93530a3a19a853afd55466823
   react-native-biometrics: 352e5a794bfffc46a0c86725ea7dc62deb085bdc
-  react-native-blur: cfdad7b3c01d725ab62a8a729f42ea463998afa2
+  react-native-blur: b2b140d3d65077a1d5d26be62d9415f895592344
   react-native-cameraroll: 2a198b0eb86c7ccf3303fb57702b2465cc292c94
   react-native-change-icon: ea9bb7255b09e89f41cbf282df16eade91ab1833
   react-native-config: 5330c8258265c1e5fdb8c009d2cabd6badd96727

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@react-native-async-storage/async-storage": "1.21.0",
     "@react-native-camera-roll/camera-roll": "^7.2.0",
     "@react-native-clipboard/clipboard": "^1.13.2",
-    "@react-native-community/blur": "4.3.2",
+    "@react-native-community/blur": "4.4.1",
     "@react-native-community/netinfo": "9.5.0",
     "@react-native-cookies/cookies": "^6.2.1",
     "@react-native-firebase/app": "^14.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4231,10 +4231,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.13.2.tgz#28adcfc43ed2addddf79a59198ec1b25087c115e"
   integrity sha512-uVM55oEGc6a6ZmSATDeTcMm55A/C1km5X47g0xaoF0Zagv7N/8RGvLceA5L/izPwflIy78t7XQeJUcnGSib0nA==
 
-"@react-native-community/blur@4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/blur/-/blur-4.3.2.tgz#185a2c7dd03ba168cc95069bc4742e9505fd6c6c"
-  integrity sha512-0ID+pyZKdC4RdgC7HePxUQ6JmsbNrgz03u+6SgqYpmBoK/rE+7JffqIw7IEsfoKitLEcRNLGekIBsfwCqiEkew==
+"@react-native-community/blur@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/blur/-/blur-4.4.1.tgz#72cbc0be5a84022c33091683ec6888925ebcca6e"
+  integrity sha512-XBSsRiYxE/MOEln2ayunShfJtWztHwUxLFcSL20o+HNNRnuUDv+GXkF6FmM2zE8ZUfrnhQ/zeTqvnuDPGw6O8A==
 
 "@react-native-community/cli-clean@12.3.7":
   version "12.3.7"


### PR DESCRIPTION
`@react-native-community/blur` has been upgraded to `4.4.1` in order to fix a bug where CI was not able to build the app due to missing BlurView-version-2.0.3.aar

More info: Kureev/react-native-blur#641
