### PR TITLE
fix: Open sign up links in in app browser

### DIFF
--- a/src/app/domain/navigation/webviews/UrlService.ts
+++ b/src/app/domain/navigation/webviews/UrlService.ts
@@ -7,7 +7,8 @@ import {
   checkIsRedirectOutside,
   checkIsSameApp,
   checkIsSlugSwitch,
-  openUrlInAppBrowser
+  openUrlInAppBrowser,
+  isSignupUrl
 } from '/libs/functions/urlHelpers'
 import {
   checkIsPreviewableLink,
@@ -68,6 +69,11 @@ export const interceptNavigation = ({
     const clouderyOfferUrlWithInAppPurchaseParams =
       formatClouderyOfferUrlWithInAppPurchaseParams(initialRequest.url)
     showClouderyOffer(clouderyOfferUrlWithInAppPurchaseParams)
+    return false
+  }
+
+  if (isSignupUrl(initialRequest.url)) {
+    openUrlInAppBrowser(initialRequest.url)
     return false
   }
 

--- a/src/libs/functions/urlHelpers.js
+++ b/src/libs/functions/urlHelpers.js
@@ -1,9 +1,10 @@
-import Minilog from 'cozy-minilog'
 import { Platform } from 'react-native'
 import { InAppBrowser } from 'react-native-inappbrowser-reborn'
 
 import { generateWebLink } from 'cozy-client'
 import { deconstructCozyWebLinkWithSlug } from 'cozy-client/dist/helpers'
+import flag from 'cozy-flags'
+import Minilog from 'cozy-minilog'
 
 const log = Minilog('CozyWebView')
 
@@ -234,4 +235,15 @@ export const openUrlInAppBrowser = url => {
       throw error
     }
   }
+}
+
+/**
+ * Compare URL with sign up URL
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export const isSignupUrl = url => {
+  const signupUrl = flag('signup.url')
+  return url.startsWith(signupUrl)
 }


### PR DESCRIPTION
When clicking on "Create business account" from cozy-bar, it try to open the URL as an app because sign-up.twake.app can be seen for the flagship as user = sign and app = up. So let's add a new check to open sign up links in IAB.