### PR TITLE
SSO by email for company server

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,7 +126,8 @@
         "email": "Enter my company email address"
       },
       "textFieldLabel": "Url",
-      "buttonLogin": "Next"
+      "buttonLogin": "Next",
+      "companyServerNotFound": "Company server not found"
     }
   },
   "services": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -118,7 +118,12 @@
     "companyServer": {
       "title": "Login",
       "body": {
-        "byUrl": "To log in and access your Twake, please enter its URL"
+        "byUrl": "To log in and access your Twake, please enter its URL",
+        "byEmail": "To log in and access your Twake, please enter your company email address"
+      },
+      "toggle": {
+        "url": "Enter my Twake URL",
+        "email": "Enter my company email address"
       },
       "textFieldLabel": "Url",
       "buttonLogin": "Next"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -117,7 +117,9 @@
     },
     "companyServer": {
       "title": "Login",
-      "body": "To log in and access your Twake, please enter its URL",
+      "body": {
+        "byUrl": "To log in and access your Twake, please enter its URL"
+      },
       "textFieldLabel": "Url",
       "buttonLogin": "Next"
     }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -126,7 +126,8 @@
         "email": "Introduzca la dirección de correo electrónico corporativa"
       },
       "textFieldLabel": "Url",
-      "buttonLogin": "Siguiente"
+      "buttonLogin": "Siguiente",
+      "companyServerNotFound": "No se ha encontrado el servidor de la corporativa"
     }
   },
   "services": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -118,7 +118,12 @@
     "companyServer": {
       "title": "Acceso",
       "body": {
-        "byUrl": "Para conectarse y acceder a su Twake, introduzca su URL"
+        "byUrl": "Para conectarse y acceder a su Twake, introduzca su URL",
+        "byEmail": "Para conectarse y acceder a su Twake, introduzca la dirección de correo electrónico corporativa"
+      },
+      "toggle": {
+        "url": "Introduce mi URL de Twake",
+        "email": "Introduzca la dirección de correo electrónico corporativa"
       },
       "textFieldLabel": "Url",
       "buttonLogin": "Siguiente"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -117,7 +117,9 @@
     },
     "companyServer": {
       "title": "Acceso",
-      "body": "Para conectarse y acceder a su Twake, introduzca su URL",
+      "body": {
+        "byUrl": "Para conectarse y acceder a su Twake, introduzca su URL"
+      },
       "textFieldLabel": "Url",
       "buttonLogin": "Siguiente"
     }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -117,7 +117,9 @@
     },
     "companyServer": {
       "title": "Se connecter",
-      "body": "Pour vous connecter et accéder à votre Twake, veuillez saisir son URL",
+      "body": {
+        "byUrl": "Pour vous connecter et accéder à votre Twake, veuillez saisir son URL"
+      },
       "textFieldLabel": "Serveur",
       "buttonLogin": "Suivant"
     }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -126,7 +126,8 @@
         "email": "Entrer mon adresse email d'entreprise"
       },
       "textFieldLabel": "Serveur",
