### PR TITLE
fix: Correctly send Databases by email when using universal link

### DIFF
--- a/src/pouchdb/sendDbByEmail.ts
+++ b/src/pouchdb/sendDbByEmail.ts
@@ -25,7 +25,9 @@ export const sendDbByEmail = async (client?: CozyClient): Promise<void> => {
 
     const { fqdn } = getInstanceAndFqdnFromClient(client)
 
-    const files = await RNFS.readDir(RNFS.DocumentDirectoryPath)
+    const files = await RNFS.readDir(
+      RNFS.DocumentDirectoryPath + '/../databases'
+    )
 
     const dbFiles = files.filter(f => f.name.startsWith(`${fqdn}_`))
 


### PR DESCRIPTION
Somewhere in the previous Offline related changes, we changed where the Pouch database are stored, which broke the emailing process