### PR TITLE
feat: Allow to use Papillon while offline

### DIFF
--- a/src/libs/httpserver/indexGenerator.ts
+++ b/src/libs/httpserver/indexGenerator.ts
@@ -36,7 +36,8 @@ const log = Minilog('IndexGenerator')
 // - cozy-pass-web cannot be injected because fetch with { mode: 'no-cors' } does not work
 const slugAllowList = [
   { platform: 'ALL', slug: 'home' },
-  { platform: 'android', slug: 'ALL' }
+  { platform: 'android', slug: 'ALL' },
+  { platform: 'ALL', slug: 'papillon' }
 ]
 
 const slugBlockList = [{ platform: 'ALL', slug: 'passwords' }]

--- a/src/pouchdb/getLinks.ts
+++ b/src/pouchdb/getLinks.ts
@@ -31,6 +31,11 @@ export const offlineDoctypes = [
   'io.cozy.apps.suggestions',
   'io.cozy.triggers',
   'io.cozy.apps_registry',
+  'io.cozy.calendar.events',
+  'io.cozy.calendar.todos',
+  'io.cozy.calendar.presence',
+  'io.cozy.timeseries.grades',
+  'io.cozy.identities',
 
   // app specific
   'io.cozy.mespapiers.settings',


### PR DESCRIPTION
This PR declares the Papillon related doctypes needed for offline replication and allows Papillon app to use local HTTP server on iOS