-      "buttonLogin": "Suivant"
+      "buttonLogin": "Suivant",
+      "companyServerNotFound": "Serveur d'entreprise introuvable"
     }
   },
   "services": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -118,7 +118,12 @@
     "companyServer": {
       "title": "Se connecter",
       "body": {
-        "byUrl": "Pour vous connecter et accéder à votre Twake, veuillez saisir son URL"
+        "byUrl": "Pour vous connecter et accéder à votre Twake, veuillez saisir son URL",
+        "byEmail": "Pour vous connecter et accéder à votre Twake, veuillez saisir votre adresse email d'entreprise"
+      },
+      "toggle": {
+        "url": "Entrer l'URL de mon Twake",
+        "email": "Entrer mon adresse email d'entreprise"
       },
       "textFieldLabel": "Serveur",
       "buttonLogin": "Suivant"

--- a/src/screens/login/components/TwakeCustomServerView.tsx
+++ b/src/screens/login/components/TwakeCustomServerView.tsx
@@ -46,7 +46,7 @@ export const TwakeCustomServerView = ({
   setInstanceData,
   startOidcOauthNoCode
 }: TwakeCustomServerViewProps): JSX.Element => {
-  const [input, setInput] = useState('')
+  const [urlInput, setUrlInput] = useState('')
   const [error, setError] = useState<string | undefined>()
 
   const version = useMemo(() => getVersion(), [])
@@ -63,14 +63,14 @@ export const TwakeCustomServerView = ({
       BackHandler.removeEventListener('hardwareBackPress', handleBackPress)
   }, [handleBackPress])
 
-  const handleInput = (input: string): void => {
-    setInput(input)
+  const handleUrlInput = (input: string): void => {
+    setUrlInput(input)
   }
 
-  const handleLogin = async (): Promise<void> => {
+  const handleLoginByUrl = async (): Promise<void> => {
     setError(undefined)
     try {
-      const sanitizedInput = sanitizeUrlInput(input)
+      const sanitizedInput = sanitizeUrlInput(urlInput)
 
       const details = await fetchRegistrationDetails(new URL(sanitizedInput))
 
@@ -119,16 +119,16 @@ export const TwakeCustomServerView = ({
                 textAlign: 'center'
               }}
             >
-              {t('screens.companyServer.body')}
+              {t('screens.companyServer.body.byUrl')}
             </Typography>
             <TextField
               style={styles.urlField}
               label={t('screens.companyServer.textFieldLabel')}
-              onChangeText={handleInput}
+              onChangeText={handleUrlInput}
               // eslint-disable-next-line @typescript-eslint/no-misused-promises
-              onSubmitEditing={handleLogin}
+              onSubmitEditing={handleLoginByUrl}
               returnKeyType="go"
-              value={input}
+              value={urlInput}
               autoCapitalize="none"
               autoFocus={false}
               placeholder="https://claude.mycozy.cloud"
@@ -146,7 +146,7 @@ export const TwakeCustomServerView = ({
         <Grid alignItems="center" direction="column" style={styles.footerGrid}>
           <Button
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            onPress={handleLogin}
+            onPress={handleLoginByUrl}
             variant="primary"
             label={t('screens.companyServer.buttonLogin')}
             style={styles.loginButton}

--- a/src/screens/login/components/TwakeCustomServerView.tsx
+++ b/src/screens/login/components/TwakeCustomServerView.tsx
@@ -46,7 +46,9 @@ export const TwakeCustomServerView = ({
   setInstanceData,
   startOidcOauthNoCode
 }: TwakeCustomServerViewProps): JSX.Element => {
+  const [isLoginByEmail, setIsLoginByEmail] = useState(true)
   const [urlInput, setUrlInput] = useState('')
+  const [emailInput, setEmailInput] = useState('')
   const [error, setError] = useState<string | undefined>()
 
   const version = useMemo(() => getVersion(), [])
@@ -63,8 +65,17 @@ export const TwakeCustomServerView = ({
       BackHandler.removeEventListener('hardwareBackPress', handleBackPress)
   }, [handleBackPress])
 
+  const toggleLoginByEmail = (): void => {
+    setIsLoginByEmail(!isLoginByEmail)
+    setError(undefined)
+  }
+
   const handleUrlInput = (input: string): void => {
     setUrlInput(input)
+  }
+
+  const handleEmailInput = (input: string): void => {
+    setEmailInput(input)
   }
 
   const handleLoginByUrl = async (): Promise<void> => {
@@ -99,6 +110,10 @@ export const TwakeCustomServerView = ({
     }
   }
 
+  const handleLoginByEmail = async (): Promise<void> => {
+    // TODO
+  }
+
   return (
     <Container transparent={false}>
       <Grid container direction="column" justifyContent="space-between">
@@ -112,29 +127,68 @@ export const TwakeCustomServerView = ({
             <Typography variant="h2" color="textPrimary">
               {t('screens.companyServer.title')}
             </Typography>
-            <Typography
-              variant="body2"
-              color="textPrimary"
-              style={{
-                textAlign: 'center'
-              }}
-            >
-              {t('screens.companyServer.body.byUrl')}
-            </Typography>
-            <TextField
-              style={styles.urlField}
-              label={t('screens.companyServer.textFieldLabel')}
-              onChangeText={handleUrlInput}
-              // eslint-disable-next-line @typescript-eslint/no-misused-promises
-              onSubmitEditing={handleLoginByUrl}
-              returnKeyType="go"
-              value={urlInput}
-              autoCapitalize="none"
-              autoFocus={false}
-              placeholder="https://claude.mycozy.cloud"
-              placeholderTextColor={colors.actionColorDisabled}
-              inputMode="url"
-            />
+            {isLoginByEmail ? (
+              <>
+                <Typography
+                  variant="body2"
+                  color="textPrimary"
+                  style={{
+                    textAlign: 'center'
+                  }}
+                >
+                  {t('screens.companyServer.body.byEmail')}
+                </Typography>
+                <TextField
+                  style={styles.urlField}
+                  label="Email"
+                  onChangeText={handleEmailInput}
+                  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                  onSubmitEditing={handleLoginByEmail}
+                  returnKeyType="go"
+                  value={emailInput}
+                  autoCapitalize="none"
+                  autoFocus={false}
+                  placeholder="claude@company.com"
+                  placeholderTextColor={colors.actionColorDisabled}
+                  inputMode="email"
+                />
+              </>
+            ) : (
+              <>
+                <Typography
+                  variant="body2"
+                  color="textPrimary"
+                  style={{
+                    textAlign: 'center'
+                  }}
+                >
+                  {t('screens.companyServer.body.byUrl')}
+                </Typography>
+                <TextField
+                  style={styles.urlField}
+                  label={t('screens.companyServer.textFieldLabel')}
+                  onChangeText={handleUrlInput}
+                  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                  onSubmitEditing={handleLoginByUrl}
+                  returnKeyType="go"
+                  value={urlInput}
+                  autoCapitalize="none"
+                  autoFocus={false}
+                  placeholder="https://claude.mycozy.cloud"
+                  placeholderTextColor={colors.actionColorDisabled}
+                  inputMode="url"
+                />
+              </>
+            )}
+
+            <Link onPress={toggleLoginByEmail}>
+              <Typography variant="caption" color="primary">
+                {isLoginByEmail
+                  ? t('screens.companyServer.toggle.url')
+                  : t('screens.companyServer.toggle.email')}
+              </Typography>
+            </Link>
+
             {error && (
               <Typography variant="body2" color="error">
                 {error}
@@ -146,7 +200,7 @@ export const TwakeCustomServerView = ({
         <Grid alignItems="center" direction="column" style={styles.footerGrid}>
           <Button
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            onPress={handleLoginByUrl}
+            onPress={isLoginByEmail ? handleLoginByEmail : handleLoginByUrl}
             variant="primary"
             label={t('screens.companyServer.buttonLogin')}
             style={styles.loginButton}

--- a/src/screens/login/components/TwakeWelcomeView.tsx
+++ b/src/screens/login/components/TwakeWelcomeView.tsx
@@ -109,6 +109,8 @@ export const TwakeWelcomeView = ({
         openTos={openTos}
         setInstanceData={setInstanceData}
         startOidcOauthNoCode={startOidcOauthNoCode}
+        startOidcOAuth={startOidcOAuth}
+        startOidcOnboarding={startOidcOnboarding}
       />
     )
   }

--- a/src/screens/login/components/functions/autodiscovery.ts
+++ b/src/screens/login/components/functions/autodiscovery.ts
@@ -1,0 +1,79 @@
+import strings from '/constants/strings.json'
+
+interface TwakeConfiguration {
+  'twake-pass-login-uri'?: string
+  'twake-flagship-login-uri'?: string
+}
+
+export const extractDomain = (companyEmail: string): string | null => {
+  if (!companyEmail) {
+    return null
+  }
+
+  const email = companyEmail.trim()
+
+  const atIndex = email.lastIndexOf('@')
+
+  if (atIndex === -1) {
+    return null
+  }
+
+  return email.substring(atIndex + 1)
+}
+
+export const fetchLoginUriWithWellKnown = async (
+  domain: string
+): Promise<URL | null> => {
+  const url = `https://${domain}/.well-known/twake-configuration`
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      }
+    })
+
+    if (response.ok) {
+      const twakeConfiguration: TwakeConfiguration =
+        (await response.json()) as unknown as TwakeConfiguration
+
+      if (!twakeConfiguration['twake-flagship-login-uri']) {
+        return null
+      }
+
+      return new URL(twakeConfiguration['twake-flagship-login-uri'])
+    } else {
+      return null
+    }
+  } catch {
+    return null
+  }
+}
+
+export const getLoginUri = async (
+  companyEmail: string
+): Promise<URL | null> => {
+  try {
+    const domain = extractDomain(companyEmail)
+
+    if (!domain) {
+      throw new Error()
+    }
+
+    const uriFromWellKnown = await fetchLoginUriWithWellKnown(domain)
+
+    if (uriFromWellKnown) {
+      uriFromWellKnown.searchParams.append(
+        'redirect_after_oidc',
+        strings.COZY_SCHEME
+      )
+      return uriFromWellKnown
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
When using a company server, your previously needed to enter your Twake instance link which is not very user friendly.

Here we homogenize the behavior with our other apps (see https://github.com/cozy/cozy-pass-mobile/pull/104 and https://github.com/cozy/cozy-keys-browser/pull/359) with an autodiscovery mechanism based on a .well-known file so that we can only ask the company email.

We keep the login by url feature as a backup.

```
### ✨ Features

* Login by email when using a company server

```

<img width="200" alt="Screenshot_1756892850" src="https://github.com/user-attachments/assets/a1ab388f-59ec-415f-8d40-4d4278d1d9e7" />
<img width="200" alt="Screenshot_1756892854" src="https://github.com/user-attachments/assets/8fed18f0-d261-44f0-9a40-88436cff31f5" />


#### Checklist

Before merging this PR, the following things must have been done if relevant:

* [ ] Tested on iOS
* [x] Tested on Android
* [ ] Test coverage
* [ ] README and documentation

