### PR TITLE
feat: Implement OIDC login for new Twake scenario

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@sentry/integrations": "7.114.0",
     "@sentry/react-native": "5.33.1",
     "base-64": "^1.0.0",
-    "cozy-client": "^57.6.0",
+    "cozy-client": "^58.3.0",
     "cozy-clisk": "^0.38.1",
     "cozy-dataproxy-lib": "3.5.0",
     "cozy-device-helper": "^2.7.0",

--- a/src/screens/login/LoginScreen.js
+++ b/src/screens/login/LoginScreen.js
@@ -286,6 +286,29 @@ const LoginSteps = ({
     }
   }
 
+  const startOidcOauthNoCode = async instance => {
+    if (await NetService.isOffline())
+      NetService.handleOffline(routes.authenticate)
+
+    try {
+      const client = await createClient(instance)
+
+      await client.certifyFlagship()
+
+      await authorizeClientAndLogin({
+        client,
+        sessionCode: undefined
+      })
+
+      showSplashScreen()
+      setClient(client)
+    } catch (error) {
+      if (error !== OAUTH_USER_CANCELED_ERROR) {
+        setError(error.message, error)
+      }
+    }
+  }
+
   const startMagicLinkOAuth = useCallback(
     async (fqdn, magicCode) => {
       if (await NetService.isOffline())
@@ -568,6 +591,7 @@ const LoginSteps = ({
           startOidcOAuth={startOidcOAuth}
           startOidcOnboarding={startOidcOnboarding}
           setInstanceData={setInstanceData}
+          startOidcOauthNoCode={startOidcOauthNoCode}
         />
       )
     } else {

--- a/src/screens/login/components/TwakeWelcomeView.tsx
+++ b/src/screens/login/components/TwakeWelcomeView.tsx
@@ -32,13 +32,15 @@ interface TwakeWelcomeViewProps {
   startOidcOAuth: startOidcOAuth
   startOidcOnboarding: startOidcOnboarding
   setInstanceData: setInstanceData
+  startOidcOauthNoCode: startOidcOauthNoCode
 }
 
 export const TwakeWelcomeView = ({
   setError,
   startOidcOAuth,
   startOidcOnboarding,
-  setInstanceData
+  setInstanceData,
+  startOidcOauthNoCode
 }: TwakeWelcomeViewProps): JSX.Element => {
   const { showOverlay, hideOverlay } = useLoadingOverlay()
   const { setOnboardedRedirection } = useHomeStateContext()
@@ -106,6 +108,7 @@ export const TwakeWelcomeView = ({
         close={(): void => setIsCustomServer(false)}
         openTos={openTos}
         setInstanceData={setInstanceData}
+        startOidcOauthNoCode={startOidcOauthNoCode}
       />
     )
   }

--- a/src/screens/login/components/typedefs.js
+++ b/src/screens/login/components/typedefs.js
@@ -77,6 +77,12 @@
  */
 
 /**
+ * Start OIDC Oauth process for current instance without code.
+ * @callback startOidcOauthNoCode
+ * @param {string} instance
+ */
+
+/**
  * Start OIDC Onboarding process.
  * @callback startOidcOnboarding
  * @param {string} onboardUrl

--- a/yarn.lock
+++ b/yarn.lock
@@ -8713,6 +8713,33 @@ cozy-client@^57.6.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
+cozy-client@^58.3.0:
+  version "58.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-58.3.0.tgz#abccb6ab49712a2fe9c86b1f452ab65613fe9ad3"
+  integrity sha512-YwI3urghhmr/lrfTPvNYhK7+FGjz16uJmwxla1CaxhAMRWG+bQpFU17qpaex2yo3Ri+37IxYeD7OfZ6B+eXqMQ==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    "@fastify/deepmerge" "^2.0.2"
+    "@types/jest" "^26.0.20"
+    "@types/lodash" "^4.14.170"
+    btoa "^1.2.1"
+    cozy-stack-client "^58.0.0"
+    date-fns "2.29.3"
+    fast-deep-equal "^3.1.3"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    node-polyglot "2.4.2"
+    open "7.4.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "3 || 4"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^8.0.0"
+
 cozy-clisk@^0.38.1:
   version "0.38.1"
   resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.38.1.tgz#0b42f723ebed7ef32c13cf6eac3a8bc241dc52c1"
@@ -8797,6 +8824,15 @@ cozy-stack-client@^57.2.0:
   version "57.2.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-57.2.0.tgz#837176d73561aa1983f6b2c0a9b0cbe1eb0a0d14"
   integrity sha512-k68fuNdfLXsskdgA0pd04Bk+CDUCqICCm5IZHJZiIEJkovvA6IqI/jU8vyNI7fNrCuRQasCjwatIRoT7Qq9O6g==
+  dependencies:
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^58.0.0:
+  version "58.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-58.0.0.tgz#de9082686d00d6f4ba9bd2b463df93be6b8de1ad"
+  integrity sha512-y462sU1Monpp6qZrTSpW7nAf/vYRYnBEFiqoaNUXX2kE7Ti3svUu9A/SoEu1jaE86iV5a/DKLMLY5GoOMyiYCQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
When clicking on `Use your company server` button, we wan't to be able to either:
- login to old Cozy instances (already implemented)
- login to OIDC instance (to be implemented)

This commit implement the detection of the login mechanism (classic vs OIDC)

Then for OIDC instances, in implements the login mechanism. To make this login work, we use the `client.authorize()` mechanism that already implement in-app-browser based authorisation scenario that is able to redirect to the OIDC portal if detected. This redirection is handled by the cozy-stack
