### PR TITLE
feat: Upgrade Cozy's react-native-gzip to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@craftzdog/pouchdb-collate-react-native": "^7.3.0",
     "@craftzdog/react-native-buffer": "^6.0.5",
-    "@fengweichong/react-native-gzip": "github:cozy/react-native-gzip#1.1.0",
+    "@fengweichong/react-native-gzip": "github:cozy/react-native-gzip#1.2.0",
     "@mythologi/react-native-receive-sharing-intent": "2.2.1",
     "@notifee/react-native": "^7.8.0",
     "@op-engineering/op-sqlite": "^6.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3264,9 +3264,9 @@
   resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
   integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
 
-"@fengweichong/react-native-gzip@github:cozy/react-native-gzip#1.1.0":
+"@fengweichong/react-native-gzip@github:cozy/react-native-gzip#1.2.0":
   version "2.0.0"
-  resolved "https://codeload.github.com/cozy/react-native-gzip/tar.gz/41178cf223fe3c866dfa6ede78a881461de066fd"
+  resolved "https://codeload.github.com/cozy/react-native-gzip/tar.gz/6849a504aba17de01e7879f0184bdc2153319a07"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"


### PR DESCRIPTION
Due to the removal of geolocation libraries in #1283 we encountered some dependencies bug in the react-native-gzip library

This new version should fix those issues

Related PR: cozy/react-native-gzip#4