### PR TITLE
fix: Clear all non-device persisted data on logout

### DIFF
--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -8,6 +8,7 @@ import { logger } from '/libs/functions/logger'
 import { SerializedOfflineFilesConfiguration } from '/app/domain/io.cozy.files/offlineFilesConfiguration'
 import type { OnboardingPartner } from '/screens/welcome/install-referrer/onboardingPartner'
 import { OauthData } from '/libs/clientHelpers/persistClient'
+import { UserPersistedStorageKeys } from '/libs/localStore/userPersistedStorage'
 
 const log = logger('storage.ts')
 
@@ -101,9 +102,10 @@ export const getData = async <T>(name: StorageKey): Promise<T | null> => {
 export const clearCozyData = async (): Promise<void> => {
   try {
     const keys = storage.getAllKeys()
-    const keysToKeep = Object.values(
-      DevicePersistedStorageKeys
-    ) as unknown as string
+    const keysToKeep = [
+      ...Object.values(DevicePersistedStorageKeys),
+      ...Object.values(UserPersistedStorageKeys)
+    ] as string[]
 
     for (const key of keys) {
       if (!keysToKeep.includes(key)) {

--- a/src/libs/localStore/storage.ts
+++ b/src/libs/localStore/storage.ts
@@ -100,11 +100,16 @@ export const getData = async <T>(name: StorageKey): Promise<T | null> => {
 
 export const clearCozyData = async (): Promise<void> => {
   try {
-    const keys = Object.values(CozyPersistedStorageKeys)
+    const keys = storage.getAllKeys()
+    const keysToKeep = Object.values(
+      DevicePersistedStorageKeys
+    ) as unknown as string
 
     for (const key of keys) {
-      await removeItem(key)
-      storage.delete(key)
+      if (!keysToKeep.includes(key)) {
+        await removeItem(key)
+        storage.delete(key)
+      }
     }
   } catch (error) {
     log.error(`Failed to clear data from persistent storage`, error)


### PR DESCRIPTION
In previous implementation we did not clear all the non-device persisted data on Logout

Some of them were created by cozy-pouch-link and were not listed here so they were ignored by the clear process (and so the pouch replication process would be broken after switch cozy's instances)

To prevent this in the future, we change the algorithm to clear ALL the persisted data except the device ones