### PR TITLE
fix: Make the CI builds target iOS 18

### DIFF
--- a/.github/workflows/build-ios-dev.yml
+++ b/.github/workflows/build-ios-dev.yml
@@ -21,8 +21,8 @@ jobs:
       - name: List Xcode installations
         run: sudo ls -1 /Applications | grep "Xcode"
 
-      - name: Select Xcode 15.3
-        run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
 
       - name: Check out Git repository
         uses: actions/checkout@v3

--- a/.github/workflows/build-ios-prod.yml
+++ b/.github/workflows/build-ios-prod.yml
@@ -21,8 +21,8 @@ jobs:
       - name: List Xcode installations
         run: sudo ls -1 /Applications | grep "Xcode"
 
-      - name: Select Xcode 15.3
-        run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
 
       - name: Check out Git repository
         uses: actions/checkout@v3

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -90,5 +90,23 @@ target 'CozyReactNative' do
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']
       end
     end
+
+    # https://medium.com/@ssthil75/how-i-solved-the-asset-validation-failed-invalid-executable-error-in-xcode-16-on-m2-macs-00b21ce0ba17
+    # https://stackoverflow.com/questions/79018593/asset-validation-failed-invalid-executable-the-executable-myapp-app-frameworks/79030093#79030093
+    bitcode_strip_path = `xcrun --find bitcode_strip`.chop!
+    def strip_bitcode_from_framework(bitcode_strip_path, framework_relative_path)
+      framework_path = File.join(Dir.pwd, framework_relative_path)
+      command = "#{bitcode_strip_path} #{framework_path} -r -o #{framework_path}"
+      puts "Stripping bitcode: #{command}"
+      system(command)
+    end
+
+    framework_paths = [
+      "Pods/OpenSSL-Universal/Frameworks/OpenSSL.xcframework/ios-arm64_armv7/OpenSSL.framework/OpenSSL"
+    ]
+
+    framework_paths.each do |framework_relative_path|
+      strip_bitcode_from_framework(bitcode_strip_path, framework_relative_path)
+    end
   end
 end


### PR DESCRIPTION
Apple now requires apps to be build using iOS18 SDK